### PR TITLE
Removed Empty Default Assets and nested asset duplicates

### DIFF
--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
@@ -205,6 +205,6 @@ namespace PrefabDependencyViewer
             }
         }
 
-        return AZStd::move(count);
+        return count;
     }
 } // namespace PrefabDependencyViewer

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
@@ -128,7 +128,7 @@ namespace PrefabDependencyViewer
 
             // Unassigned default assets would have an empty source and
             // therefore are an invalid asset.
-            if (assetInfo.m_relativePath != "")
+            if (!assetInfo.m_relativePath.empty())
             {
                 AZ::Data::AssetInfo productAssetInfo;
                 AZ::Data::AssetCatalogRequestBus::BroadcastResult(productAssetInfo,
@@ -181,13 +181,13 @@ namespace PrefabDependencyViewer
 
             // Unassigned default assets would have an empty source and
             // therefore are an invalid asset.
-            if (assetInfo.m_relativePath != "")
+            if (!assetInfo.m_relativePath.empty())
             {
                 AZ::Data::AssetInfo productAssetInfo;
                 AZ::Data::AssetCatalogRequestBus::BroadcastResult(
                     productAssetInfo, &AZ::Data::AssetCatalogRequestBus::Events::GetAssetInfoById, asset.GetId());
 
-                AZStd::string productAssetDesciption = productAssetInfo.m_relativePath == "" ? "" : ": " + productAssetInfo.m_relativePath;
+                AZStd::string productAssetDesciption = productAssetInfo.m_relativePath.empty() ? "" : ": " + productAssetInfo.m_relativePath;
 
                 AZStd::string assetDescription = assetInfo.m_relativePath + productAssetDesciption;
 

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
@@ -112,7 +112,8 @@ namespace PrefabDependencyViewer
         }
     }
 
-    /* static */ void PrefabDependencyTree::AddAssetNodeToPrefab(const PrefabDom& prefabDom, NodePtr node, AssetDescriptionCountMap& count)
+    /* static */ void PrefabDependencyTree::AddAssetNodeToPrefab(const PrefabDom& prefabDom, NodePtr node,
+                                                        AssetDescriptionCountMap& assetDescriptionCountMap)
     {
         AssetList assetList = GetAssets(prefabDom);
         for (const auto& asset : assetList)
@@ -140,10 +141,10 @@ namespace PrefabDependencyViewer
 
                 // If all the children claimed the asset, then the asset description count should
                 // go to 0 which implies that the current asset is not a node dependency.
-                if (count[assetDescription] > 0)
+                if (assetDescriptionCountMap[assetDescription] > 0)
                 {
                     node->AddChild(Utils::Node::CreateAssetNode(assetInfo.m_relativePath/* assetDescription */));
-                    --count[assetDescription];
+                    --assetDescriptionCountMap[assetDescription];
                 }
             }
         }

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
@@ -22,7 +22,7 @@ namespace PrefabDependencyViewer
             PrefabDom& rootPrefabDom = prefabSystemComponentInterface->FindTemplateDom(tid);
 
             AssetList allNestedAssets = GetAssets(rootPrefabDom);
-            AssetDescriptionCountMap count = GetAssetsDescriptionCount(allNestedAssets);
+            AssetDescriptionCountMap count = GetAssetsDescriptionCountMap(allNestedAssets);
 
             NodePtrOutcome outcome = GenerateTreeAndSetRootRecursive(tid, prefabSystemComponentInterface, count);
             if (outcome.IsSuccess())
@@ -89,10 +89,10 @@ namespace PrefabDependencyViewer
                         }
 
                         // Get the TemplateId for the nested Instance.
-                        TemplateId childtid = prefabSystemComponentInterface->GetTemplateIdFromFilePath(sourceFileName);
+                        TemplateId childTemplateId = prefabSystemComponentInterface->GetTemplateIdFromFilePath(sourceFileName);
 
                         // Recurse on the nested instance.
-                        NodePtrOutcome outcome = GenerateTreeAndSetRootRecursive(childtid, prefabSystemComponentInterface, count);
+                        NodePtrOutcome outcome = GenerateTreeAndSetRootRecursive(childTemplateId, prefabSystemComponentInterface, count);
                         if (outcome.IsSuccess())
                         {
                             parent->AddChild(outcome.GetValue());
@@ -166,7 +166,7 @@ namespace PrefabDependencyViewer
         return referencedAssets;
     }
 
-    /* static */ AssetDescriptionCountMap PrefabDependencyTree::GetAssetsDescriptionCount(AssetList allNestedAssets)
+    /* static */ AssetDescriptionCountMap PrefabDependencyTree::GetAssetsDescriptionCountMap(AssetList allNestedAssets)
     {
         AssetDescriptionCountMap count;
 

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
@@ -141,10 +141,11 @@ namespace PrefabDependencyViewer
 
                 // If all the children claimed the asset, then the asset description count should
                 // go to 0 which implies that the current asset is not a node dependency.
-                if (assetDescriptionCountMap[assetDescription] > 0)
+                auto it = assetDescriptionCountMap.find(assetDescription);
+                if (it != assetDescriptionCountMap.end() && it->second > 0)
                 {
                     node->AddChild(Utils::Node::CreateAssetNode(assetInfo.m_relativePath/* assetDescription */));
-                    --assetDescriptionCountMap[assetDescription];
+                    it->second -= 1;
                 }
             }
         }

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
@@ -193,12 +193,14 @@ namespace PrefabDependencyViewer
 
                 // If all the children claimed the asset, then the asset description count should
                 // go to 0 which implies that the current asset is not a node dependency.
-                if (count.find(assetDescription) == count.end()) {
+                auto it = count.find(assetDescription);
+                if (it == count.end())
+                {
                     count[assetDescription] = 1;
                 }
                 else
                 {
-                    ++count[assetDescription];
+                    it->second += 1;
                 }
             }
         }

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
@@ -45,7 +45,9 @@ namespace PrefabDependencyViewer
             AssetDescriptionCountMap& count);
 
         static AssetDescriptionCountMap GetAssetsDescriptionCount(AssetList allNestedAssets);
-        static void AddAssetNodeToPrefab(const PrefabDom& prefabDom, NodePtr node, AssetDescriptionCountMap& count);
+        static void AddAssetNodeToPrefab(const PrefabDom& prefabDom, NodePtr node,
+                                AssetDescriptionCountMap& assetDescriptionCountMap);
+
         static AssetList GetAssets(const PrefabDom& prefabDom);
     };
 }

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
@@ -44,7 +44,7 @@ namespace PrefabDependencyViewer
             PrefabSystemComponentInterface* prefabSystemComponentInterface,
             AssetDescriptionCountMap& count);
 
-        static AssetDescriptionCountMap GetAssetsDescriptionCount(AssetList allNestedAssets);
+        static AssetDescriptionCountMap GetAssetsDescriptionCountMap(AssetList allNestedAssets);
         static void AddAssetNodeToPrefab(const PrefabDom& prefabDom, NodePtr node,
                                 AssetDescriptionCountMap& assetDescriptionCountMap);
 

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
@@ -24,18 +24,28 @@ namespace PrefabDependencyViewer
     using TemplateId                     = AzToolsFramework::Prefab::TemplateId;
     using PrefabDom                      = AzToolsFramework::Prefab::PrefabDom;
     using PrefabSystemComponentInterface = AzToolsFramework::Prefab::PrefabSystemComponentInterface;
-    using Outcome                        = AZ::Outcome<PrefabDependencyTree, AZStd::string_view>;
+    
     using AssetList                      = AZStd::vector<AZ::Data::Asset<AZ::Data::AssetData>>;
+    using AssetDescriptionCountMap       = AZStd::unordered_map<AZStd::string, int>;
     using LoadInstanceFlags              = AzToolsFramework::Prefab::PrefabDomUtils::LoadInstanceFlags;
+
     using NodePtr                        = AZStd::shared_ptr<Utils::Node>;
+    using TreeOutcome                    = AZ::Outcome<PrefabDependencyTree, AZStd::string_view>;
+    using NodePtrOutcome                 = AZ::Outcome<NodePtr, AZStd::string_view>;
 
     class PrefabDependencyTree : public Utils::DirectedTree
     {
     public:
-        static Outcome GenerateTreeAndSetRoot(TemplateId tid,
-            PrefabSystemComponentInterface* s_prefabSystemComponentInterface);
+        static TreeOutcome GenerateTreeAndSetRoot(TemplateId tid, PrefabSystemComponentInterface* s_prefabSystemComponentInterface);
 
-        static void AddAssetNodeToPrefab(const PrefabDom& prefabDom, NodePtr node);
+    private:
+        static NodePtrOutcome GenerateTreeAndSetRootRecursive(
+            TemplateId templateId,
+            PrefabSystemComponentInterface* prefabSystemComponentInterface,
+            AssetDescriptionCountMap& count);
+
+        static AssetDescriptionCountMap GetAssetsDescriptionCount(AssetList allNestedAssets);
+        static void AddAssetNodeToPrefab(const PrefabDom& prefabDom, NodePtr node, AssetDescriptionCountMap& count);
         static AssetList GetAssets(const PrefabDom& prefabDom);
     };
 }


### PR DESCRIPTION
Earlier unassigned default asset would return an Empty Asset. => There is no default asset to begin with. Therefore, removed the empty asset Node.

Also, assets from a Child Prefab showed up in the parent Prefab even though the parent prefab didn't depend on those assets directly. Removed these asset duplicates from the parent.

Before
![dependencyViewerCandidate1](https://user-images.githubusercontent.com/85369837/128542122-72e59f12-f0e9-41fb-8c09-9d178e478aa1.PNG)

After
![removedDuplicatedNestedAssets](https://user-images.githubusercontent.com/85369837/128542146-8b5342f5-4ce6-4877-8e52-06b8f2e725c7.PNG)