### PR TITLE
Fix logging and paths in TIAF scripts

### DIFF
--- a/scripts/build/TestImpactAnalysis/git_utils.py
+++ b/scripts/build/TestImpactAnalysis/git_utils.py
@@ -21,7 +21,7 @@ class Repo:
         branch = self._repo.active_branch
         return branch.name
 
-    def create_diff_file(self, src_commit_hash: str, dst_commit_hash: str, output_path: str):
+    def create_diff_file(self, src_commit_hash: str, dst_commit_hash: str, output_path: pathlib.Path):
         """
         Attempts to create a diff from the src and dst commits and write to the specified output file.
 
@@ -32,15 +32,14 @@ class Repo:
 
         try:
             # Remove the existing file (if any) and create the 
-            if pathlib.Path.is_file(output_path):
-                pathlib.Path.unlink(output_path)
-            pathlib.Path.mkdir(pathlib.PurePath.parent(output_path), exist_ok=True)
+            output_path.unlink(missing_ok=True)
+            output_path.parent.mkdir(exist_ok=True)
         except EnvironmentError as e:
             raise RuntimeError(f"Could not create path for output file '{output_path}'")
 
         # git diff will only write to the output file if both commit hashes are valid
         subprocess.run(["git", "diff", "--name-status", f"--output={output_path}", src_commit_hash, dst_commit_hash])
-        if not pathlib.Path.is_file(output_path):
+        if not output_path.is_file():
             raise RuntimeError(f"Source commit '{src_commit_hash}' and/or destination commit '{dst_commit_hash}' are invalid")
 
     def is_descendent(self, src_commit_hash: str, dst_commit_hash: str):

--- a/scripts/build/TestImpactAnalysis/git_utils.py
+++ b/scripts/build/TestImpactAnalysis/git_utils.py
@@ -31,7 +31,7 @@ class Repo:
         """
 
         try:
-            # Remove the existing file (if any) and create the 
+            # Remove the existing file (if any) and create the parent directory
             output_path.unlink(missing_ok=True)
             output_path.parent.mkdir(exist_ok=True)
         except EnvironmentError as e:

--- a/scripts/build/TestImpactAnalysis/mars_utils.py
+++ b/scripts/build/TestImpactAnalysis/mars_utils.py
@@ -9,10 +9,9 @@
 import datetime
 import json
 import socket
-import logging
+from tiaf_logger import get_logger
 
-logger = logging.getLogger()
-logging.basicConfig()
+logger = get_logger(__file__)
 
 MARS_JOB_KEY = "job"
 SRC_COMMIT_KEY = "src_commit"

--- a/scripts/build/TestImpactAnalysis/tiaf.py
+++ b/scripts/build/TestImpactAnalysis/tiaf.py
@@ -10,14 +10,13 @@ import json
 import subprocess
 import re
 import uuid
-import logging
 import pathlib
 from git_utils import Repo
 from tiaf_persistent_storage_local import PersistentStorageLocal
 from tiaf_persistent_storage_s3 import PersistentStorageS3
+from tiaf_logger import get_logger
 
-logger = logging.getLogger()
-logging.basicConfig()
+logger = get_logger(__file__)
 
 class TestImpact:
     def __init__(self, config_file: str):
@@ -46,8 +45,8 @@ class TestImpact:
 
                 # TIAF
                 self._use_test_impact_analysis = self._config["jenkins"]["use_test_impact_analysis"]
-                self._tiaf_bin = self._config["repo"]["tiaf_bin"]
-                if self._use_test_impact_analysis and not pathlib.Path.is_file(self._tiaf_bin):
+                self._tiaf_bin = pathlib.Path(self._config["repo"]["tiaf_bin"])
+                if self._use_test_impact_analysis and not self._tiaf_bin.is_file():
                     logger.warning(f"Could not find TIAF binary at location {self._tiaf_bin}, TIAF will be turned off.")
                     self._use_test_impact_analysis = False
 
@@ -78,7 +77,7 @@ class TestImpact:
                 logger.info(f"Source commit '{self._src_commit}' and destination commit '{self._dst_commit}' are not related.")
                 return
             self._commit_distance = self._repo.commit_distance(self._src_commit, self._dst_commit)
-            diff_path = pathlib.PurePath(self._temp_workspace).joinpath(f"changelist.{instance_id}.diff")
+            diff_path = pathlib.Path(pathlib.PurePath(self._temp_workspace).joinpath(f"changelist.{instance_id}.diff"))
             try:
                 self._repo.create_diff_file(self._src_commit, self._dst_commit, diff_path)
             except RuntimeError as e:
@@ -287,8 +286,8 @@ class TestImpact:
             logger.info(f"Global sequence timeout is set to {test_timeout} seconds.")
 
         # Run sequence
-        logger.info("Args: ", end='')
-        logger.info(*args)
+        unpacked_args = " ".join(args)
+        logger.info(f"Args: {unpacked_args}")
         runtime_result = subprocess.run([self._tiaf_bin] + args)
         report = None
 

--- a/scripts/build/TestImpactAnalysis/tiaf_driver.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_driver.py
@@ -11,14 +11,13 @@ import mars_utils
 import sys
 import pathlib
 from tiaf import TestImpact
-import logging
+from tiaf_logger import get_logger
 
-logger = logging.getLogger()
-logging.basicConfig()
+logger = get_logger(__file__)
 
 def parse_args():
     def valid_file_path(value):
-        if pathlib.Path.is_file(value):
+        if pathlib.Path(value).is_file():
             return value
         else:
             raise FileNotFoundError(value)

--- a/scripts/build/TestImpactAnalysis/tiaf_logger.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_logger.py
@@ -1,0 +1,20 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+import logging
+import sys
+
+def get_logger(name: str):
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('[%(asctime)s][TIAF][%(levelname)s] %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    return logger

--- a/scripts/build/TestImpactAnalysis/tiaf_persistent_storage.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_persistent_storage.py
@@ -8,11 +8,10 @@
 
 import json
 import pathlib
-import logging
 from abc import ABC, abstractmethod
+from tiaf_logger import get_logger
 
-logger = logging.getLogger()
-logging.basicConfig()
+logger = get_logger(__file__)
 
 # Abstraction for the persistent storage required by TIAF to store and retrieve the branch coverage data and other meta-data
 class PersistentStorage(ABC):
@@ -27,20 +26,16 @@ class PersistentStorage(ABC):
         # Work on the assumption that there is no historic meta-data (a valid state to be in, should none exist)
         self._last_commit_hash = None
         self._has_historic_data = False
-        self._unpacked_coverage_data_file = None
 
         try:
             # The runtime expects the coverage data to be in the location specified in the config file (unless overridden with 
             # the --datafile command line argument, which the TIAF scripts do not do)
-            self._active_workspace = config["workspace"]["active"]["root"]
+            self._active_workspace = pathlib.Path(config["workspace"]["active"]["root"])
             unpacked_coverage_data_file = config["workspace"]["active"]["relative_paths"]["test_impact_data_files"][suite]
         except KeyError as e:
             raise SystemError(f"The config does not contain the key {str(e)}.")
 
-        self._unpacked_coverage_data_file = pathlib.PurePath(self._active_workspace).joinpath(unpacked_coverage_data_file)
-        if not pathlib.Path.is_file(self._unpacked_coverage_data_file):
-            logging.error(f"The coverage data file '{self._unpacked_coverage_data_file}' is not a valid file path.")
-            self._unpacked_coverage_data_file = None
+        self._unpacked_coverage_data_file = self._active_workspace.joinpath(unpacked_coverage_data_file)
         
     def _unpack_historic_data(self, historic_data_json: str):
         """
@@ -50,9 +45,6 @@ class PersistentStorage(ABC):
         """
         
         self._has_historic_data = False
-        if self._unpacked_coverage_data_file is None:
-            logger.error("Cannot unpack historic data, the unpacked coverage data file path is invalid")
-            return
 
         try:
             historic_data = json.loads(historic_data_json)
@@ -60,7 +52,7 @@ class PersistentStorage(ABC):
 
             # Create the active workspace directory where the coverage data file will be placed and unpack the coverage data so 
             # it is accessible by the runtime
-            pathlib.Path.mkdir(self._active_workspace, exist_ok=True)
+            self._active_workspace.mkdir(exist_ok=True)
             with open(self._unpacked_coverage_data_file, "w", newline='\n') as coverage_data:
                 coverage_data.write(historic_data["coverage_data"])
 
@@ -80,13 +72,9 @@ class PersistentStorage(ABC):
         @return:                 The packed historic data in JSON format.
         """
 
-        if self._unpacked_coverage_data_file is None:
-            logger.error("Cannot pack historic data, the unpacked coverage data file path is invalid")
-            return
-
         try:
             # Attempt to read the existing coverage data
-            if pathlib.Path.is_file(self._unpacked_coverage_data_file):
+            if self._unpacked_coverage_data_file.is_file():
                 with open(self._unpacked_coverage_data_file, "r") as coverage_data:
                     historic_data = {"last_commit_hash": last_commit_hash, "coverage_data": coverage_data.read()}
                     return json.dumps(historic_data)

--- a/scripts/build/TestImpactAnalysis/tiaf_persistent_storage_s3.py
+++ b/scripts/build/TestImpactAnalysis/tiaf_persistent_storage_s3.py
@@ -12,9 +12,9 @@ import zlib
 import logging
 from io import BytesIO
 from tiaf_persistent_storage import PersistentStorage
+from tiaf_logger import get_logger
 
-logger = logging.getLogger()
-logging.basicConfig()
+logger = get_logger(__file__)
 
 # Implementation of s3 bucket persistent storage
 class PersistentStorageS3(PersistentStorage):


### PR DESCRIPTION
The changes in PR 176 [here](https://github.com/aws-lumberyard-dev/o3de/pull/176) require some additional changes to instantiate and configure the logger across the scripts as well as the way `PathLib` was used.