### PR TITLE
Update to camera orbit behavior

### DIFF
--- a/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
+++ b/Code/Sandbox/Plugins/ComponentEntityEditorPlugin/SandboxIntegration.cpp
@@ -1732,13 +1732,14 @@ void SandboxIntegrationManager::GoToEntitiesInViewports(const AzToolsFramework::
                 // compute new camera transform
                 const float fov = AzFramework::RetrieveFov(viewportContext->GetCameraProjectionMatrix());
                 const float fovScale = (1.0f / AZStd::tan(fov * 0.5f));
-                const float distanceToTarget = selectionSize * fovScale * centerScale;
+                const float distanceToLookAt = selectionSize * fovScale * centerScale;
                 const AZ::Transform nextCameraTransform =
-                    AZ::Transform::CreateLookAt(aabb.GetCenter() - (forward * distanceToTarget), aabb.GetCenter());
+                    AZ::Transform::CreateLookAt(aabb.GetCenter() - (forward * distanceToLookAt), aabb.GetCenter());
 
                 AtomToolsFramework::ModularViewportCameraControllerRequestBus::Event(
                     viewportContext->GetId(),
-                    &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform, nextCameraTransform);
+                    &AtomToolsFramework::ModularViewportCameraControllerRequestBus::Events::InterpolateToTransform, nextCameraTransform,
+                    distanceToLookAt);
             }
         }
     }

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraController.h
@@ -51,7 +51,8 @@ namespace AtomToolsFramework
         void UpdateViewport(const AzFramework::ViewportControllerUpdateEvent& event) override;
 
         // ModularViewportCameraControllerRequestBus overrides ...
-        void InterpolateToTransform(const AZ::Transform& worldFromLocal) override;
+        void InterpolateToTransform(const AZ::Transform& worldFromLocal, float lookAtDistance) override;
+        AZStd::optional<AZ::Vector3> LookAtAfterInterpolation() const override;
 
     private:
         // AzFramework::ViewportDebugDisplayEventBus overrides ...
@@ -71,6 +72,8 @@ namespace AtomToolsFramework
         AZ::Transform m_transformEnd = AZ::Transform::CreateIdentity();
         float m_animationT = 0.0f;
         CameraMode m_cameraMode = CameraMode::Control;
+        AZStd::optional<AZ::Vector3> m_lookAtAfterInterpolation; //!< The look at point after an interpolation has finished.
+                                                                 //!< Will be cleared when the view changes (camera looks away).
         bool m_updatingTransform = false;
 
         AZ::RPI::ViewportContext::MatrixChangedEvent::Handler m_cameraViewMatrixChangeHandler;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Include/AtomToolsFramework/Viewport/ModularViewportCameraControllerRequestBus.h
@@ -32,7 +32,12 @@ namespace AtomToolsFramework
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
 
         //! Begin a smooth transition of the camera to the requested transform.
-        virtual void InterpolateToTransform(const AZ::Transform& worldFromLocal) = 0;
+        //! @param worldFromLocal The transform of where the camera should end up.
+        //! @param lookAtDistance The distance between the camera transform and the imagined look at point.
+        virtual void InterpolateToTransform(const AZ::Transform& worldFromLocal, float lookAtDistance) = 0;
+
+        //! Look at point after an interpolation has finished and no translation has occurred.
+        virtual AZStd::optional<AZ::Vector3> LookAtAfterInterpolation() const = 0;
 
     protected:
         ~ModularViewportCameraControllerRequests() = default;

--- a/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
+++ b/Gems/Atom/Tools/AtomToolsFramework/Code/Source/Viewport/ModularViewportCameraController.cpp
@@ -140,6 +140,18 @@ namespace AtomToolsFramework
                 m_targetCamera = m_cameraSystem.StepCamera(m_targetCamera, event.m_deltaTime.count());
                 m_camera = AzFramework::SmoothCamera(m_camera, m_targetCamera, event.m_deltaTime.count());
 
+                // if there has been an interpolation, only clear the look at point if it is no longer
+                // centered in the view (the camera has looked away from it)
+                if (m_lookAtAfterInterpolation.has_value())
+                {
+                    if (const float lookDirection =
+                            (*m_lookAtAfterInterpolation - m_camera.Translation()).GetNormalized().Dot(m_camera.Transform().GetBasisY());
+                        !AZ::IsCloseMag(lookDirection, 1.0f, 0.001f))
+                    {
+                        m_lookAtAfterInterpolation = {};
+                    }
+                }
+
                 viewportContext->SetCameraTransform(m_camera.Transform());
             }
             else if (m_cameraMode == CameraMode::Animation)
@@ -148,8 +160,8 @@ namespace AtomToolsFramework
                 {
                     return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f);
                 };
-                const float transitionT = smootherStepFn(m_animationT);
 
+                const float transitionT = smootherStepFn(m_animationT);
                 const AZ::Transform current = AZ::Transform::CreateFromQuaternionAndTranslation(
                     m_transformStart.GetRotation().Slerp(m_transformEnd.GetRotation(), transitionT),
                     m_transformStart.GetTranslation().Lerp(m_transformEnd.GetTranslation(), transitionT));
@@ -185,11 +197,17 @@ namespace AtomToolsFramework
         }
     }
 
-    void ModernViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal)
+    void ModernViewportCameraControllerInstance::InterpolateToTransform(const AZ::Transform& worldFromLocal, const float lookAtDistance)
     {
         m_animationT = 0.0f;
         m_cameraMode = CameraMode::Animation;
         m_transformStart = m_camera.Transform();
         m_transformEnd = worldFromLocal;
+        m_lookAtAfterInterpolation = m_transformEnd.GetTranslation() + m_transformEnd.GetBasisY() * lookAtDistance;
+    }
+
+    AZStd::optional<AZ::Vector3> ModernViewportCameraControllerInstance::LookAtAfterInterpolation() const
+    {
+        return m_lookAtAfterInterpolation;
     }
 } // namespace AtomToolsFramework


### PR DESCRIPTION
After some iteration and experimentation it was decided using the manipulator as the orbit point was actually a bad idea - it lead to problems when using Alt to go to local space and when using the new mesh intersection functionality.

What we do instead is use the central point after an object 'align' (pressing `Z`) to use as the orbit point. This feels much more natural as it doesn't cause the view to change when holding Alt. As soon as the view changes, this point is cleared and the normal intersection logic will run again (for intersecting a mesh).

Note: Opening this PR against the parent branch for now so the diff is visible, once https://github.com/aws-lumberyard/o3de/pull/1026 is submitted I'll open another PR against main with these changes