### PR TITLE
Fix hair offset bug when hair entity is moved away from origin

### DIFF
--- a/Gems/AtomTressFX/Code/Components/HairComponentController.h
+++ b/Gems/AtomTressFX/Code/Components/HairComponentController.h
@@ -110,10 +110,12 @@ namespace AZ
                 Data::Asset<HairAsset> m_hairAsset;
 
                 // Store a cache of the bone index lookup we generated during the creation of hair object.
-                AMD::LocalToGlobalBoneIndexLookup m_boneIndexLookup;
+                AMD::LocalToGlobalBoneIndexLookup m_hairBoneIndexLookup;
+                AMD::LocalToGlobalBoneIndexLookup m_collisionBoneIndexLookup;
 
                 // Cache the bone matrices array to avoid frequent allocation.
-                AZStd::vector<AZ::Matrix3x4> m_cachedBoneMatrices;
+                AZStd::vector<AZ::Matrix3x4> m_cachedHairBoneMatrices;
+                AZStd::vector<AZ::Matrix3x4> m_cachedCollisionBoneMatrices;
 
                 AZ::Matrix3x4 m_entityWorldMatrix;
             };

--- a/Gems/AtomTressFX/External/Code/src/TressFX/TressFXAsset.cpp
+++ b/Gems/AtomTressFX/External/Code/src/TressFX/TressFXAsset.cpp
@@ -956,9 +956,18 @@ namespace AMD
         return true;
     }
 
-    bool TressFXAsset::GenerateLocaltoGlobalBoneIndexLookup(const BoneNameToIndexMap& globalBoneIndexMap, LocalToGlobalBoneIndexLookup& outLookup)
+    bool TressFXAsset::GenerateLocaltoGlobalHairBoneIndexLookup(const BoneNameToIndexMap& globalBoneIndexMap, LocalToGlobalBoneIndexLookup& outLookup)
     {
         return GenerateLocaltoGlobalBoneIndexLookup(globalBoneIndexMap, m_boneNames, outLookup);
+    }
+
+    bool TressFXAsset::GenerateLocaltoGlobalCollisionBoneIndexLookup(const BoneNameToIndexMap& globalBoneIndexMap, LocalToGlobalBoneIndexLookup& outLookup)
+    {
+        if (m_collisionMesh)
+        {
+            return GenerateLocaltoGlobalBoneIndexLookup(globalBoneIndexMap, m_collisionMesh->m_boneNames, outLookup);
+        }
+        return true; // do not touch outlookUp, simply return true if there is no associated collision mesh
     }
 
     bool TressFXAsset::GenerateLocaltoGlobalBoneIndexLookup( const BoneNameToIndexMap& boneIndicesMap,

--- a/Gems/AtomTressFX/External/Code/src/TressFX/TressFXAsset.h
+++ b/Gems/AtomTressFX/External/Code/src/TressFX/TressFXAsset.h
@@ -164,12 +164,12 @@ namespace AMD
         inline AMD::uint32 GetNumHairTriangleIndices() { return 6 * GetNumHairSegments(); }
         inline AMD::uint32 GetNumHairLineIndices() { return 2 * GetNumHairSegments(); }
 
-        // Generates a local to global bone index lookup. We are passing only a subset of the full bone information found in an
+        // Generates a local to global bone index lookup for hair and collision. We are passing only a subset of the full bone information found in an
         // emfx actor to the shader. The purpose of the index lookup is to map an emfx actor bone to the subset consisting of
         // TressFX bones. Essentially, the full set of bones found in an emfx actor are the global bones, while the bones in a
         // TressFX asset are the local bones.
-        bool GenerateLocaltoGlobalBoneIndexLookup(const BoneNameToIndexMap& globalBoneIndexMap, LocalToGlobalBoneIndexLookup& outLookup);
-
+        bool GenerateLocaltoGlobalHairBoneIndexLookup(const BoneNameToIndexMap& globalBoneIndexMap, LocalToGlobalBoneIndexLookup& outLookup);
+        bool GenerateLocaltoGlobalCollisionBoneIndexLookup(const BoneNameToIndexMap& globalBoneIndexMap, LocalToGlobalBoneIndexLookup& outLookup);
     private:
 
         // Generates a local to global bone index lookup for specified bones only. This can be called if we only need information


### PR DESCRIPTION
JIRA: Hair offset bug - https://jira.agscollab.com/browse/ATOM-15547
        Add collision bone matrix preparation - https://jira.agscollab.com/browse/ATOM-15630

Notes:
* m_boneSkinningData is only used in the GPU. Previously, we were converting its local bone index into global bone index, however the bone matrices we pass to the shader only contain the local bones. The root cause of this bug is that the shader was attempting to access the bone matrices using a global index.
* We are still using the global bone index in HairComponentController::UpdateActorMatrices() when collecting bone matrices from the emfx actor instance and loading that into m_cachedBoneMatrices that we eventually pass into the shader. 
* Started some refactor on function names, maybe we ought to clarify the local/global concept here.
* Add collision bone matrix preparation. I've verified that the matrix is indeed populated.