### PR TITLE
Fix GetCurrentProject now GetGlobalProject

### DIFF
--- a/Code/Tools/ProjectManager/Source/ProjectsHome.cpp
+++ b/Code/Tools/ProjectManager/Source/ProjectsHome.cpp
@@ -26,8 +26,8 @@ namespace O3DE::ProjectManager
 
         ConnectSlotsAndSignals();
 
-        // example of how to get the current project name
-        ProjectInfo currentProject = PythonBindingsInterface::Get()->GetCurrentProject();
+        // example of how to get the global project name
+        ProjectInfo globalProject = PythonBindingsInterface::Get()->GetGlobalProject();
     }
 
     ProjectsHome::~ProjectsHome()

--- a/Code/Tools/ProjectManager/Source/PythonBindings.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindings.h
@@ -26,7 +26,7 @@ namespace O3DE::ProjectManager
         ~PythonBindings() override;
 
         // PythonBindings overrides
-        ProjectInfo GetCurrentProject() override;
+        ProjectInfo GetGlobalProject() override;
 
     private:
         AZ_DISABLE_COPY_MOVE(PythonBindings);

--- a/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
+++ b/Code/Tools/ProjectManager/Source/PythonBindingsInterface.h
@@ -31,8 +31,8 @@ namespace O3DE::ProjectManager
         IPythonBindings() = default;
         virtual ~IPythonBindings() = default;
 
-        //! Get the current project 
-        virtual ProjectInfo GetCurrentProject() = 0;
+        //! Get the global project 
+        virtual ProjectInfo GetGlobalProject() = 0;
     };
 
     using PythonBindingsInterface = AZ::Interface<IPythonBindings>;


### PR DESCRIPTION
This change updates the c++ python interface to reflect recent breaking changes made in o3de.py 