### PR TITLE
Added Component Mode functionality to Image Gradient Component

### DIFF
--- a/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/GradientRequestBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/GradientRequestBus.h
@@ -54,6 +54,11 @@ namespace GradientSignal
         virtual float GetValue(const GradientSampleParams& sampleParams) const = 0;
 
         /**
+         * Given a certain position and a new value, update the bit's value.
+         */
+        virtual void SetValue([[maybe_unused]] const GradientSampleParams& sampleParams, [[maybe_unused]] float newValue) { AZ_Assert(false, "SetValue() not implemented"); }
+
+        /**
         * Call to check the hierarchy to see if a given entityId exists in the gradient signal chain
         */
         virtual bool IsEntityInHierarchy([[maybe_unused]] const AZ::EntityId& entityId) const { return false; }

--- a/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/ImageGradientRequestBus.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/Ebuses/ImageGradientRequestBus.h
@@ -36,8 +36,6 @@ namespace GradientSignal
 
         virtual float GetTilingY() const = 0;
         virtual void SetTilingY(float tilingY) = 0;
-
-        virtual void SetValue(AZ::Vector3 uvw, float newValue) = 0;
     };
 
     using ImageGradientRequestBus = AZ::EBus<ImageGradientRequests>;

--- a/Gems/GradientSignal/Code/Include/GradientSignal/ImageAsset.h
+++ b/Gems/GradientSignal/Code/Include/GradientSignal/ImageAsset.h
@@ -59,5 +59,5 @@ namespace GradientSignal
     };
 
     float GetValueFromImageAsset(const AZ::Data::Asset<ImageAsset>& imageAsset, const AZ::Vector3& uvw, float tilingX, float tilingY, float defaultValue);
-    void UpdateValueFromImageAsset(const AZ::Data::Asset<ImageAsset>& imageAsset, const AZ::Vector3& uvw, float tilingX, float tilingY, float newValue);
+    void SetValueInImageAsset(const AZ::Data::Asset<ImageAsset>& imageAsset, const AZ::Vector3& uvw, float tilingX, float tilingY, float newValue);
 } // namespace GradientSignal

--- a/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.h
+++ b/Gems/GradientSignal/Code/Source/Components/ImageGradientComponent.h
@@ -73,6 +73,7 @@ namespace GradientSignal
         //////////////////////////////////////////////////////////////////////////
         // GradientRequestBus
         float GetValue(const GradientSampleParams& sampleParams) const override;
+        void SetValue(const GradientSampleParams& sampleParams, float newValue) override;
 
         //////////////////////////////////////////////////////////////////////////
         // AZ::Data::AssetBus::Handler
@@ -94,8 +95,6 @@ namespace GradientSignal
 
         float GetTilingY() const override;
         void SetTilingY(float tilingY) override;
-
-        void SetValue(AZ::Vector3 uvw, float newValue) override;
 
     private:
         ImageGradientConfig m_configuration;

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
@@ -12,6 +12,7 @@
 
 #include "GradientSignal_precompiled.h"
 #include "EditorImageGradientComponentMode.h"
+#include <GradientSignal/Ebuses/GradientRequestBus.h>
 #include <GradientSignal/Ebuses/ImageGradientRequestBus.h>
 
 namespace GradientSignal
@@ -20,7 +21,11 @@ namespace GradientSignal
         const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType)
         : EditorBaseComponentMode(entityComponentIdPair, componentType)
     {
-        AZ::Vector3 coordinateExample{0.0f, 0.0f, 0.0f};
-        ImageGradientRequestBus::Event(entityComponentIdPair.GetEntityId(), &ImageGradientRequestBus::Events::SetValue, coordinateExample, 1.0);
+        GradientSignal::GradientSampleParams params;
+        params.m_position = AZ::Vector3::CreateZero();
+
+        const float newValue = 1.0f;
+
+        GradientRequestBus::Event(entityComponentIdPair.GetEntityId(), &GradientRequestBus::Events::SetValue, params, newValue);
     }
 } // namespace GradientSignal

--- a/Gems/GradientSignal/Code/Source/GradientSignalSystemComponent.cpp
+++ b/Gems/GradientSignal/Code/Source/GradientSignalSystemComponent.cpp
@@ -88,6 +88,7 @@ namespace GradientSignal
 
             behaviorContext->EBus<GradientRequestBus>("GradientRequestBus")
                 ->Event("GetValue", &GradientRequestBus::Events::GetValue)
+                ->Event("SetValue", &GradientRequestBus::Events::SetValue)
                 ;
         }
     }


### PR DESCRIPTION
Implemented some basic functionality of the Image Gradient Component's "Component Mode" that should alter the pixel uvw(0,0,0) to have a bit value of 1 when it enters "Component Mode". 

To accomplish this, I built some setter methods to update a value of a current pixel on the Image Gradient's bitmap with `UpdateValue` and `UpdateValueFromImageAsset` in `ImageAsset`. Additionally, I created a method `SetValue` that can be utilized for the Image Gradient bus so that, when in the component is in "Component Mode," it would bus in a request to update a value in the bitmap.