### PR TITLE
Prefab dependency viewer add product count to the asset Node and remove the Input and Output Slot names.

### DIFF
--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/MainWindow.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/MainWindow.cpp
@@ -123,11 +123,11 @@ namespace PrefabDependencyViewer
             nodeUiId, &GraphCanvas::SlotLayoutRequests::ConfigureSlotGroup, GraphCanvas::SlotGroups::DataGroup,
             GraphCanvas::SlotGroupConfiguration(1));
 
-        GraphCanvas::SlotId inputSlotId = CreateDataSlot(nodeUiId, "Input", "Parent",
+        GraphCanvas::SlotId inputSlotId = CreateDataSlot(nodeUiId, "", "Parent",
                                                         azrtti_typeid<AZ::EntityId>(),
                                                         GraphCanvas::SlotGroups::DataGroup, true);
 
-        GraphCanvas::SlotId outputSlotId = CreateDataSlot(nodeUiId, "Output", "Child",
+        GraphCanvas::SlotId outputSlotId = CreateDataSlot(nodeUiId, "", "Child",
                                                         azrtti_typeid<AZ::EntityId>(),
                                                         GraphCanvas::SlotGroups::DataGroup, false);
 


### PR DESCRIPTION
Before
![removedDuplicatedNestedAssets](https://user-images.githubusercontent.com/85369837/128574304-fcefcaa5-a2dd-4cd8-a4f3-ddbe2d3eb13b.PNG)

After
![withoutInputAndOutput](https://user-images.githubusercontent.com/85369837/128575069-d5422296-b74d-439f-b909-6f99aaf3f9aa.PNG)
