### PR TITLE
SPEC-4851: TIAF runtime-side implementation of sequence reporting

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Include/TestImpactFramework/TestImpactRuntime.h
@@ -11,7 +11,7 @@
 #include <TestImpactFramework/TestImpactChangeList.h>
 #include <TestImpactFramework/TestImpactClientTestSelection.h>
 #include <TestImpactFramework/TestImpactClientTestRun.h>
-#include <TestImpactFramework/TestImpactClientFailureReport.h>
+#include <TestImpactFramework/TestImpactClientSequenceReport.h>
 #include <TestImpactFramework/TestImpactTestSequence.h>
 
 #include <AzCore/std/string/string.h>
@@ -33,10 +33,12 @@ namespace TestImpact
     class TestEngineInstrumentedRun;
 
     //! Callback for a test sequence that isn't using test impact analysis to determine selected tests.
+    //! @parm suiteType The test suite to select tests from.
     //! @param tests The tests that will be run for this sequence.
-    using TestSequenceStartCallback = AZStd::function<void(Client::TestRunSelection&& tests)>;
+    using TestSequenceStartCallback = AZStd::function<void(SuiteType suiteType, const Client::TestRunSelection& tests)>;
 
     //! Callback for a test sequence using test impact analysis.
+    //! @parm suiteType The test suite to select tests from.
     //! @param selectedTests The tests that have been selected for this run by test impact analysis.
     //! @param discardedTests The tests that have been rejected for this run by test impact analysis. 
     //! @param draftedTests The tests that have been drafted in for this run due to requirements outside of test impact analysis
@@ -45,11 +47,13 @@ namespace TestImpact
     //! These tests will be run with coverage instrumentation.
     //! @note discardedTests and draftedTests may contain overlapping tests.
     using ImpactAnalysisTestSequenceStartCallback = AZStd::function<void(
-        Client::TestRunSelection&& selectedTests,
-        AZStd::vector<AZStd::string>&& discardedTests,
-        AZStd::vector<AZStd::string>&& draftedTests)>;
+        SuiteType suiteType,
+        const Client::TestRunSelection& selectedTests,
+        const AZStd::vector<AZStd::string>& discardedTests,
+        const AZStd::vector<AZStd::string>& draftedTests)>;
 
     //! Callback for a test sequence using test impact analysis.
+    //! @parm suiteType The test suite to select tests from.
     //! @param selectedTests The tests that have been selected for this run by test impact analysis.
     //! @param discardedTests The tests that have been rejected for this run by test impact analysis.
     //! These tests will not be run without coverage instrumentation unless there is an entry in the draftedTests list.
@@ -58,30 +62,22 @@ namespace TestImpact
     //! to execute previously).
     //! @note discardedTests and draftedTests may contain overlapping tests.
     using SafeImpactAnalysisTestSequenceStartCallback = AZStd::function<void(
-        Client::TestRunSelection&& selectedTests,
-        Client::TestRunSelection&& discardedTests,
-        AZStd::vector<AZStd::string>&& draftedTests)>;
+        SuiteType suiteType,
+        const Client::TestRunSelection& selectedTests,
+        const Client::TestRunSelection& discardedTests,
+        const AZStd::vector<AZStd::string>& draftedTests)>;
 
     //! Callback for end of a test sequence.
-    //! @param failureReport The test runs that failed for any reason during this sequence.
-    //! @param duration The total duration of this test sequence.
-    using TestSequenceCompleteCallback = AZStd::function<void(
-        Client::SequenceFailure&& failureReport,
-        AZStd::chrono::milliseconds duration)>;
-
-    //! Callback for end of a test impact analysis test sequence.
-    //! @param selectedFailureReport The selected test runs that failed for any reason during this sequence.
-    //! @param discardedFailureReport The discarded test runs that failed for any reason during this sequence.
-    //! @param duration The total duration of this test sequence.
-    using SafeTestSequenceCompleteCallback = AZStd::function<void(
-        Client::SequenceFailure&& selectedFailureReport,
-        Client::SequenceFailure&& discardedFailureReport,
-        AZStd::chrono::milliseconds selectedDuration,
-        AZStd::chrono::milliseconds discardedDuration)>;
+    //! @tparam SequenceReportType The report type to be used for the sequence.
+    //! @param sequenceReport The completed sequence report.
+    template<typename SequenceReportType>
+    using TestSequenceCompleteCallback = AZStd::function<void(const SequenceReportType& sequenceReport)>;
 
     //! Callback for test runs that have completed for any reason.
-    //! @param selectedTests The test that has completed.
-    using TestRunCompleteCallback = AZStd::function<void(Client::TestRun&& selectedTests)>;
+    //! @param testRunMeta The test that has completed.
+    //! @param numTestRunsCompleted The number of test runs that have completed.
+    //! @param totalNumTestRuns The total number of test runs in the sequence.
+    using TestRunCompleteCallback = AZStd::function<void(Client::TestRun& testRun, size_t numTestRunsCompleted, size_t totalNumTestRuns)>;
 
     //! The API exposed to the client responsible for all test runs and persistent data management.
     class Runtime
@@ -107,19 +103,19 @@ namespace TestImpact
             AZStd::optional<size_t> maxConcurrency = AZStd::nullopt);
 
         ~Runtime();
-
+        
         //! Runs a test sequence where all tests with a matching suite in the suite filter and also not on the excluded list are selected.
         //! @param testTargetTimeout The maximum duration individual test targets may be in flight for (infinite if empty).
         //! @param globalTimeout The maximum duration the entire test sequence may run for (infinite if empty).
         //! @param testSequenceStartCallback The client function to be called after the test targets have been selected but prior to running the tests.
         //! @param testSequenceCompleteCallback The client function to be called after the test sequence has completed.
         //! @param testRunCompleteCallback The client function to be called after an individual test run has completed.
-        //! @returns
-        TestSequenceResult RegularTestSequence(
+        //! @returns The test run and sequence report for the selected test sequence.
+        Client::SequenceReport RegularTestSequence(
             AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
             AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
             AZStd::optional<TestSequenceStartCallback> testSequenceStartCallback,
-            AZStd::optional<TestSequenceCompleteCallback> testSequenceCompleteCallback,
+            AZStd::optional<TestSequenceCompleteCallback<Client::SequenceReport>> testSequenceCompleteCallback,
             AZStd::optional<TestRunCompleteCallback> testRunCompleteCallback);
 
         //! Runs a test sequence where tests are selected according to test impact analysis so long as they are not on the excluded list.
@@ -131,15 +127,15 @@ namespace TestImpact
         //! @param testSequenceStartCallback The client function to be called after the test targets have been selected but prior to running the tests.
         //! @param testSequenceCompleteCallback The client function to be called after the test sequence has completed.
         //! @param testRunCompleteCallback The client function to be called after an individual test run has completed.
-        //! @returns
-        TestSequenceResult ImpactAnalysisTestSequence(
+        //! @returns The test run and sequence report for the selected and drafted test sequences.
+        Client::ImpactAnalysisSequenceReport ImpactAnalysisTestSequence(
             const ChangeList& changeList,
             Policy::TestPrioritization testPrioritizationPolicy,
             Policy::DynamicDependencyMap dynamicDependencyMapPolicy,
             AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
             AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
             AZStd::optional<ImpactAnalysisTestSequenceStartCallback> testSequenceStartCallback,
-            AZStd::optional<TestSequenceCompleteCallback> testSequenceCompleteCallback,
+            AZStd::optional<TestSequenceCompleteCallback<Client::ImpactAnalysisSequenceReport>> testSequenceCompleteCallback,
             AZStd::optional<TestRunCompleteCallback> testRunCompleteCallback);
 
         //! Runs a test sequence as per the ImpactAnalysisTestSequence where the tests not selected are also run (albeit without instrumentation).
@@ -150,14 +146,14 @@ namespace TestImpact
         //! @param testSequenceStartCallback The client function to be called after the test targets have been selected but prior to running the tests.
         //! @param testSequenceCompleteCallback The client function to be called after the test sequence has completed.
         //! @param testRunCompleteCallback The client function to be called after an individual test run has completed.
-        //! @returns
-        AZStd::pair<TestSequenceResult, TestSequenceResult> SafeImpactAnalysisTestSequence(
+        //! @returns The test run and sequence report for the selected, discarded and drafted test sequences.
+        Client::SafeImpactAnalysisSequenceReport SafeImpactAnalysisTestSequence(
             const ChangeList& changeList,
             Policy::TestPrioritization testPrioritizationPolicy,
             AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
             AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
             AZStd::optional<SafeImpactAnalysisTestSequenceStartCallback> testSequenceStartCallback,
-            AZStd::optional<SafeTestSequenceCompleteCallback> testSequenceCompleteCallback,
+            AZStd::optional<TestSequenceCompleteCallback<Client::SafeImpactAnalysisSequenceReport>> testSequenceCompleteCallback,
             AZStd::optional<TestRunCompleteCallback> testRunCompleteCallback);
 
         //! Runs all tests not on the excluded list and uses their coverage data to seed the test impact analysis data (ant existing data will be overwritten).
@@ -166,12 +162,12 @@ namespace TestImpact
         //! @param testSequenceStartCallback The client function to be called after the test targets have been selected but prior to running the tests.
         //! @param testSequenceCompleteCallback The client function to be called after the test sequence has completed.
         //! @param testRunCompleteCallback The client function to be called after an individual test run has completed.
-        //! 
-        TestSequenceResult SeededTestSequence(
+        //! @returns The test run and sequence report for the selected test sequence.
+        Client::SequenceReport SeededTestSequence(
             AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
             AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
             AZStd::optional<TestSequenceStartCallback> testSequenceStartCallback,
-            AZStd::optional<TestSequenceCompleteCallback> testSequenceCompleteCallback,
+            AZStd::optional<TestSequenceCompleteCallback<Client::SequenceReport>> testSequenceCompleteCallback,
             AZStd::optional<TestRunCompleteCallback> testRunCompleteCallback);
 
         //! Returns true if the runtime has test impact analysis data (either preexisting or generated).
@@ -208,8 +204,8 @@ namespace TestImpact
         void UpdateAndSerializeDynamicDependencyMap(const AZStd::vector<TestEngineInstrumentedRun>& jobs);
 
         RuntimeConfig m_config;
-        SuiteType m_suiteFilter;
         RepoPath m_sparTIAFile;
+        SuiteType m_suiteFilter;
         Policy::ExecutionFailure m_executionFailurePolicy;
         Policy::FailedTestCoverage m_failedTestCoveragePolicy;
         Policy::TestFailure m_testFailurePolicy;

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/TestImpactTestEngine.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/TestImpactTestEngine.cpp
@@ -261,7 +261,7 @@ namespace TestImpact
         Policy::TestFailure testFailurePolicy,
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
         AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
-        AZStd::optional<TestEngineJobCompleteCallback> callback)
+        AZStd::optional<TestEngineJobCompleteCallback> callback) const
     {
         TestEngineJobMap<TestEnumerator::JobInfo::IdType> engineJobs;
         const auto jobInfos = m_testJobInfoGenerator->GenerateTestEnumerationJobInfos(testTargets, TestEnumerator::JobInfo::CachePolicy::Write);
@@ -284,7 +284,7 @@ namespace TestImpact
         [[maybe_unused]]Policy::TargetOutputCapture targetOutputCapture,
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
         AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
-        AZStd::optional<TestEngineJobCompleteCallback> callback)
+        AZStd::optional<TestEngineJobCompleteCallback> callback) const
     {
         DeleteArtifactXmls();
 
@@ -311,7 +311,7 @@ namespace TestImpact
         [[maybe_unused]]Policy::TargetOutputCapture targetOutputCapture,
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
         AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
-        AZStd::optional<TestEngineJobCompleteCallback> callback)
+        AZStd::optional<TestEngineJobCompleteCallback> callback) const
     {
         DeleteArtifactXmls();
 

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/TestImpactTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/TestImpactTestEngine.h
@@ -68,7 +68,7 @@ namespace TestImpact
             Policy::TestFailure testFailurePolicy,
             AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
             AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
-            AZStd::optional<TestEngineJobCompleteCallback> callback);
+            AZStd::optional<TestEngineJobCompleteCallback> callback) const;
 
         //! Performs a test run without any instrumentation and, for each test target, returns the test run results and metrics about the run.
         //! @param testTargets The test targets to run.
@@ -88,7 +88,7 @@ namespace TestImpact
             Policy::TargetOutputCapture targetOutputCapture,
             AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
             AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
-            AZStd::optional<TestEngineJobCompleteCallback> callback);
+            AZStd::optional<TestEngineJobCompleteCallback> callback) const;
 
         //! Performs a test run with instrumentation and, for each test target, returns the test run results, coverage data and metrics about the run.
         //! @param testTargets The test targets to run.
@@ -110,7 +110,7 @@ namespace TestImpact
             Policy::TargetOutputCapture targetOutputCapture,
             AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
             AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
-            AZStd::optional<TestEngineJobCompleteCallback> callback);
+            AZStd::optional<TestEngineJobCompleteCallback> callback) const;
 
     private:
         //! Cleans up the artifacts directory of any artifacts from previous runs.

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -33,11 +33,31 @@ namespace TestImpact
             {
             }
 
-            //! Returns the time elapsed (in milliseconds) since the timer was instantiated
-            AZStd::chrono::milliseconds Elapsed()
+            //! Returns the time point that the timer was instantiated.
+            AZStd::chrono::high_resolution_clock::time_point GetStartTimePoint() const
+            {
+                return m_startTime;
+            }
+
+            //! Returns the time point that the timer was instantiated relative to the specified starting time point.
+            AZStd::chrono::high_resolution_clock::time_point GetStartTimePointRelative(const Timer& start) const
+            {
+                return AZStd::chrono::high_resolution_clock::time_point() +
+                    AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(m_startTime - start.GetStartTimePoint());
+            }
+
+            //! Returns the time elapsed (in milliseconds) since the timer was instantiated.
+            AZStd::chrono::milliseconds GetElapsedMs() const
             {
                 const auto endTime = AZStd::chrono::high_resolution_clock::now();
                 return AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(endTime - m_startTime);
+            }
+
+            //! Returns the current time point relative to the time point the timer was instantiated.
+            AZStd::chrono::high_resolution_clock::time_point GetElapsedTimepoint() const
+            {
+                const auto endTime = AZStd::chrono::high_resolution_clock::now();
+                return m_startTime + AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(endTime - m_startTime);
             }
 
         private:
@@ -48,8 +68,11 @@ namespace TestImpact
         class TestRunCompleteCallbackHandler
         {
         public:
-            TestRunCompleteCallbackHandler(AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
-                : m_testCompleteCallback(testCompleteCallback)
+            TestRunCompleteCallbackHandler(
+                size_t totalTests,
+                AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
+                : m_totalTests(totalTests)
+                , m_testCompleteCallback(testCompleteCallback)
             {
             }
 
@@ -57,19 +80,24 @@ namespace TestImpact
             {
                 if (m_testCompleteCallback.has_value())
                 {
-                    (*m_testCompleteCallback)
-                        (Client::TestRun(testJob.GetTestTarget()->GetName(), testJob.GetTestResult(), testJob.GetDuration()));
+                    Client::TestRun testRun(
+                        testJob.GetTestTarget()->GetName(), testJob.GetCommandString(), testJob.GetStartTime(), testJob.GetDuration(),
+                        testJob.GetTestResult());
+
+                    (*m_testCompleteCallback)(testRun, ++m_numTestsCompleted, m_totalTests);
                 }
             }
 
         private:
+            size_t m_totalTests;
+            size_t m_numTestsCompleted = 0;
             AZStd::optional<TestRunCompleteCallback> m_testCompleteCallback;
         };
     }
 
     //! Utility for concatenating two vectors.
     template<typename T>
-    AZStd::vector<T> ConcatenateVectors(const AZStd::vector<T>& v1, const AZStd::vector<T>& v2)
+    static AZStd::vector<T> ConcatenateVectors(const AZStd::vector<T>& v1, const AZStd::vector<T>& v2)
     {
         AZStd::vector<T> result;
         result.reserve(v1.size() + v2.size());
@@ -297,6 +325,7 @@ namespace TestImpact
                     continue;
                 }
 
+                // Add the sources covered by this test target to the coverage map
                 for (const auto& source : job.GetTestCoverge().value().GetSourcesCovered())
                 {
                     coverage[source.String()].insert(job.GetTestTarget()->GetName());
@@ -308,6 +337,7 @@ namespace TestImpact
         sourceCoveringTests.reserve(coverage.size());
         for (auto&& [source, testTargets] : coverage)
         {
+            // Check to see whether this source is inside the repo or not (not a perfect check but weeds out the obvious non-repo sources)
             if (const auto sourcePath = RepoPath(source);
                 sourcePath.IsRelativeTo(m_config.m_repo.m_root))
             {
@@ -352,17 +382,17 @@ namespace TestImpact
         }
     }
 
-    TestSequenceResult Runtime::RegularTestSequence(
+    Client::SequenceReport Runtime::RegularTestSequence(
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
         AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
         AZStd::optional<TestSequenceStartCallback> testSequenceStartCallback,
-        AZStd::optional<TestSequenceCompleteCallback> testSequenceEndCallback,
+        AZStd::optional<TestSequenceCompleteCallback<Client::SequenceReport>> testSequenceEndCallback,
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
     {
-        Timer timer;
+        Timer sequenceTimer;
         AZStd::vector<const TestTarget*> includedTestTargets;
         AZStd::vector<const TestTarget*> excludedTestTargets;
-
+        
         // Separate the test targets into those that are excluded by either the test filter or exclusion list and those that are not
         for (const auto& testTarget : m_dynamicDependencyMap->GetTestTargetList().GetTargets())
         {
@@ -377,12 +407,17 @@ namespace TestImpact
             }
         }
 
-        // Sequence start callback
+        // Extract the client facing representation of selected test targets
+        const Client::TestRunSelection selectedTests(ExtractTestTargetNames(includedTestTargets), ExtractTestTargetNames(excludedTestTargets));
+
+        // Inform the client that the sequence is about to start
         if (testSequenceStartCallback.has_value())
         {
-            (*testSequenceStartCallback)(Client::TestRunSelection(ExtractTestTargetNames(includedTestTargets), ExtractTestTargetNames(excludedTestTargets)));
+            (*testSequenceStartCallback)(m_suiteFilter, selectedTests);
         }
 
+        // Run the test targets and collect the test run results
+        Timer testRunTimer;
         const auto [result, testJobs] = m_testEngine->RegularRun(
             includedTestTargets,
             m_testShardingPolicy,
@@ -391,27 +426,124 @@ namespace TestImpact
             m_targetOutputCapture,
             testTargetTimeout,
             globalTimeout,
-            TestRunCompleteCallbackHandler(testCompleteCallback));
+            TestRunCompleteCallbackHandler(includedTestTargets.size(), testCompleteCallback));
+        const auto testRunDuration = testRunTimer.GetElapsedMs();
 
+        // Generate the sequence report for the client
+        const auto sequenceReport = Client::SequenceReport(
+            m_suiteFilter,
+            selectedTests,
+            GenerateTestRunReport(result, testRunTimer.GetStartTimePointRelative(sequenceTimer), testRunDuration, testJobs));
+
+        // Inform the client that the sequence has ended
         if (testSequenceEndCallback.has_value())
         {
-            (*testSequenceEndCallback)(GenerateSequenceFailureReport(testJobs), timer.Elapsed());
+            (*testSequenceEndCallback)(sequenceReport);
         }
 
-        return result;
+        return sequenceReport;
     }
 
-    TestSequenceResult Runtime::ImpactAnalysisTestSequence(
+    //! Wrapper for the impact analysis test sequence to handle both the updating and non-updating policies through a common pathway.
+    //! @tparam TestRunnerFunctor The functor for running the specified tests.
+    //! @tparam TestJob The test engine job type returned by the functor.
+    //! @param suiteType The suite type used for this sequence.
+    //! @param timer The timer to use for the test run timings.
+    //! @param testRunner The test runner functor to use for each of the test runs.
+    //! @param includedSelectedTestTargets The subset of test targets that were selected to run and not also fully excluded from running.
+    //! @param excludedSelectedTestTargets The subset of test targets that were selected to run but were fully excluded running.
+    //! @param discardedTestTargets The subset of test targets that were discarded from the test selection and will not be run.
+    //! @param globalTimeout The maximum duration the entire test sequence may run for (infinite if empty).
+    //! @param testSequenceStartCallback The client function to be called after the test targets have been selected but prior to running the tests.
+    //! @param testSequenceCompleteCallback The client function to be called after the test sequence has completed.
+    //! @param testRunCompleteCallback The client function to be called after an individual test run has completed.
+    //! @param updateCoverage The function to call to update the dynamic dependency map with test coverage (if any).
+    template<typename TestRunnerFunctor, typename TestJob>
+    Client::ImpactAnalysisSequenceReport ImpactAnalysisTestSequenceWrapper(
+        SuiteType suiteType,
+        const Timer& sequenceTimer,
+        const TestRunnerFunctor& testRunner,
+        const AZStd::vector<const TestTarget*>& includedSelectedTestTargets,
+        const AZStd::vector<const TestTarget*>& excludedSelectedTestTargets,
+        const AZStd::vector<const TestTarget*>& discardedTestTargets,
+        const AZStd::vector<const TestTarget*>& draftedTestTargets,
+        const AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
+        AZStd::optional<ImpactAnalysisTestSequenceStartCallback> testSequenceStartCallback,
+        AZStd::optional<TestSequenceCompleteCallback<Client::ImpactAnalysisSequenceReport>> testSequenceEndCallback,
+        AZStd::optional<TestRunCompleteCallback> testCompleteCallback,
+        AZStd::optional<AZStd::function<void(const AZStd::vector<TestJob>& jobs)>> updateCoverage)
+    {
+        auto sequenceTimeout = globalTimeout;
+
+        // Extract the client facing representation of selected, discarded and drafted test targets
+        const Client::TestRunSelection selectedTests(
+            ExtractTestTargetNames(includedSelectedTestTargets), ExtractTestTargetNames(excludedSelectedTestTargets));
+        const auto discardedTests = ExtractTestTargetNames(discardedTestTargets);
+        const auto draftedTests = ExtractTestTargetNames(draftedTestTargets);
+
+        // Inform the client that the sequence is about to start
+        if (testSequenceStartCallback.has_value())
+        {
+            (*testSequenceStartCallback)(suiteType, selectedTests, discardedTests, draftedTests);
+        }
+
+        // We share the test run complete handler between the selected and drafted test runs as to present them together as one
+        // continuous test sequence to the client rather than two discrete test runs
+        const size_t totalNumTestRuns = includedSelectedTestTargets.size() + draftedTestTargets.size();
+        TestRunCompleteCallbackHandler testRunCompleteHandler(totalNumTestRuns, testCompleteCallback);
+
+        // Run the selected test targets and collect the test run results
+        Timer selectedTestRunTimer;
+        const auto [selectedResult, selectedTestJobs] = testRunner(includedSelectedTestTargets, testRunCompleteHandler, globalTimeout);
+        const auto selectedTestRunDuration = selectedTestRunTimer.GetElapsedMs();
+
+        // Carry the remaining global sequence time over to the drafted test run
+        if (globalTimeout.has_value())
+        {
+            const auto elapsed = selectedTestRunDuration;
+            sequenceTimeout = elapsed < globalTimeout.value() ? globalTimeout.value() - elapsed : AZStd::chrono::milliseconds(0);
+        }
+
+        // Run the drafted test targets and collect the test run results
+        Timer draftedTestRunTimer;
+        const auto [draftedResult, draftedTestJobs] = testRunner(draftedTestTargets, testRunCompleteHandler, globalTimeout);
+        const auto draftedTestRunDuration = draftedTestRunTimer.GetElapsedMs();
+
+        // Generate the sequence report for the client
+        const auto sequenceReport = Client::ImpactAnalysisSequenceReport(
+            suiteType,
+            selectedTests,
+            discardedTests,
+            draftedTests,
+            GenerateTestRunReport(selectedResult, selectedTestRunTimer.GetStartTimePointRelative(sequenceTimer), selectedTestRunDuration, selectedTestJobs),
+            GenerateTestRunReport(draftedResult, draftedTestRunTimer.GetStartTimePointRelative(sequenceTimer), draftedTestRunDuration, draftedTestJobs));
+
+        // Inform the client that the sequence has ended
+        if (testSequenceEndCallback.has_value())
+        {
+            (*testSequenceEndCallback)(sequenceReport);
+        }
+
+        // Update the dynamic dependency map with the latest coverage data (if any)
+        if (updateCoverage.has_value())
+        {
+            (*updateCoverage)(ConcatenateVectors(selectedTestJobs, draftedTestJobs));
+        }
+
+        return sequenceReport;
+    }
+
+    Client::ImpactAnalysisSequenceReport Runtime::ImpactAnalysisTestSequence(
         const ChangeList& changeList,
         Policy::TestPrioritization testPrioritizationPolicy,
         Policy::DynamicDependencyMap dynamicDependencyMapPolicy,
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
         AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
         AZStd::optional<ImpactAnalysisTestSequenceStartCallback> testSequenceStartCallback,
-        AZStd::optional<TestSequenceCompleteCallback> testSequenceEndCallback,
+        AZStd::optional<TestSequenceCompleteCallback<Client::ImpactAnalysisSequenceReport>> testSequenceEndCallback,
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
     {
-        Timer timer;
+        Timer sequenceTimer;
 
         // Draft in the test targets that have no coverage entries in the dynamic dependency map
         AZStd::vector<const TestTarget*> draftedTestTargets = m_dynamicDependencyMap->GetNotCoveringTests();
@@ -422,71 +554,94 @@ namespace TestImpact
         // The subset of selected test targets that are not on the configuration's exclude list and those that are
         auto [includedSelectedTestTargets, excludedSelectedTestTargets] = SelectTestTargetsByExcludeList(selectedTestTargets);
 
-        // We present to the client the included selected test targets and the drafted test targets as distinct sets but internally
-        // we consider the concatenated set of the two the actual set of tests to run
-        AZStd::vector<const TestTarget*> testTargetsToRun = ConcatenateVectors(includedSelectedTestTargets, draftedTestTargets);
-
-        if (testSequenceStartCallback.has_value())
+        // Functor for running instrumented test targets
+        const auto instrumentedTestRun =
+            [this, &testTargetTimeout](
+                const AZStd::vector<const TestTarget*>& testsTargets,
+                TestRunCompleteCallbackHandler& testRunCompleteHandler,
+                AZStd::optional<AZStd::chrono::milliseconds> globalTimeout)
         {
-            (*testSequenceStartCallback)(
-                Client::TestRunSelection(ExtractTestTargetNames(includedSelectedTestTargets), ExtractTestTargetNames(excludedSelectedTestTargets)),
-                ExtractTestTargetNames(discardedTestTargets),
-                ExtractTestTargetNames(draftedTestTargets));
-        }
+            return m_testEngine->InstrumentedRun(
+                testsTargets,
+                m_testShardingPolicy,
+                m_executionFailurePolicy,
+                m_integrationFailurePolicy,
+                m_testFailurePolicy,
+                m_targetOutputCapture,
+                testTargetTimeout,
+                globalTimeout,
+                AZStd::ref(testRunCompleteHandler));
+        };
+
+        // Functor for running uninstrumented test targets
+        const auto regularTestRun =
+            [this, &testTargetTimeout](
+                const AZStd::vector<const TestTarget*>& testsTargets,
+                 TestRunCompleteCallbackHandler& testRunCompleteHandler,
+                AZStd::optional<AZStd::chrono::milliseconds> globalTimeout)
+        {
+            return m_testEngine->RegularRun(
+                testsTargets,
+                m_testShardingPolicy,
+                m_executionFailurePolicy,
+                m_testFailurePolicy,
+                m_targetOutputCapture,
+                testTargetTimeout,
+                globalTimeout,
+                AZStd::ref(testRunCompleteHandler));
+        };
 
         if (dynamicDependencyMapPolicy == Policy::DynamicDependencyMap::Update)
         {
-            const auto [result, testJobs] = m_testEngine->InstrumentedRun(
-                testTargetsToRun,
-                m_testShardingPolicy,
-                m_executionFailurePolicy,
-                Policy::IntegrityFailure::Continue,
-                m_testFailurePolicy,
-                m_targetOutputCapture,
-                testTargetTimeout,
-                globalTimeout,
-                TestRunCompleteCallbackHandler(testCompleteCallback));
-
-            UpdateAndSerializeDynamicDependencyMap(testJobs);
-
-            if (testSequenceEndCallback.has_value())
+            AZStd::optional<AZStd::function<void(const AZStd::vector<TestEngineInstrumentedRun>& jobs)>> updateCoverage =
+                [this](const AZStd::vector<TestEngineInstrumentedRun>& jobs)
             {
-                (*testSequenceEndCallback)(GenerateSequenceFailureReport(testJobs), timer.Elapsed());
-            }
+                UpdateAndSerializeDynamicDependencyMap(jobs);
+            };
 
-            return result;
+            return ImpactAnalysisTestSequenceWrapper(
+                m_suiteFilter,
+                sequenceTimer,
+                instrumentedTestRun,
+                includedSelectedTestTargets,
+                excludedSelectedTestTargets,
+                discardedTestTargets,
+                draftedTestTargets,
+                globalTimeout,
+                testSequenceStartCallback,
+                testSequenceEndCallback,
+                testCompleteCallback,
+                updateCoverage);
         }
         else
         {
-            const auto [result, testJobs] = m_testEngine->RegularRun(
-                testTargetsToRun,
-                m_testShardingPolicy,
-                m_executionFailurePolicy,
-                m_testFailurePolicy,
-                m_targetOutputCapture,
-                testTargetTimeout,
+            return ImpactAnalysisTestSequenceWrapper(
+                m_suiteFilter,
+                sequenceTimer,
+                regularTestRun,
+                includedSelectedTestTargets,
+                excludedSelectedTestTargets,
+                discardedTestTargets,
+                draftedTestTargets,
                 globalTimeout,
-                TestRunCompleteCallbackHandler(testCompleteCallback));
-
-            if (testSequenceEndCallback.has_value())
-            {
-                (*testSequenceEndCallback)(GenerateSequenceFailureReport(testJobs), timer.Elapsed());
-            }
-
-            return result;
+                testSequenceStartCallback,
+                testSequenceEndCallback,
+                testCompleteCallback,
+                AZStd::optional<AZStd::function<void(const AZStd::vector<TestEngineRegularRun>& jobs)>>{ AZStd::nullopt });
         }
     }
 
-    AZStd::pair<TestSequenceResult, TestSequenceResult> Runtime::SafeImpactAnalysisTestSequence(
+    Client::SafeImpactAnalysisSequenceReport Runtime::SafeImpactAnalysisTestSequence(
         const ChangeList& changeList,
         Policy::TestPrioritization testPrioritizationPolicy,
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
         AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
         AZStd::optional<SafeImpactAnalysisTestSequenceStartCallback> testSequenceStartCallback,
-        AZStd::optional<SafeTestSequenceCompleteCallback> testSequenceEndCallback,
+            AZStd::optional<TestSequenceCompleteCallback<Client::SafeImpactAnalysisSequenceReport>> testSequenceEndCallback,
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
     {
-        Timer timer;
+        Timer sequenceTimer;
+        auto sequenceTimeout = globalTimeout;
 
         // Draft in the test targets that have no coverage entries in the dynamic dependency map
         AZStd::vector<const TestTarget*> draftedTestTargets = m_dynamicDependencyMap->GetNotCoveringTests();
@@ -500,40 +655,46 @@ namespace TestImpact
         // The subset of discarded test targets that are not on the configuration's exclude list and those that are
         auto [includedDiscardedTestTargets, excludedDiscardedTestTargets] = SelectTestTargetsByExcludeList(discardedTestTargets);
 
-        // We present to the client the included selected test targets and the drafted test targets as distinct sets but internally
-        // we consider the concatenated set of the two the actual set of tests to run
-        AZStd::vector<const TestTarget*> testTargetsToRun = ConcatenateVectors(includedSelectedTestTargets, draftedTestTargets);
+        // Extract the client facing representation of selected, discarded and drafted test targets
+        const Client::TestRunSelection selectedTests(
+            ExtractTestTargetNames(includedSelectedTestTargets), ExtractTestTargetNames(excludedSelectedTestTargets));
+        const Client::TestRunSelection discardedTests(ExtractTestTargetNames(includedDiscardedTestTargets), ExtractTestTargetNames(excludedDiscardedTestTargets));
+            const auto draftedTests = ExtractTestTargetNames(draftedTestTargets);
 
+        // Inform the client that the sequence is about to start
         if (testSequenceStartCallback.has_value())
         {
-            (*testSequenceStartCallback)(
-                Client::TestRunSelection(ExtractTestTargetNames(includedSelectedTestTargets), ExtractTestTargetNames(excludedSelectedTestTargets)),
-                Client::TestRunSelection(ExtractTestTargetNames(includedDiscardedTestTargets), ExtractTestTargetNames(excludedDiscardedTestTargets)),
-                ExtractTestTargetNames(draftedTestTargets));
+            (*testSequenceStartCallback)(m_suiteFilter, selectedTests, discardedTests, draftedTests);
         }
 
-        // Impact analysis run of the selected test targets
+        // We share the test run complete handler between the selected and drafted test runs as to present them together as one
+        // continuous test sequence to the client rather than two discrete test runs
+        const size_t totalNumTestRuns = includedSelectedTestTargets.size() + draftedTestTargets.size() + includedDiscardedTestTargets.size();
+        TestRunCompleteCallbackHandler testRunCompleteHandler(totalNumTestRuns, testCompleteCallback);
+
+        // Run the selected test targets and collect the test run results
+        Timer selectedTestRunTimer;
         const auto [selectedResult, selectedTestJobs] = m_testEngine->InstrumentedRun(
-            testTargetsToRun,
+            includedSelectedTestTargets,
             m_testShardingPolicy,
             m_executionFailurePolicy,
-            Policy::IntegrityFailure::Continue,
+            m_integrationFailurePolicy,
             m_testFailurePolicy,
             m_targetOutputCapture,
             testTargetTimeout,
-            globalTimeout,
-            TestRunCompleteCallbackHandler(testCompleteCallback));
-        
-        const auto selectedDuraton = timer.Elapsed();
+            sequenceTimeout,
+            AZStd::ref(testRunCompleteHandler));
+        const auto selectedTestRunDuration = selectedTestRunTimer.GetElapsedMs();
 
-        // Carry the remaining global sequence time over to the discarded test run
+        // Carry the remaining global sequence time over to the drafted test run
         if (globalTimeout.has_value())
         {
-            const auto elapsed = timer.Elapsed();
-            globalTimeout = elapsed < globalTimeout.value() ? globalTimeout.value() - elapsed : AZStd::chrono::milliseconds(0);
+            const auto elapsed = selectedTestRunDuration;
+            sequenceTimeout = elapsed < globalTimeout.value() ? globalTimeout.value() - elapsed : AZStd::chrono::milliseconds(0);
         }
 
-        // Regular run of the discarded test targets
+        // Run the discarded test targets and collect the test run results
+        Timer discardedTestRunTimer;
         const auto [discardedResult, discardedTestJobs] = m_testEngine->RegularRun(
             includedDiscardedTestTargets,
             m_testShardingPolicy,
@@ -541,35 +702,63 @@ namespace TestImpact
             m_testFailurePolicy,
             m_targetOutputCapture,
             testTargetTimeout,
-            globalTimeout,
-            TestRunCompleteCallbackHandler(testCompleteCallback));
+            sequenceTimeout,
+            AZStd::ref(testRunCompleteHandler));
+        const auto discardedTestRunDuration = discardedTestRunTimer.GetElapsedMs();
 
-        const auto discardedDuraton = timer.Elapsed();
-
-        if (testSequenceEndCallback.has_value())
+        // Carry the remaining global sequence time over to the drafted test run
+        if (globalTimeout.has_value())
         {
-            (*testSequenceEndCallback)(
-                GenerateSequenceFailureReport(selectedTestJobs),
-                GenerateSequenceFailureReport(discardedTestJobs),
-                selectedDuraton,
-                discardedDuraton);
+            const auto elapsed = selectedTestRunDuration + discardedTestRunDuration;
+            sequenceTimeout = elapsed < globalTimeout.value() ? globalTimeout.value() - elapsed : AZStd::chrono::milliseconds(0);
         }
 
-        UpdateAndSerializeDynamicDependencyMap(selectedTestJobs);
-        return { selectedResult, discardedResult };
+        // Run the drafted test targets and collect the test run results
+        Timer draftedTestRunTimer;
+        const auto [draftedResult, draftedTestJobs] = m_testEngine->InstrumentedRun(
+            draftedTestTargets,
+            m_testShardingPolicy,
+            m_executionFailurePolicy,
+            m_integrationFailurePolicy,
+            m_testFailurePolicy,
+            m_targetOutputCapture,
+            testTargetTimeout,
+            sequenceTimeout,
+            AZStd::ref(testRunCompleteHandler));
+        const auto draftedTestRunDuration = draftedTestRunTimer.GetElapsedMs();
+
+        // Generate the sequence report for the client
+        const auto sequenceReport = Client::SafeImpactAnalysisSequenceReport(
+            m_suiteFilter,
+            selectedTests,
+            discardedTests,
+            draftedTests,
+            GenerateTestRunReport(selectedResult, selectedTestRunTimer.GetStartTimePointRelative(sequenceTimer), selectedTestRunDuration, selectedTestJobs),
+            GenerateTestRunReport(discardedResult, discardedTestRunTimer.GetStartTimePointRelative(sequenceTimer), discardedTestRunDuration, discardedTestJobs),
+            GenerateTestRunReport(draftedResult, draftedTestRunTimer.GetStartTimePointRelative(sequenceTimer), draftedTestRunDuration, draftedTestJobs));
+
+        // Inform the client that the sequence has ended
+        if (testSequenceEndCallback.has_value())
+        {
+            (*testSequenceEndCallback)(sequenceReport);
+        }
+
+        UpdateAndSerializeDynamicDependencyMap(ConcatenateVectors(selectedTestJobs, draftedTestJobs));
+        return sequenceReport;
     }
 
-    TestSequenceResult Runtime::SeededTestSequence(
+    Client::SequenceReport Runtime::SeededTestSequence(
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
         AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
         AZStd::optional<TestSequenceStartCallback> testSequenceStartCallback,
-        AZStd::optional<TestSequenceCompleteCallback> testSequenceEndCallback,
+        AZStd::optional<TestSequenceCompleteCallback<Client::SequenceReport>> testSequenceEndCallback,
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
     {
-        Timer timer;
+        Timer sequenceTimer;
         AZStd::vector<const TestTarget*> includedTestTargets;
         AZStd::vector<const TestTarget*> excludedTestTargets;
 
+        // Separate the test targets into those that are excluded by either the test filter or exclusion list and those that are not
         for (const auto& testTarget : m_dynamicDependencyMap->GetTestTargetList().GetTargets())
         {
             if (!m_testTargetExcludeList.contains(&testTarget))
@@ -582,31 +771,44 @@ namespace TestImpact
             }
         }
 
+        // Extract the client facing representation of selected test targets
+        Client::TestRunSelection selectedTests(ExtractTestTargetNames(includedTestTargets), ExtractTestTargetNames(excludedTestTargets));
+
+        // Inform the client that the sequence is about to start
         if (testSequenceStartCallback.has_value())
         {
-            (*testSequenceStartCallback)(Client::TestRunSelection(ExtractTestTargetNames(includedTestTargets), ExtractTestTargetNames(excludedTestTargets)));
+            (*testSequenceStartCallback)(m_suiteFilter, selectedTests);
         }
 
+        // Run the test targets and collect the test run results
+        Timer testRunTimer;
         const auto [result, testJobs] = m_testEngine->InstrumentedRun(
             includedTestTargets,
             m_testShardingPolicy,
             m_executionFailurePolicy,
-            Policy::IntegrityFailure::Continue,
+            m_integrationFailurePolicy,
             m_testFailurePolicy,
             m_targetOutputCapture,
             testTargetTimeout,
             globalTimeout,
-            TestRunCompleteCallbackHandler(testCompleteCallback));
+            TestRunCompleteCallbackHandler(includedTestTargets.size(), testCompleteCallback));
+        const auto testRunDuration = testRunTimer.GetElapsedMs();
 
+        // Generate the sequence report for the client
+        const auto sequenceReport = Client::SequenceReport(
+            m_suiteFilter,
+            selectedTests,
+            GenerateTestRunReport(result, testRunTimer.GetStartTimePointRelative(sequenceTimer), testRunDuration, testJobs));
+
+        // Inform the client that the sequence has ended
         if (testSequenceEndCallback.has_value())
         {
-            (*testSequenceEndCallback)(GenerateSequenceFailureReport(testJobs), timer.Elapsed());
+            (*testSequenceEndCallback)(sequenceReport);
         }
 
         ClearDynamicDependencyMapAndRemoveExistingFile();
         UpdateAndSerializeDynamicDependencyMap(testJobs);
-
-        return result;
+        return sequenceReport;
     }
 
     bool Runtime::HasImpactAnalysisData() const

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -392,7 +392,7 @@ namespace TestImpact
         AZStd::optional<TestSequenceCompleteCallback<Client::SequenceReport>> testSequenceEndCallback,
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
     {
-        Timer sequenceTimer;
+        const Timer sequenceTimer;
         AZStd::vector<const TestTarget*> includedTestTargets;
         AZStd::vector<const TestTarget*> excludedTestTargets;
         
@@ -420,7 +420,7 @@ namespace TestImpact
         }
 
         // Run the test targets and collect the test run results
-        Timer testRunTimer;
+        const Timer testRunTimer;
         const auto [result, testJobs] = m_testEngine->RegularRun(
             includedTestTargets,
             m_testShardingPolicy,
@@ -496,7 +496,7 @@ namespace TestImpact
         TestRunCompleteCallbackHandler testRunCompleteHandler(totalNumTestRuns, testCompleteCallback);
 
         // Run the selected test targets and collect the test run results
-        Timer selectedTestRunTimer;
+        const Timer selectedTestRunTimer;
         const auto [selectedResult, selectedTestJobs] = testRunner(includedSelectedTestTargets, testRunCompleteHandler, globalTimeout);
         const auto selectedTestRunDuration = selectedTestRunTimer.GetElapsedMs();
 
@@ -546,7 +546,7 @@ namespace TestImpact
         AZStd::optional<TestSequenceCompleteCallback<Client::ImpactAnalysisSequenceReport>> testSequenceEndCallback,
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
     {
-        Timer sequenceTimer;
+        const Timer sequenceTimer;
 
         // Draft in the test targets that have no coverage entries in the dynamic dependency map
         AZStd::vector<const TestTarget*> draftedTestTargets = m_dynamicDependencyMap->GetNotCoveringTests();
@@ -640,10 +640,10 @@ namespace TestImpact
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
         AZStd::optional<AZStd::chrono::milliseconds> globalTimeout,
         AZStd::optional<SafeImpactAnalysisTestSequenceStartCallback> testSequenceStartCallback,
-            AZStd::optional<TestSequenceCompleteCallback<Client::SafeImpactAnalysisSequenceReport>> testSequenceEndCallback,
+        AZStd::optional<TestSequenceCompleteCallback<Client::SafeImpactAnalysisSequenceReport>> testSequenceEndCallback,
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
     {
-        Timer sequenceTimer;
+        const Timer sequenceTimer;
         auto sequenceTimeout = globalTimeout;
 
         // Draft in the test targets that have no coverage entries in the dynamic dependency map
@@ -676,7 +676,7 @@ namespace TestImpact
         TestRunCompleteCallbackHandler testRunCompleteHandler(totalNumTestRuns, testCompleteCallback);
 
         // Run the selected test targets and collect the test run results
-        Timer selectedTestRunTimer;
+        const Timer selectedTestRunTimer;
         const auto [selectedResult, selectedTestJobs] = m_testEngine->InstrumentedRun(
             includedSelectedTestTargets,
             m_testShardingPolicy,
@@ -697,7 +697,7 @@ namespace TestImpact
         }
 
         // Run the discarded test targets and collect the test run results
-        Timer discardedTestRunTimer;
+        const Timer discardedTestRunTimer;
         const auto [discardedResult, discardedTestJobs] = m_testEngine->RegularRun(
             includedDiscardedTestTargets,
             m_testShardingPolicy,
@@ -717,7 +717,7 @@ namespace TestImpact
         }
 
         // Run the drafted test targets and collect the test run results
-        Timer draftedTestRunTimer;
+        const Timer draftedTestRunTimer;
         const auto [draftedResult, draftedTestJobs] = m_testEngine->InstrumentedRun(
             draftedTestTargets,
             m_testShardingPolicy,
@@ -757,7 +757,7 @@ namespace TestImpact
         AZStd::optional<TestSequenceCompleteCallback<Client::SequenceReport>> testSequenceEndCallback,
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback)
     {
-        Timer sequenceTimer;
+        const Timer sequenceTimer;
         AZStd::vector<const TestTarget*> includedTestTargets;
         AZStd::vector<const TestTarget*> excludedTestTargets;
 
@@ -784,7 +784,7 @@ namespace TestImpact
         }
 
         // Run the test targets and collect the test run results
-        Timer testRunTimer;
+        const Timer testRunTimer;
         const auto [result, testJobs] = m_testEngine->InstrumentedRun(
             includedTestTargets,
             m_testShardingPolicy,

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -81,7 +81,10 @@ namespace TestImpact
                 if (m_testCompleteCallback.has_value())
                 {
                     Client::TestRun testRun(
-                        testJob.GetTestTarget()->GetName(), testJob.GetCommandString(), testJob.GetStartTime(), testJob.GetDuration(),
+                        testJob.GetTestTarget()->GetName(),
+                        testJob.GetCommandString(),
+                        testJob.GetStartTime(),
+                        testJob.GetDuration(),
                         testJob.GetTestResult());
 
                     (*m_testCompleteCallback)(testRun, ++m_numTestsCompleted, m_totalTests);
@@ -89,8 +92,8 @@ namespace TestImpact
             }
 
         private:
-            size_t m_totalTests;
-            size_t m_numTestsCompleted = 0;
+            const size_t m_totalTests; //!< The total number of tests to run for the entire sequence.
+            size_t m_numTestsCompleted = 0; //!< The running total of tests that have completed.
             AZStd::optional<TestRunCompleteCallback> m_testCompleteCallback;
         };
     }
@@ -667,8 +670,8 @@ namespace TestImpact
             (*testSequenceStartCallback)(m_suiteFilter, selectedTests, discardedTests, draftedTests);
         }
 
-        // We share the test run complete handler between the selected and drafted test runs as to present them together as one
-        // continuous test sequence to the client rather than two discrete test runs
+        // We share the test run complete handler between the selected, discarded and drafted test runs as to present them together as one
+        // continuous test sequence to the client rather than three discrete test runs
         const size_t totalNumTestRuns = includedSelectedTestTargets.size() + draftedTestTargets.size() + includedDiscardedTestTargets.size();
         TestRunCompleteCallbackHandler testRunCompleteHandler(totalNumTestRuns, testCompleteCallback);
 
@@ -686,7 +689,7 @@ namespace TestImpact
             AZStd::ref(testRunCompleteHandler));
         const auto selectedTestRunDuration = selectedTestRunTimer.GetElapsedMs();
 
-        // Carry the remaining global sequence time over to the drafted test run
+        // Carry the remaining global sequence time over to the discarded test run
         if (globalTimeout.has_value())
         {
             const auto elapsed = selectedTestRunDuration;

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -476,7 +476,7 @@ namespace TestImpact
         AZStd::optional<TestRunCompleteCallback> testCompleteCallback,
         AZStd::optional<AZStd::function<void(const AZStd::vector<TestJob>& jobs)>> updateCoverage)
     {
-        auto sequenceTimeout = globalTimeout;
+        AZStd::optional<AZStd::chrono::milliseconds> sequenceTimeout = globalTimeout;
 
         // Extract the client facing representation of selected, discarded and drafted test targets
         const Client::TestRunSelection selectedTests(

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.cpp
@@ -49,7 +49,7 @@ namespace TestImpact
         auto buildTargetDescriptors = ReadBuildTargetDescriptorFiles(buildTargetDescriptorConfig);
         auto buildTargets = CompileTargetDescriptors(AZStd::move(buildTargetDescriptors), AZStd::move(testTargetmetaMap));
         auto&& [productionTargets, testTargets] = buildTargets;
-        return AZStd::make_unique<TestImpact::DynamicDependencyMap>(AZStd::move(productionTargets), AZStd::move(testTargets));
+        return AZStd::make_unique<DynamicDependencyMap>(AZStd::move(productionTargets), AZStd::move(testTargets));
     }
 
     AZStd::unordered_set<const TestTarget*> ConstructTestTargetExcludeList(
@@ -67,7 +67,7 @@ namespace TestImpact
         return testTargetExcludeList;
     }
 
-    AZStd::vector<AZStd::string> ExtractTestTargetNames(const AZStd::vector<const TestTarget*> testTargets)
+    AZStd::vector<AZStd::string> ExtractTestTargetNames(const AZStd::vector<const TestTarget*>& testTargets)
     {
         AZStd::vector<AZStd::string> testNames;
         AZStd::transform(testTargets.begin(), testTargets.end(), AZStd::back_inserter(testNames), [](const TestTarget* testTarget)

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.cpp
@@ -23,13 +23,13 @@ namespace TestImpact
         return TestTargetMetaMapFactory(masterTestListData, suiteFilter);
     }
 
-    AZStd::vector<TestImpact::BuildTargetDescriptor> ReadBuildTargetDescriptorFiles(const BuildTargetDescriptorConfig& buildTargetDescriptorConfig)
+    AZStd::vector<BuildTargetDescriptor> ReadBuildTargetDescriptorFiles(const BuildTargetDescriptorConfig& buildTargetDescriptorConfig)
     {
-        AZStd::vector<TestImpact::BuildTargetDescriptor> buildTargetDescriptors;
+        AZStd::vector<BuildTargetDescriptor> buildTargetDescriptors;
         for (const auto& buildTargetDescriptorFile : std::filesystem::directory_iterator(buildTargetDescriptorConfig.m_mappingDirectory.c_str()))
         {
             const auto buildTargetDescriptorContents = ReadFileContents<RuntimeException>(buildTargetDescriptorFile.path().string().c_str());
-            auto buildTargetDescriptor = TestImpact::BuildTargetDescriptorFactory(
+            auto buildTargetDescriptor = BuildTargetDescriptorFactory(
                 buildTargetDescriptorContents,
                 buildTargetDescriptorConfig.m_staticInclusionFilters,
                 buildTargetDescriptorConfig.m_inputInclusionFilters,
@@ -40,7 +40,7 @@ namespace TestImpact
         return buildTargetDescriptors;
     }
 
-    AZStd::unique_ptr<TestImpact::DynamicDependencyMap> ConstructDynamicDependencyMap(
+    AZStd::unique_ptr<DynamicDependencyMap> ConstructDynamicDependencyMap(
         SuiteType suiteFilter,
         const BuildTargetDescriptorConfig& buildTargetDescriptorConfig,
         const TestTargetMetaConfig& testTargetMetaConfig)

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.h
@@ -82,8 +82,11 @@ namespace TestImpact
         
         for (const auto& testJob : testJobs)
         {
+            // Test job start time relative to start time
             const auto relativeStartTime =
-                testJob.GetStartTime() + AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(testJob.GetStartTime() - startTime);
+                AZStd::chrono::high_resolution_clock::time_point() +
+                AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(testJob.GetStartTime() - startTime);
+
             Client::TestRun clientTestRun(
                 testJob.GetTestTarget()->GetName(), testJob.GetCommandString(), relativeStartTime, testJob.GetDuration(),
                 testJob.GetTestResult());

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.h
@@ -35,7 +35,7 @@ namespace TestImpact
         const AZStd::vector<AZStd::string>& excludedTestTargets);
 
     //! Extracts the name information from the specified test targets.
-    AZStd::vector<AZStd::string> ExtractTestTargetNames(const AZStd::vector<const TestTarget*> testTargets);
+    AZStd::vector<AZStd::string> ExtractTestTargetNames(const AZStd::vector<const TestTarget*>& testTargets);
 
     //! Generates a test run failure report from the specified test engine job information.
     //! @tparam TestJob The test engine job type.

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.h
@@ -9,7 +9,7 @@
 
 #include <TestImpactFramework/TestImpactConfiguration.h>
 #include <TestImpactFramework/TestImpactClientTestSelection.h>
-#include <TestImpactFramework/TestImpactClientFailureReport.h>
+#include <TestImpactFramework/TestImpactClientSequenceReport.h>
 
 #include <Artifact/Static/TestImpactTestTargetMeta.h>
 #include <Artifact/Static/TestImpactBuildTargetDescriptor.h>
@@ -24,7 +24,7 @@
 namespace TestImpact
 {
     //! Construct a dynamic dependency map from the build target descriptors and test target metas.
-    AZStd::unique_ptr<TestImpact::DynamicDependencyMap> ConstructDynamicDependencyMap(
+    AZStd::unique_ptr<DynamicDependencyMap> ConstructDynamicDependencyMap(
         SuiteType suiteFilter,
         const BuildTargetDescriptorConfig& buildTargetDescriptorConfig,
         const TestTargetMetaConfig& testTargetMetaConfig);
@@ -35,16 +35,17 @@ namespace TestImpact
         const AZStd::vector<AZStd::string>& excludedTestTargets);
 
     //! Extracts the name information from the specified test targets.
-    AZStd::vector<AZStd::string> ExtractTestTargetNames(const AZStd::vector<const TestTarget*> testTargets);    
+    AZStd::vector<AZStd::string> ExtractTestTargetNames(const AZStd::vector<const TestTarget*> testTargets);
 
     //! Generates a test run failure report from the specified test engine job information.
     //! @tparam TestJob The test engine job type.
     template<typename TestJob>
-    Client::TestRunFailure GenerateTestRunFailure(const TestJob& testJob)
+    AZStd::vector<Client::TestCaseFailure> GenerateTestCaseFailures(const TestJob& testJob)
     {
+        AZStd::vector<Client::TestCaseFailure> testCaseFailures;
+
         if (testJob.GetTestRun().has_value())
         {
-            AZStd::vector<Client::TestCaseFailure> testCaseFailures;
             for (const auto& testSuite : testJob.GetTestRun()->GetTestSuites())
             {
                 AZStd::vector<Client::TestFailure> testFailures;
@@ -55,57 +56,63 @@ namespace TestImpact
                         testFailures.push_back(Client::TestFailure(testCase.m_name, "No error message retrieved"));
                     }
                 }
-
+    
                 if (!testFailures.empty())
                 {
                     testCaseFailures.push_back(Client::TestCaseFailure(testSuite.m_name, AZStd::move(testFailures)));
                 }
             }
+        }
 
-            return Client::TestRunFailure(Client::TestRunFailure(testJob.GetTestTarget()->GetName(), AZStd::move(testCaseFailures)));
-        }
-        else
-        {
-            return Client::TestRunFailure(testJob.GetTestTarget()->GetName(), { });
-        }
+        return testCaseFailures;
     }
 
-    //! Generates a sequence failure report from the specified list of test engine jobs.
-    //! @tparam TestJob The test engine job type.
     template<typename TestJob>
-    Client::SequenceFailure GenerateSequenceFailureReport(const AZStd::vector<TestJob>& testJobs)
+    Client::TestRunReport GenerateTestRunReport(
+        TestSequenceResult result,
+        AZStd::chrono::high_resolution_clock::time_point startTime,
+        AZStd::chrono::milliseconds duration,
+        const AZStd::vector<TestJob>& testJobs)
     {
-        AZStd::vector<Client::ExecutionFailure> executionFailures;
-        AZStd::vector<Client::TestRunFailure> testRunFailures;
-        AZStd::vector<Client::TargetFailure> timedOutTestRuns;
-        AZStd::vector<Client::TargetFailure> unexecutedTestRuns;
-
+        AZStd::vector<Client::TestRun> passingTests;
+        AZStd::vector<Client::TestRunWithTestFailures> failingTests;
+        AZStd::vector<Client::TestRun> executionFailureTests;
+        AZStd::vector<Client::TestRun> timedOutTests;
+        AZStd::vector<Client::TestRun> unexecutedTests;
+        
         for (const auto& testJob : testJobs)
         {
+            const auto relativeStartTime =
+                testJob.GetStartTime() + AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(testJob.GetStartTime() - startTime);
+            Client::TestRun clientTestRun(
+                testJob.GetTestTarget()->GetName(), testJob.GetCommandString(), relativeStartTime, testJob.GetDuration(),
+                testJob.GetTestResult());
+
             switch (testJob.GetTestResult())
             {
             case Client::TestRunResult::FailedToExecute:
             {
-                executionFailures.push_back(Client::ExecutionFailure(testJob.GetTestTarget()->GetName(), testJob.GetCommandString()));
+                executionFailureTests.push_back(clientTestRun);
                 break;
             }
             case Client::TestRunResult::NotRun:
             {
-                unexecutedTestRuns.push_back(testJob.GetTestTarget()->GetName());
+                unexecutedTests.push_back(clientTestRun);
                 break;
             }
             case Client::TestRunResult::Timeout:
             {
-                timedOutTestRuns.push_back(testJob.GetTestTarget()->GetName());
+                timedOutTests.push_back(clientTestRun);
                 break;
             }
             case Client::TestRunResult::AllTestsPass:
             {
+                passingTests.push_back(clientTestRun);
                 break;
             }
             case Client::TestRunResult::TestFailures:
             {
-                testRunFailures.push_back(GenerateTestRunFailure(testJob));
+                failingTests.emplace_back(AZStd::move(clientTestRun), GenerateTestCaseFailures(testJob));
                 break;
             }
             default:
@@ -115,11 +122,15 @@ namespace TestImpact
             }
             }
         }
-
-        return Client::SequenceFailure(
-            AZStd::move(executionFailures),
-            AZStd::move(testRunFailures),
-            AZStd::move(timedOutTestRuns),
-            AZStd::move(unexecutedTestRuns));
+        
+        return Client::TestRunReport(
+            result,
+            startTime,
+            duration,
+            AZStd::move(passingTests),
+            AZStd::move(failingTests),
+            AZStd::move(executionFailureTests),
+            AZStd::move(timedOutTests),
+            AZStd::move(unexecutedTests));
     }
-}
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Code/testimpactframework_runtime_files.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/testimpactframework_runtime_files.cmake
@@ -18,7 +18,7 @@ set(FILES
     Include/TestImpactFramework/TestImpactTestSequence.h
     Include/TestImpactFramework/TestImpactClientTestSelection.h
     Include/TestImpactFramework/TestImpactClientTestRun.h
-    Include/TestImpactFramework/TestImpactClientFailureReport.h
+    Include/TestImpactFramework/TestImpactClientSequenceReport.h
     Include/TestImpactFramework/TestImpactFileUtils.h
     Source/Artifact/TestImpactArtifactException.h
     Source/Artifact/Factory/TestImpactBuildTargetDescriptorFactory.cpp
@@ -122,7 +122,8 @@ set(FILES
     Source/TestImpactRuntimeUtils.h
     Source/TestImpactClientTestSelection.cpp
     Source/TestImpactClientTestRun.cpp
-    Source/TestImpactClientFailureReport.cpp
+    Source/TestImpactClientSequenceReport.cpp
     Source/TestImpactChangeListSerializer.cpp
+    Source/TestImpactChangeListSerializerInternal.h
     Source/TestImpactRepoPath.cpp
 )


### PR DESCRIPTION
This PR changes the TIAF runtime significantly to accommodate the new, richer approach to reporting the results of sequences in order to facilitate fine grain reporting of sequences to stakeholders. The most significant change is the philosophical pivot away from the sequence callbacks being used by the client to gather pertinent sequence metrics (with the sequence itself returning a simple pass/fail/timeout result) and instead the move towards callbacks being purely opt-in for real-time informational purposes with the sequence itself returning a rich report of all pertinent metrics.

Signed-off-by: John <jonawals@amazon.com>