### PR TITLE
[SPEC-6716] Add StopGameSession support on server code

### DIFF
--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerManager.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerManager.cpp
@@ -21,10 +21,6 @@
 #include <AzCore/std/bind/bind.h>
 #include <AzFramework/Session/SessionNotifications.h>
 
-#include <ctime>
-
-#pragma warning(disable : 4996)
-
 namespace AWSGameLift
 {
     AWSGameLiftServerManager::AWSGameLiftServerManager()
@@ -105,7 +101,8 @@ namespace AWSGameLift
             AZ::Interface<AzFramework::ISessionHandlingServerRequests>::Unregister(this);
         }
 
-        AZ_TracePrintf(AWSGameLiftServerManagerName, "Server process is scheduled to be shut down at %s", GetTerminationTime().c_str());
+        AZ_TracePrintf(AWSGameLiftServerManagerName, "Server process is scheduled to be shut down at %s",
+            m_gameLiftServerSDKWrapper->GetTerminationTime().c_str());
 
         // Send notifications to handler(s) to gracefully shut down the server process.
         bool destroySessionResult = true;
@@ -124,26 +121,6 @@ namespace AWSGameLift
 
         AZ_Error(AWSGameLiftServerManagerName, processEndingIsSuccess, AWSGameLiftServerProcessEndingErrorMessage,
             processEndingOutcome.GetError().GetErrorMessage().c_str());
-    }
-    
-    AZStd::string AWSGameLiftServerManager::GetTerminationTime() const
-    {
-        // Timestamp format is using the UTC ISO8601 format
-        std::time_t terminationTime;
-        Aws::GameLift::AwsLongOutcome GetTerminationTimeOutcome = Aws::GameLift::Server::GetTerminationTime();
-        if (GetTerminationTimeOutcome.IsSuccess())
-        {
-            terminationTime = GetTerminationTimeOutcome.GetResult();
-        }
-        else
-        {
-            time(&terminationTime);
-        }
-
-        char buffer[50];
-        strftime(buffer, sizeof(buffer), "%FT%TZ", gmtime(&terminationTime));
-
-        return AZStd::string(buffer);
     }
 
     void AWSGameLiftServerManager::HandlePlayerLeaveSession(const AzFramework::PlayerConnectionConfig& playerConnectionConfig)

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerManager.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/AWSGameLiftServerManager.h
@@ -97,8 +97,6 @@ namespace AWSGameLift
         //! @return Whether the server process is healthy.
         bool OnHealthCheck();
 
-        AZStd::string GetTerminationTime() const;
-
         AZStd::unique_ptr<GameLiftServerSDKWrapper> m_gameLiftServerSDKWrapper;
         bool m_serverSDKInitialized;
     };

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/GameLiftServerSDKWrapper.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/GameLiftServerSDKWrapper.cpp
@@ -12,6 +12,10 @@
 
 #include <GameLiftServerSDKWrapper.h>
 
+#include <ctime>
+
+#pragma warning(disable : 4996)
+
 namespace AWSGameLift
 {
     Aws::GameLift::GenericOutcome GameLiftServerSDKWrapper::ActivateGameSession()
@@ -33,5 +37,26 @@ namespace AWSGameLift
     Aws::GameLift::GenericOutcome GameLiftServerSDKWrapper::ProcessEnding()
     {
         return Aws::GameLift::Server::ProcessEnding();
+    }
+
+    AZStd::string GameLiftServerSDKWrapper::GetTerminationTime()
+    {
+        // Timestamp format is using the UTC ISO8601 format
+        std::time_t terminationTime;
+        Aws::GameLift::AwsLongOutcome GetTerminationTimeOutcome = Aws::GameLift::Server::GetTerminationTime();
+        if (GetTerminationTimeOutcome.IsSuccess())
+        {
+            terminationTime = GetTerminationTimeOutcome.GetResult();
+        }
+        else
+        {
+            // Use the current system time if the termination time is not available from GameLift.
+            time(&terminationTime);
+        }
+
+        char buffer[50];
+        strftime(buffer, sizeof(buffer), "%FT%TZ", gmtime(&terminationTime));
+
+        return AZStd::string(buffer);
     }
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/GameLiftServerSDKWrapper.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Source/GameLiftServerSDKWrapper.h
@@ -14,6 +14,8 @@
 
 #include <aws/gamelift/server/GameLiftServerAPI.h>
 
+#include <AzCore/std/string/string.h>
+
 namespace AWSGameLift
 {
     /* Wrapper to use to GameLift Server SDK.
@@ -43,5 +45,9 @@ namespace AWSGameLift
         //! Notifies the GameLift service that the server process is shutting down.
         //! @return Returns a generic outcome consisting of success or failure with an error message.
         virtual Aws::GameLift::GenericOutcome ProcessEnding();
+
+        //! Returns the time that a server process is scheduled to be shut down.
+        //! @return Timestamp using the UTC ISO8601 format.
+        virtual AZStd::string GetTerminationTime();
     };
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerManagerTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerManagerTest.cpp
@@ -113,6 +113,7 @@ namespace UnitTest
 
         SessionNotificationsHandlerMock handlerMock;
         EXPECT_CALL(handlerMock, OnDestroySessionBegin()).Times(1).WillOnce(testing::Return(false));
+        EXPECT_CALL(*(m_serverManager->m_gameLiftServerSDKWrapperMockPtr), GetTerminationTime()).Times(1);
         EXPECT_CALL(*(m_serverManager->m_gameLiftServerSDKWrapperMockPtr), ProcessEnding()).Times(0);
 
         AZ_TEST_START_TRACE_SUPPRESSION;
@@ -133,6 +134,7 @@ namespace UnitTest
 
         SessionNotificationsHandlerMock handlerMock;
         EXPECT_CALL(handlerMock, OnDestroySessionBegin()).Times(1).WillOnce(testing::Return(true));
+        EXPECT_CALL(*(m_serverManager->m_gameLiftServerSDKWrapperMockPtr), GetTerminationTime()).Times(1);
         EXPECT_CALL(*(m_serverManager->m_gameLiftServerSDKWrapperMockPtr), ProcessEnding()).Times(1);
 
         m_serverManager->m_gameLiftServerSDKWrapperMockPtr->m_onProcessTerminateFunc();

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerMocks.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/Tests/AWSGameLiftServerMocks.h
@@ -46,6 +46,7 @@ namespace UnitTest
         MOCK_METHOD0(InitSDK, Server::InitSDKOutcome());
         MOCK_METHOD1(ProcessReady, GenericOutcome(const Server::ProcessParameters& processParameters));
         MOCK_METHOD0(ProcessEnding, GenericOutcome());
+        MOCK_METHOD0(GetTerminationTime, AZStd::string());
 
         GenericOutcome ProcessReadyMock(const Server::ProcessParameters& processParameters)
         {


### PR DESCRIPTION
All unit tests passed. Code coverage: 87%.

Tested with GameLiftLocal:
23:18:05,987  INFO || - [SDKListenerImpl] nioEventLoopGroup-3-1 - onProcessEnding received from: /127.0.0.1:65143 and ackRequest requested? true
23:18:05,987  INFO || - [GameTerminationManager] nioEventLoopGroup-3-1 - Handling process disconnect event for PID: 37044
23:18:05,987  INFO || - [SDKInvokerImpl] Thread-16 - Received ack response: true