### PR TITLE
Changed PaintBrushNotificationBus to send events

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrush.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrush.cpp
@@ -63,21 +63,21 @@ namespace AzToolsFramework
         }
     }
 
-    AZ::u32 PaintBrush::OnIntensityChange() const
+    AZ::u32 PaintBrush::OnIntensityChange()
     {
-        PaintBrushNotificationBus::Broadcast(&PaintBrushNotificationBus::Events::OnIntensityChanged, m_radius);
+        PaintBrushNotificationBus::Event(m_ownerEntity, &PaintBrushNotificationBus::Events::OnIntensityChanged, m_intensity);
         return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
     }
 
-    AZ::u32 PaintBrush::OnOpacityChange() const
+    AZ::u32 PaintBrush::OnOpacityChange()
     {
-        PaintBrushNotificationBus::Broadcast(&PaintBrushNotificationBus::Events::OnOpacityChanged, m_radius);
+        PaintBrushNotificationBus::Event(m_ownerEntity, &PaintBrushNotificationBus::Events::OnOpacityChanged, m_opacity);
         return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
     }
 
-    AZ::u32 PaintBrush::OnRadiusChange() const
+    AZ::u32 PaintBrush::OnRadiusChange()
     {
-        PaintBrushNotificationBus::Broadcast(&PaintBrushNotificationBus::Events::OnRadiusChanged, m_radius);
+        PaintBrushNotificationBus::Event(m_ownerEntity, &PaintBrushNotificationBus::Events::OnRadiusChanged, m_radius);
         return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
     }
 
@@ -164,11 +164,11 @@ namespace AzToolsFramework
         if (entityIdUnderCursor.IsValid())
         {
             AZ::Transform space = AZ::Transform::CreateTranslation(result);
-            PaintBrushNotificationBus::Broadcast(&PaintBrushNotificationBus::Events::OnWorldSpaceChanged, space);
+            PaintBrushNotificationBus::Event(m_ownerEntity, &PaintBrushNotificationBus::Events::OnWorldSpaceChanged, space);
 
             if (m_isPainting)
             {
-                PaintBrushNotificationBus::Broadcast(
+                PaintBrushNotificationBus::Event(m_ownerEntity,
                     &PaintBrushNotificationBus::Events::OnPaint, AZ::Aabb::CreateCenterRadius(result, m_radius));
             }
 
@@ -200,6 +200,7 @@ namespace AzToolsFramework
 
     void PaintBrush::Activate(const AZ::EntityComponentIdPair& entityComponentIdPair)
     {
+        m_ownerEntity = entityComponentIdPair;
         PaintBrushRequestBus::Handler::BusConnect(entityComponentIdPair);
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrush.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrush.cpp
@@ -65,19 +65,19 @@ namespace AzToolsFramework
 
     AZ::u32 PaintBrush::OnIntensityChange()
     {
-        PaintBrushNotificationBus::Event(m_ownerEntity, &PaintBrushNotificationBus::Events::OnIntensityChanged, m_intensity);
+        PaintBrushNotificationBus::Event(m_ownerEntityComponentId, &PaintBrushNotificationBus::Events::OnIntensityChanged, m_intensity);
         return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
     }
 
     AZ::u32 PaintBrush::OnOpacityChange()
     {
-        PaintBrushNotificationBus::Event(m_ownerEntity, &PaintBrushNotificationBus::Events::OnOpacityChanged, m_opacity);
+        PaintBrushNotificationBus::Event(m_ownerEntityComponentId, &PaintBrushNotificationBus::Events::OnOpacityChanged, m_opacity);
         return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
     }
 
     AZ::u32 PaintBrush::OnRadiusChange()
     {
-        PaintBrushNotificationBus::Event(m_ownerEntity, &PaintBrushNotificationBus::Events::OnRadiusChanged, m_radius);
+        PaintBrushNotificationBus::Event(m_ownerEntityComponentId, &PaintBrushNotificationBus::Events::OnRadiusChanged, m_radius);
         return AZ::Edit::PropertyRefreshLevels::AttributesAndValues;
     }
 
@@ -164,12 +164,12 @@ namespace AzToolsFramework
         if (entityIdUnderCursor.IsValid())
         {
             AZ::Transform space = AZ::Transform::CreateTranslation(result);
-            PaintBrushNotificationBus::Event(m_ownerEntity, &PaintBrushNotificationBus::Events::OnWorldSpaceChanged, space);
+            PaintBrushNotificationBus::Event(m_ownerEntityComponentId, &PaintBrushNotificationBus::Events::OnWorldSpaceChanged, space);
 
             if (m_isPainting)
             {
-                PaintBrushNotificationBus::Event(m_ownerEntity,
-                    &PaintBrushNotificationBus::Events::OnPaint, AZ::Aabb::CreateCenterRadius(result, m_radius));
+                PaintBrushNotificationBus::Event(
+                    m_ownerEntityComponentId, &PaintBrushNotificationBus::Events::OnPaint, AZ::Aabb::CreateCenterRadius(result, m_radius));
             }
 
             return true;
@@ -200,7 +200,7 @@ namespace AzToolsFramework
 
     void PaintBrush::Activate(const AZ::EntityComponentIdPair& entityComponentIdPair)
     {
-        m_ownerEntity = entityComponentIdPair;
+        m_ownerEntityComponentId = entityComponentIdPair;
         PaintBrushRequestBus::Handler::BusConnect(entityComponentIdPair);
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrush.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrush.h
@@ -50,8 +50,8 @@ namespace AzToolsFramework
         float m_intensity = 1.0f;
         float m_opacity = 1.0f;
 
-        AZ::u32 OnIntensityChange() const;
-        AZ::u32 OnOpacityChange() const;
-        AZ::u32 OnRadiusChange() const;
+        AZ::u32 OnIntensityChange();
+        AZ::u32 OnOpacityChange();
+        AZ::u32 OnRadiusChange();
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrush.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrush.h
@@ -40,7 +40,7 @@ namespace AzToolsFramework
     private:
         bool HandleMouseEvent(const ViewportInteraction::MouseInteractionEvent& mouseInteraction);
 
-        AZ::EntityComponentIdPair m_ownerEntity;
+        AZ::EntityComponentIdPair m_ownerEntityComponentId;
         
         bool m_isPainting = false;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrushNotificationBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Brushes/PaintBrushNotificationBus.h
@@ -15,8 +15,9 @@ namespace AzToolsFramework
     class PaintBrushNotifications : public AZ::EBusTraits
     {
     public:
-        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
-        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+        static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Single;
+        static const AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::ById;
+        using BusIdType = AZ::EntityComponentIdPair;
 
         virtual void OnIntensityChanged([[maybe_unused]] float radius) { }
         virtual void OnOpacityChanged([[maybe_unused]] float radius) { }

--- a/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
+++ b/Gems/GradientSignal/Code/Source/Editor/EditorImageGradientComponentMode.cpp
@@ -30,7 +30,7 @@ namespace GradientSignal
         const AZ::EntityComponentIdPair& entityComponentIdPair, AZ::Uuid componentType)
         : EditorBaseComponentMode(entityComponentIdPair, componentType)
     {
-        AzToolsFramework::PaintBrushNotificationBus::Handler::BusConnect();
+        AzToolsFramework::PaintBrushNotificationBus::Handler::BusConnect(entityComponentIdPair);
 
         AZ::Transform worldFromLocal = AZ::Transform::CreateIdentity();
         AZ::TransformBus::EventResult(worldFromLocal, GetEntityId(), &AZ::TransformInterface::GetWorldTM);


### PR DESCRIPTION
Modified the `PaintBrushNotificationBus` calls to send out `Event` calls rather than `Broadcast` calls. Additionally, removed the `const` from On*Changed functions. 