### PR TITLE
Debug Display for hair

### DIFF
--- a/Gems/AtomTressFX/Code/Components/EditorHairComponent.cpp
+++ b/Gems/AtomTressFX/Code/Components/EditorHairComponent.cpp
@@ -11,8 +11,8 @@
 */
 
 #include <AzCore/RTTI/BehaviorContext.h>
-
 #include <Components/EditorHairComponent.h>
+#include <Rendering/HairRenderObject.h>
 
 namespace AZ
 {
@@ -86,12 +86,51 @@ namespace AZ
             void EditorHairComponent::Activate()
             {
                 BaseClass::Activate();
+                AzFramework::EntityDebugDisplayEventBus::Handler::BusConnect(GetEntityId());
+            }
+
+            void EditorHairComponent::Deactivate()
+            {
+                BaseClass::Deactivate();
+                AzFramework::EntityDebugDisplayEventBus::Handler::BusDisconnect();
             }
 
             u32 EditorHairComponent::OnConfigurationChanged()
             {
                 m_controller.OnHairConfigChanged();
                 return Edit::PropertyRefreshLevels::AttributesAndValues;
+            }
+
+            void EditorHairComponent::DisplayEntityViewport(
+                [[maybe_unused]] const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay)
+            {
+                // Only render debug information when selected.
+                if (!IsSelected())
+                {
+                    return;
+                }
+
+                // Only render debug information after render object got created.
+                if (!m_controller.m_renderObject)
+                {
+                    return;
+                }
+
+                float x = 40.0;
+                float y = 20.0f; 
+                float size = 1.00f;
+                bool center = false;
+
+                AZStd::string debugString = AZStd::string::format(
+                    "Hair component stats:\n"
+                    "    Total number of hairs: %zu\n"
+                    "    Total number of guide hairs: %zu\n"
+                    "    Amount of follow hair per guide hair: %zu\n",
+                    m_controller.m_renderObject->GetNumTotalHairStrands(),
+                    m_controller.m_renderObject->GetNumGuideHairs(),
+                    m_controller.m_renderObject->GetNumFollowHairsPerGuideHair());
+
+                debugDisplay.Draw2dTextLabel(x, y, size, debugString.c_str(), center);
             }
         } // namespace Hair
     } // namespace Render

--- a/Gems/AtomTressFX/Code/Components/EditorHairComponent.h
+++ b/Gems/AtomTressFX/Code/Components/EditorHairComponent.h
@@ -13,6 +13,8 @@
 #pragma once
 
 #include <AzToolsFramework/ToolsComponents/EditorComponentAdapter.h>
+#include <AzFramework/Entity/EntityDebugDisplayBus.h>
+
 #include <Components/HairComponent.h>
 #include <Components/HairComponentConfig.h>
 #include <Components/HairComponentController.h>
@@ -29,6 +31,7 @@ namespace AZ
 
             class EditorHairComponent final
                 : public AzToolsFramework::Components::EditorComponentAdapter<HairComponentController, HairComponent, HairComponentConfig>
+                , private AzFramework::EntityDebugDisplayEventBus::Handler
             {
             public:
 
@@ -41,7 +44,11 @@ namespace AZ
                 EditorHairComponent(const HairComponentConfig& config);
 
                 void Activate() override;
+                void Deactivate() override;
 
+                // AzFramework::DebugDisplayRequestBus::Handler interface
+                void DisplayEntityViewport(
+                    const AzFramework::ViewportInfo& viewportInfo, AzFramework::DebugDisplayRequests& debugDisplay) override;
             private:
 
                 //! EditorRenderComponentAdapter overrides...

--- a/Gems/AtomTressFX/Code/Rendering/HairRenderObject.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairRenderObject.h
@@ -247,7 +247,10 @@ namespace AZ
                 int GetNumVerticesPerStrand() const { return m_NumVerticesPerStrand; }
                 int GetCPULocalShapeIterations() const { return  m_CPULocalShapeIterations; }
                 int GetNumFollowHairsPerGuideHair() const { return m_NumFollowHairsPerGuideHair; }
-
+                int GetNumGuideHairs() const
+                {
+                    return GetNumTotalHairStrands() / (GetNumFollowHairsPerGuideHair() + 1);
+                }
                 //! This method is mainly a wrapper around BindRenderSrgResources to keep the
                 //! connection in code to the TressFX method.
                 //! Bind Render Srg (m_hairRenderSrg) resources. No resources data update should be doe here


### PR DESCRIPTION
Signed-off-by: rhhong <rhhong@amazon.com>

![image](https://user-images.githubusercontent.com/69218254/123910742-bd723180-d92f-11eb-85ce-63bf983b9930.png)

@Adi-Amazon It's not on the component, but it used the atom debug rendering and display it on the screen. Seems to be the standard way for atom objects.