### PR TITLE
[SPEC-6726] Move request interface into public and some cleanups

### DIFF
--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/CMakeLists.txt
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/CMakeLists.txt
@@ -34,7 +34,7 @@ ly_add_target(
 )
 
 ly_add_target(
-    NAME AWSGameLift.Client ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAME AWSGameLift.Clients ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         awsgamelift_client_shared_files.cmake
@@ -52,10 +52,9 @@ ly_add_target(
 )
 
 # Load the "Gem::AWSGameLift" module in all types of applications.
-ly_create_alias(NAME AWSGameLift.Clients NAMESPACE Gem TARGETS Gem::AWSGameLift.Client)
 if (PAL_TRAIT_BUILD_HOST_TOOLS)
-    ly_create_alias(NAME AWSGameLift.Tools NAMESPACE Gem TARGETS Gem::AWSGameLift.Client)
-    ly_create_alias(NAME AWSGameLift.Builders NAMESPACE Gem TARGETS Gem::AWSGameLift.Client)
+    ly_create_alias(NAME AWSGameLift.Tools NAMESPACE Gem TARGETS Gem::AWSGameLift.Clients)
+    ly_create_alias(NAME AWSGameLift.Builders NAMESPACE Gem TARGETS Gem::AWSGameLift.Clients)
 endif()
 
 ################################################################################

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftSearchSessionsRequest.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/AWSGameLiftSearchSessionsRequest.h
@@ -13,9 +13,6 @@
 #pragma once
 
 #include <AzFramework/Session/ISessionRequests.h>
-#include <aws/gamelift/model/SearchGameSessionsResult.h>
-
-#include <AzFramework/Session/SessionConfig.h>
 
 namespace AWSGameLift
 {

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/IAWSGameLiftRequests.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Include/Request/IAWSGameLiftRequests.h
@@ -13,7 +13,9 @@
 #pragma once
 
 #include <AzCore/EBus/EBus.h>
+#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/string/string.h>
+#include <AzFramework/Session/ISessionRequests.h>
 
 namespace AWSGameLift
 {
@@ -51,4 +53,26 @@ namespace AWSGameLift
         static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
     };
     using AWSGameLiftRequestBus = AZ::EBus<IAWSGameLiftRequests, AWSGameLiftRequests>;
+
+    // ISessionAsyncRequests EBus wrapper for scripting
+    class AWSGameLiftSessionAsyncRequests
+        : public AZ::EBusTraits
+    {
+    public:
+        using MutexType = AZStd::recursive_mutex;
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+    };
+    using AWSGameLiftSessionAsyncRequestBus = AZ::EBus<AzFramework::ISessionAsyncRequests, AWSGameLiftSessionAsyncRequests>;
+
+    // ISessionRequests EBus wrapper for scripting
+    class AWSGameLiftSessionRequests
+        : public AZ::EBusTraits
+    {
+    public:
+        using MutexType = AZStd::recursive_mutex;
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+    };
+    using AWSGameLiftSessionRequestBus = AZ::EBus<AzFramework::ISessionRequests, AWSGameLiftSessionRequests>;
 } // namespace AWSGameLift

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.cpp
@@ -196,8 +196,6 @@ namespace AWSGameLift
         }
         else
         {
-            AZ_TracePrintf(AWSGameLiftClientManagerName, "Requesting CreateGameSession against Amazon GameLift service ...");
-
             result = CreateSessionActivity::CreateSession(*gameLiftClient, createSessionRequest);
         }
         return result;
@@ -214,8 +212,6 @@ namespace AWSGameLift
         }
         else
         {
-            AZ_TracePrintf(AWSGameLiftClientManagerName, "Requesting StartGameSessionPlacement against Amazon GameLift service ...");
-
             result = CreateSessionOnQueueActivity::CreateSessionOnQueue(*gameliftClient, createSessionOnQueueRequest);
         }
         return result;
@@ -271,12 +267,7 @@ namespace AWSGameLift
         }
         else
         {
-            AZ_TracePrintf(AWSGameLiftClientManagerName,
-                "Requesting CreatePlayerSession for player %s against Amazon GameLift service ...", joinSessionRequest.m_playerId.c_str());
-
             auto createPlayerSessionOutcome = JoinSessionActivity::CreatePlayerSession(*gameliftClient, joinSessionRequest);
-
-            AZ_TracePrintf(AWSGameLiftClientManagerName, "Requesting player to connect to game session ...");
 
             result = JoinSessionActivity::RequestPlayerJoinSession(createPlayerSessionOutcome);
         }
@@ -285,8 +276,6 @@ namespace AWSGameLift
 
     void AWSGameLiftClientManager::LeaveSession()
     {
-        AZ_TracePrintf(AWSGameLiftClientManagerName, "Requesting to leave the current session...");
-
         AWSGameLift::LeaveSessionActivity::LeaveSession();
     }
 
@@ -357,8 +346,6 @@ namespace AWSGameLift
         }
         else
         {
-            AZ_TracePrintf(AWSGameLiftClientManagerName, "Requesting SearchGameSessions against Amazon GameLift service ...");
-
             response = SearchSessionsActivity::SearchSessions(*gameliftClient, searchSessionsRequest);
         }
         return response;

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.h
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientManager.h
@@ -12,9 +12,7 @@
 
 #pragma once
 
-#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <AzFramework/Session/ISessionRequests.h>
 #include <Request/IAWSGameLiftRequests.h>
 
 namespace Aws
@@ -32,17 +30,6 @@ namespace AWSGameLift
     struct AWSGameLiftJoinSessionRequest;
     struct AWSGameLiftSearchSessionsRequest;
 
-    // ISessionAsyncRequests EBus wrapper for scripting
-    class AWSGameLiftSessionAsyncRequests
-        : public AZ::EBusTraits
-    {
-    public:
-        using MutexType = AZStd::recursive_mutex;
-        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
-    };
-    using AWSGameLiftSessionAsyncRequestBus = AZ::EBus<AzFramework::ISessionAsyncRequests, AWSGameLiftSessionAsyncRequests>;
-
     // SessionAsyncRequestNotificationBus EBus handler for scripting
     class AWSGameLiftSessionAsyncRequestNotificationBusHandler
         : public AzFramework::SessionAsyncRequestNotificationBus::Handler
@@ -50,8 +37,13 @@ namespace AWSGameLift
     {
     public:
         AZ_EBUS_BEHAVIOR_BINDER(
-            AWSGameLiftSessionAsyncRequestNotificationBusHandler, "{6E13FC73-53DC-4B6B-AEA7-9038DE4C9635}", AZ::SystemAllocator,
-            OnCreateSessionAsyncComplete, OnSearchSessionsAsyncComplete, OnJoinSessionAsyncComplete, OnLeaveSessionAsyncComplete);
+            AWSGameLiftSessionAsyncRequestNotificationBusHandler,
+            "{6E13FC73-53DC-4B6B-AEA7-9038DE4C9635}",
+            AZ::SystemAllocator,
+            OnCreateSessionAsyncComplete,
+            OnSearchSessionsAsyncComplete,
+            OnJoinSessionAsyncComplete,
+            OnLeaveSessionAsyncComplete);
 
         void OnCreateSessionAsyncComplete(const AZStd::string& createSessionReponse) override
         {
@@ -73,17 +65,6 @@ namespace AWSGameLift
             Call(FN_OnLeaveSessionAsyncComplete);
         }
     };
-
-    // ISessionRequests EBus wrapper for scripting
-    class AWSGameLiftSessionRequests
-        : public AZ::EBusTraits
-    {
-    public:
-        using MutexType = AZStd::recursive_mutex;
-        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
-        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
-    };
-    using AWSGameLiftSessionRequestBus = AZ::EBus<AzFramework::ISessionRequests, AWSGameLiftSessionRequests>;
 
     //! AWSGameLiftClientManager
     //! GameLift client manager to support game and player session related client requests

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/AWSGameLiftClientSystemComponent.cpp
@@ -13,6 +13,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
+#include <AzFramework/Session/SessionConfig.h>
 
 #include <AWSGameLiftClientManager.h>
 #include <AWSGameLiftClientSystemComponent.h>

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionActivity.cpp
@@ -43,6 +43,8 @@ namespace AWSGameLift
             const Aws::GameLift::GameLiftClient& gameliftClient,
             const AWSGameLiftCreateSessionRequest& createSessionRequest)
         {
+            AZ_TracePrintf(AWSGameLiftCreateSessionActivityName, "Requesting CreateGameSession against Amazon GameLift service ...");
+
             AZStd::string result = "";
             Aws::GameLift::Model::CreateGameSessionRequest request = BuildAWSGameLiftCreateGameSessionRequest(createSessionRequest);
             auto createSessionOutcome = gameliftClient.CreateGameSession(request);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftCreateSessionOnQueueActivity.cpp
@@ -43,6 +43,9 @@ namespace AWSGameLift
             const Aws::GameLift::GameLiftClient& gameliftClient,
             const AWSGameLiftCreateSessionOnQueueRequest& createSessionOnQueueRequest)
         {
+            AZ_TracePrintf(AWSGameLiftCreateSessionOnQueueActivityName,
+                "Requesting StartGameSessionPlacement against Amazon GameLift service ...");
+
             AZStd::string result = "";
             Aws::GameLift::Model::StartGameSessionPlacementRequest request =
                 BuildAWSGameLiftStartGameSessionPlacementRequest(createSessionOnQueueRequest);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftJoinSessionActivity.cpp
@@ -47,6 +47,10 @@ namespace AWSGameLift
             const Aws::GameLift::GameLiftClient& gameliftClient,
             const AWSGameLiftJoinSessionRequest& joinSessionRequest)
         {
+            AZ_TracePrintf(AWSGameLiftJoinSessionActivityName,
+                "Requesting CreatePlayerSession for player %s against Amazon GameLift service ...",
+                joinSessionRequest.m_playerId.c_str());
+
             Aws::GameLift::Model::CreatePlayerSessionRequest request =
                 BuildAWSGameLiftCreatePlayerSessionRequest(joinSessionRequest);
             auto createPlayerSessionOutcome = gameliftClient.CreatePlayerSession(request);
@@ -68,6 +72,8 @@ namespace AWSGameLift
                 auto clientRequestHandler = AZ::Interface<AzFramework::ISessionHandlingClientRequests>::Get();
                 if (clientRequestHandler)
                 {
+                    AZ_TracePrintf(AWSGameLiftJoinSessionActivityName, "Requesting player to connect to game session ...");
+
                     AzFramework::SessionConnectionConfig sessionConnectionConfig =
                         BuildSessionConnectionConfig(createPlayerSessionOutcome);
                     result = clientRequestHandler->RequestPlayerJoinSession(sessionConnectionConfig);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftLeaveSessionActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftLeaveSessionActivity.cpp
@@ -24,6 +24,8 @@ namespace AWSGameLift
             auto clientRequestHandler = AZ::Interface<AzFramework::ISessionHandlingClientRequests>::Get();
             if (clientRequestHandler)
             {
+                AZ_TracePrintf(AWSGameLiftLeaveSessionActivityName, "Requesting to leave the current session...");
+
                 clientRequestHandler->RequestPlayerLeaveSession();
             }
             else

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Activity/AWSGameLiftSearchSessionsActivity.cpp
@@ -10,6 +10,8 @@
  *
  */
 
+#include <AzFramework/Session/SessionConfig.h>
+
 #include <Activity/AWSGameLiftSearchSessionsActivity.h>
 #include <AWSGameLiftSessionConstants.h>
 
@@ -36,6 +38,8 @@ namespace AWSGameLift
             const Aws::GameLift::GameLiftClient& gameliftClient,
             const AWSGameLiftSearchSessionsRequest& searchSessionsRequest)
         {
+            AZ_TracePrintf(AWSGameLiftSearchSessionsActivityName, "Requesting SearchGameSessions against Amazon GameLift service ...");
+
             AzFramework::SearchSessionsResponse response;
             Aws::GameLift::Model::SearchGameSessionsRequest request = BuildAWSGameLiftSearchGameSessionsRequest(searchSessionsRequest);
             Aws::GameLift::Model::SearchGameSessionsOutcome outcome = gameliftClient.SearchGameSessions(request);

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftSearchSessionsRequest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Source/Request/AWSGameLiftSearchSessionsRequest.cpp
@@ -12,6 +12,7 @@
 
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
+#include <AzFramework/Session/SessionConfig.h>
 
 #include <Request/AWSGameLiftSearchSessionsRequest.h>
 #include <AWSGameLiftSessionConstants.h>

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientManagerTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/AWSGameLiftClientManagerTest.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
+#include <AzFramework/Session/SessionConfig.h>
 #include <Credential/AWSCredentialBus.h>
 #include <ResourceMapping/AWSResourceMappingBus.h>
 

--- a/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftSearchSessionsActivityTest.cpp
+++ b/Gems/AWSGameLift/Code/AWSGameLiftClient/Tests/Activity/AWSGameLiftSearchSessionsActivityTest.cpp
@@ -10,6 +10,8 @@
  *
  */
 
+#include <AzFramework/Session/SessionConfig.h>
+
 #include <Activity/AWSGameLiftSearchSessionsActivity.h>
 #include <AWSGameLiftClientFixture.h>
 #include <AWSGameLiftSessionConstants.h>

--- a/Gems/AWSGameLift/Code/AWSGameLiftServer/CMakeLists.txt
+++ b/Gems/AWSGameLift/Code/AWSGameLiftServer/CMakeLists.txt
@@ -30,7 +30,7 @@ ly_add_target(
     )
 
 ly_add_target(
-    NAME AWSGameLift.Server ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
+    NAME AWSGameLift.Servers ${PAL_TRAIT_MONOLITHIC_DRIVEN_MODULE_TYPE}
     NAMESPACE Gem
     FILES_CMAKE
         awsgamelift_server_shared_files.cmake
@@ -43,9 +43,6 @@ ly_add_target(
             Gem::AWSGameLift.Server.Static
             3rdParty::AWSGameLiftServerSDK
 )
-
-# Load the "Gem::AWSGameLift" module in all types of applications.
-ly_create_alias(NAME AWSGameLift.Servers NAMESPACE Gem TARGETS Gem::AWSGameLift.Server)
 
 ################################################################################
 # Tests


### PR DESCRIPTION
## Details
All cleanup works:
1. Move request declaration into public folder so it can be used as build dependency
2. Move log into its own activity function
3. Remove cmake alias target as we do have client and server module target