### PR TITLE
Added a prototypical circle to viewport when entering Image Gradient Component Mode

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorView.cpp
@@ -724,15 +724,8 @@ namespace AzToolsFramework
         const AngularManipulator& angularManipulator, const AZ::Color& color, const float radius, const float width,
         const ManipulatorViewCircle::DrawCircleFunc drawFunc)
     {
-        return CreateManipulatorViewCircle(angularManipulator.GetAxis(), color, radius, width, drawFunc);
-    }
-
-    AZStd::unique_ptr<ManipulatorViewCircle> CreateManipulatorViewCircle(
-        const AZ::Vector3 axis, const AZ::Color& color,
-        const float radius, const float width, const ManipulatorViewCircle::DrawCircleFunc drawFunc)
-    {
         AZStd::unique_ptr<ManipulatorViewCircle> viewCircle = AZStd::make_unique<ManipulatorViewCircle>();
-        viewCircle->m_axis = axis;
+        viewCircle->m_axis = angularManipulator.GetAxis();
         viewCircle->m_color = color;
         viewCircle->m_radius = radius;
         viewCircle->m_width = width;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Manipulators/ManipulatorView.h
@@ -395,10 +395,6 @@ namespace AzToolsFramework
         const AngularManipulator& angularManipulator, const AZ::Color& color,
         float radius, float width, ManipulatorViewCircle::DrawCircleFunc drawFunc);
 
-    AZStd::unique_ptr<ManipulatorViewCircle> CreateManipulatorViewCircle(
-        const AZ::Vector3 axis, const AZ::Color& color, float radius, float width,
-        ManipulatorViewCircle::DrawCircleFunc drawFunc);
-
     AZStd::unique_ptr<ManipulatorViewSplineSelect> CreateManipulatorViewSplineSelect(
         const SplineSelectionManipulator& splineManipulator, const AZ::Color& color,
         float width);

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
@@ -33,8 +33,6 @@ namespace GradientSignal
 
         GradientRequestBus::Event(entityComponentIdPair.GetEntityId(), &GradientRequestBus::Events::SetValue, params, newValue);
 
-        ///////////////////////
-
         const AZ::Color manipulatorColor = AZ::Color(1.0f, 0.0f, 0.0f, 0.6f);
         const float manipulatorRadius = 2.0f;
         const float manipulatorWidth = 0.05f;
@@ -43,11 +41,11 @@ namespace GradientSignal
         AZ::TransformBus::EventResult(worldFromLocal, GetEntityId(), &AZ::TransformInterface::GetWorldTM);
 
         m_angularManipulator = AzToolsFramework::AngularManipulator::MakeShared(worldFromLocal);
-
+        m_angularManipulator->SetAxis(AZ::Vector3::CreateAxisZ());
         Refresh();
 
         m_angularManipulator->SetView(AzToolsFramework::CreateManipulatorViewCircle(
-            AZ::Vector3::CreateAxisZ(), manipulatorColor, manipulatorRadius, manipulatorWidth,
+            *m_angularManipulator, manipulatorColor, manipulatorRadius, manipulatorWidth,
             AzToolsFramework::DrawFullCircle));
 
         m_angularManipulator->Register(AzToolsFramework::g_mainManipulatorManagerId);


### PR DESCRIPTION
Draws a full, red prototypical circle into the center of an entity containing an Image Gradient when entering Component Mode, in addition to the other functionalities added beforehand (notably altering a pixel in the Image Gradient).