### PR TITLE
Fix snapshot choice that was incorrectly added

### DIFF
--- a/scripts/build/Jenkins/Jenkinsfile
+++ b/scripts/build/Jenkins/Jenkinsfile
@@ -471,7 +471,7 @@ try {
                         }
                     } else {
                         // Non-PR builds
-                        choice(defaultValue: DEFAULT_BUILD_SNAPSHOT, name: 'SNAPSHOT', choices: BUILD_SNAPSHOTS, description: 'Selects the build snapshot to use. A more diverted snapshot will cause longer build times, but will not cause build failures.')
+                        pipelineParameters.add(choice(defaultValue: DEFAULT_BUILD_SNAPSHOT, name: 'SNAPSHOT', choices: BUILD_SNAPSHOTS, description: 'Selects the build snapshot to use. A more diverted snapshot will cause longer build times, but will not cause build failures.'))
                         snapshot = env.SNAPSHOT
                         echo "Snapshot \"${snapshot}\" selected."
                     }


### PR DESCRIPTION
The _Provisional implementation of LYN-4667_ (https://github.com/aws-lumberyard/o3de/pull/1559) was incorrectly adding the snapshot choice. This caused non-PR builds to not display the option resulting in the snapshot being `null`. 