### PR TITLE
Adds two modes for NativeUI to disable UI

### DIFF
--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUIRequests.h
@@ -25,6 +25,12 @@ namespace AZ::NativeUI
         NONE,
     };
 
+    enum class Mode
+    {
+        Console = 0,
+        UI,
+    };
+
     class NativeUIRequests
     {
     public:
@@ -55,6 +61,15 @@ namespace AZ::NativeUI
         //! Displays an assert dialog box
         //! Returns the action selected by the user
         virtual AssertAction DisplayAssertDialog([[maybe_unused]] const AZStd::string& message) const { return AssertAction::NONE; }
+
+        //! Set the operation mode of the native UI system
+        void SetMode(NativeUI::Mode mode)
+        {
+            m_mode = mode;
+        }
+
+    protected:
+        NativeUI::Mode m_mode = NativeUI::Mode::Console;
     };
 
     class NativeUIEBusTraits

--- a/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.cpp
+++ b/Code/Framework/AzCore/AzCore/NativeUI/NativeUISystemComponent.cpp
@@ -29,6 +29,11 @@ namespace AZ::NativeUI
 
     AssertAction NativeUISystem::DisplayAssertDialog(const AZStd::string& message) const
     {
+        if (m_mode == NativeUI::Mode::Console)
+        {
+            return AssertAction::NONE;
+        }
+
         static const char* buttonNames[3] = { "Ignore", "Ignore All", "Break" };
         AZStd::vector<AZStd::string> options;
         options.push_back(buttonNames[0]);
@@ -36,8 +41,7 @@ namespace AZ::NativeUI
         options.push_back(buttonNames[1]);
 #endif
         options.push_back(buttonNames[2]);
-        AZStd::string result;
-        result = DisplayBlockingDialog("Assert Failed!", message, options);
+        AZStd::string result = DisplayBlockingDialog("Assert Failed!", message, options);
 
         if (result.compare(buttonNames[0]) == 0)
             return AssertAction::IGNORE_ASSERT;
@@ -51,9 +55,12 @@ namespace AZ::NativeUI
 
     AZStd::string NativeUISystem::DisplayOkDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const
     {
-        AZStd::vector<AZStd::string> options;
+        if (m_mode == NativeUI::Mode::Console)
+        {
+            return {};
+        }
 
-        options.push_back("OK");
+        AZStd::vector<AZStd::string> options{ "OK" };
         if (showCancel)
         {
             options.push_back("Cancel");
@@ -64,10 +71,12 @@ namespace AZ::NativeUI
 
     AZStd::string NativeUISystem::DisplayYesNoDialog(const AZStd::string& title, const AZStd::string& message, bool showCancel) const
     {
-        AZStd::vector<AZStd::string> options;
+        if (m_mode == NativeUI::Mode::Console)
+        {
+            return {};
+        }
 
-        options.push_back("Yes");
-        options.push_back("No");
+        AZStd::vector<AZStd::string> options{ "Yes", "No" };
         if (showCancel)
         {
             options.push_back("Cancel");

--- a/Code/Framework/AzCore/Platform/Android/AzCore/NativeUI/NativeUISystemComponent_Android.cpp
+++ b/Code/Framework/AzCore/Platform/Android/AzCore/NativeUI/NativeUISystemComponent_Android.cpp
@@ -24,6 +24,11 @@ namespace AZ
     {
         AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
+            if (m_mode == NativeUI::Mode::Console)
+            {
+                return {};
+            }
+
             AZ::Android::JNI::Object object("com/amazon/lumberyard/NativeUI/LumberyardNativeUI");
             object.RegisterStaticMethod("DisplayDialog", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)V");
             object.RegisterStaticMethod("GetUserSelection", "()Ljava/lang/String;");

--- a/Code/Framework/AzCore/Platform/Mac/AzCore/NativeUI/NativeUISystemComponent_Mac.mm
+++ b/Code/Framework/AzCore/Platform/Mac/AzCore/NativeUI/NativeUISystemComponent_Mac.mm
@@ -28,6 +28,11 @@ namespace AZ
     {
         AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
+            if (m_mode == NativeUI::Mode::Console)
+            {
+                return {};
+            }
+
             __block NSModalResponse response = -1;
             
             auto showDialog = ^()

--- a/Code/Framework/AzCore/Platform/Windows/AzCore/NativeUI/NativeUISystemComponent_Windows.cpp
+++ b/Code/Framework/AzCore/Platform/Windows/AzCore/NativeUI/NativeUISystemComponent_Windows.cpp
@@ -247,6 +247,11 @@ namespace AZ
     {
         AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
+            if (m_mode == NativeUI::Mode::Console)
+            {
+                return {};
+            }
+
             if (options.size() >= MAX_ITEMS)
             {
                 AZ_Assert(false, "Cannot create dialog box with more than %d buttons", (MAX_ITEMS - 1));

--- a/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
+++ b/Code/Framework/AzCore/Platform/iOS/AzCore/NativeUI/NativeUISystemComponent_iOS.mm
@@ -20,6 +20,11 @@ namespace AZ
     {
         AZStd::string NativeUISystem::DisplayBlockingDialog(const AZStd::string& title, const AZStd::string& message, const AZStd::vector<AZStd::string>& options) const
         {
+            if (m_mode == NativeUI::Mode::Console)
+            {
+                return {};
+            }
+
             __block AZStd::string userSelection = "";
             
             NSString* nsTitle = [NSString stringWithUTF8String:title.c_str()];

--- a/Code/Sandbox/Editor/CryEdit.cpp
+++ b/Code/Sandbox/Editor/CryEdit.cpp
@@ -557,7 +557,6 @@ public:
     {
         bool dummy;
         QCommandLineParser parser;
-        QString appRootOverride;
         parser.addHelpOption();
         parser.setSingleDashWordOptionMode(QCommandLineParser::ParseAsLongOptions);
         parser.setApplicationDescription(QObject::tr("Open 3D Engine"));
@@ -643,7 +642,7 @@ public:
             option.second = parser.value(option.first.valueName);
         }
 
-        m_bExport = m_bExport | m_bExportTexture;
+        m_bExport = m_bExport || m_bExportTexture;
 
         const QStringList positionalArgs = parser.positionalArguments();
 
@@ -4361,6 +4360,19 @@ extern "C" int AZ_DLL_EXPORT CryEditMain(int argc, char* argv[])
     // open a scope to contain the AZToolsApp instance;
     {
         EditorInternal::EditorToolsApplication AZToolsApp(&argc, &argv);
+
+        {
+            CEditCommandLineInfo cmdInfo;
+            if (!cmdInfo.m_bAutotestMode && !cmdInfo.m_bConsoleMode && !cmdInfo.m_bExport && !cmdInfo.m_bExportTexture && !cmdInfo.m_bNullRenderer && !cmdInfo.m_bMatEditMode
+                && !cmdInfo.m_bTest)
+            {
+                if (auto nativeUI = AZ::Interface<AZ::NativeUI::NativeUIRequests>::Get();
+                    nativeUI != nullptr)
+                {
+                    nativeUI->SetMode(AZ::NativeUI::Mode::UI);
+                }
+            }
+        }
 
         // The settings registry has been created by the AZ::ComponentApplication constructor at this point
         AZ::SettingsRegistryInterface& registry = *AZ::SettingsRegistry::Get();


### PR DESCRIPTION
Creates two modes for NativeUI: UI and Console.  The idea is to operate
in one mode depending on the nature of the environment, such as whether
running a 'batch', 'test', or 'headless' application.