### PR TITLE
Implement sequence reporting for the console frontend

### DIFF
--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactCommandLineOptions.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactCommandLineOptions.cpp
@@ -297,17 +297,17 @@ namespace TestImpact
         m_suiteFilter = ParseSuiteFilter(cmd);
     }
 
-    bool CommandLineOptions::HasDataFile() const
+    bool CommandLineOptions::HasDataFilePath() const
     {
         return m_dataFile.has_value();
     }
  
-    bool CommandLineOptions::HasChangeListFile() const
+    bool CommandLineOptions::HasChangeListFilePath() const
     {
         return m_changeListFile.has_value();
     }
 
-    bool CommandLineOptions::HasSequenceReportFile() const
+    bool CommandLineOptions::HasSequenceReportFilePath() const
     {
         return m_sequenceReportFile.has_value();
     }
@@ -317,22 +317,22 @@ namespace TestImpact
         return m_safeMode;
     }
 
-    const AZStd::optional<RepoPath>& CommandLineOptions::GetDataFile() const
+    const AZStd::optional<RepoPath>& CommandLineOptions::GetDataFilePath() const
     {
         return m_dataFile;
     }
 
-    const AZStd::optional<RepoPath>& CommandLineOptions::GetChangeListFile() const
+    const AZStd::optional<RepoPath>& CommandLineOptions::GetChangeListFilePath() const
     {
         return m_changeListFile;
     }
 
-    const AZStd::optional<RepoPath>& CommandLineOptions::GetSequenceReportFile() const
+    const AZStd::optional<RepoPath>& CommandLineOptions::GetSequenceReportFilePath() const
     {
         return m_sequenceReportFile;
     }
 
-    const RepoPath& CommandLineOptions::GetConfigurationFile() const
+    const RepoPath& CommandLineOptions::GetConfigurationFilePath() const
     {
         return m_configurationFile;
     }

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactCommandLineOptions.h
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactCommandLineOptions.h
@@ -36,20 +36,29 @@ namespace TestImpact
         CommandLineOptions(int argc, char** argv);
         static AZStd::string GetCommandLineUsageString();
 
+        //! Returns true if a test impact data file path has been supplied, otherwise false.
+        bool HasDataFile() const;
+
         //! Returns true if a change list file path has been supplied, otherwise false.
         bool HasChangeListFile() const;
+
+        //! Returns true if a sequence report file path has been supplied, otherwise false.
+        bool HasSequenceReportFile() const;
 
         //! Returns true if the safe mode option has been enabled, otherwise false.
         bool HasSafeMode() const;
 
-        //! Returns true if the output change list option has been enabled, otherwise false.
-        bool HasOutputChangeList() const;
-
         //! Returns the path to the runtime configuration file.
         const RepoPath& GetConfigurationFile() const;
 
+        //! Returns the path to the data file (if any).
+        const AZStd::optional<RepoPath>& GetDataFile() const;
+
         //! Returns the path to the change list file (if any).
         const AZStd::optional<RepoPath>& GetChangeListFile() const;
+
+        //! Returns the path to the sequence report file (if any).
+        const AZStd::optional<RepoPath>& GetSequenceReportFile() const;
 
         //! Returns the test sequence type to run.
         TestSequenceType GetTestSequenceType() const;
@@ -89,8 +98,9 @@ namespace TestImpact
 
     private:
         RepoPath m_configurationFile;
+        AZStd::optional<RepoPath> m_dataFile;
         AZStd::optional<RepoPath> m_changeListFile;
-        bool m_outputChangeList = false;
+        AZStd::optional<RepoPath> m_sequenceReportFile;
         TestSequenceType m_testSequenceType;
         Policy::TestPrioritization m_testPrioritizationPolicy = Policy::TestPrioritization::None;
         Policy::ExecutionFailure m_executionFailurePolicy = Policy::ExecutionFailure::Continue;

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactCommandLineOptions.h
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactCommandLineOptions.h
@@ -37,28 +37,28 @@ namespace TestImpact
         static AZStd::string GetCommandLineUsageString();
 
         //! Returns true if a test impact data file path has been supplied, otherwise false.
-        bool HasDataFile() const;
+        bool HasDataFilePath() const;
 
         //! Returns true if a change list file path has been supplied, otherwise false.
-        bool HasChangeListFile() const;
+        bool HasChangeListFilePath() const;
 
         //! Returns true if a sequence report file path has been supplied, otherwise false.
-        bool HasSequenceReportFile() const;
+        bool HasSequenceReportFilePath() const;
 
         //! Returns true if the safe mode option has been enabled, otherwise false.
         bool HasSafeMode() const;
 
         //! Returns the path to the runtime configuration file.
-        const RepoPath& GetConfigurationFile() const;
+        const RepoPath& GetConfigurationFilePath() const;
 
         //! Returns the path to the data file (if any).
-        const AZStd::optional<RepoPath>& GetDataFile() const;
+        const AZStd::optional<RepoPath>& GetDataFilePath() const;
 
         //! Returns the path to the change list file (if any).
-        const AZStd::optional<RepoPath>& GetChangeListFile() const;
+        const AZStd::optional<RepoPath>& GetChangeListFilePath() const;
 
         //! Returns the path to the sequence report file (if any).
-        const AZStd::optional<RepoPath>& GetSequenceReportFile() const;
+        const AZStd::optional<RepoPath>& GetSequenceReportFilePath() const;
 
         //! Returns the test sequence type to run.
         TestSequenceType GetTestSequenceType() const;

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleMain.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleMain.cpp
@@ -56,11 +56,11 @@ namespace TestImpact
         template<typename SequenceReportType>
         ReturnCode ConsumeSequenceReportAndGetReturnCode(const SequenceReportType& sequenceReport, const CommandLineOptions& options)
         {
-            if (options.HasSequenceReportFile())
+            if (options.HasSequenceReportFilePath())
             {
-                std::cout << "Exporting sequence report '" << options.GetSequenceReportFile().value().c_str() << "'" << std::endl;
+                std::cout << "Exporting sequence report '" << options.GetSequenceReportFilePath().value().c_str() << "'" << std::endl;
                 const auto sequenceReportJson = SerializeSequenceReport(sequenceReport);
-                WriteFileContents<SequenceReportException>(sequenceReportJson, options.GetSequenceReportFile().value());
+                WriteFileContents<SequenceReportException>(sequenceReportJson, options.GetSequenceReportFilePath().value());
             }
 
             return GetReturnCodeForTestSequenceResult(sequenceReport.GetResult());
@@ -152,9 +152,9 @@ namespace TestImpact
                 AZStd::optional<ChangeList> changeList;
 
                 // If we have a change list, check to see whether or not the client has requested the printing of said change list
-                if (options.HasChangeListFile())
+                if (options.HasChangeListFilePath())
                 {
-                    changeList = DeserializeChangeList(ReadFileContents<CommandLineOptionsException>(*options.GetChangeListFile()));
+                    changeList = DeserializeChangeList(ReadFileContents<CommandLineOptionsException>(*options.GetChangeListFilePath()));
                 }
 
                 // As of now, there are no non-test operations but leave this door open for the future
@@ -166,8 +166,8 @@ namespace TestImpact
                 std::cout << "Constructing in-memory model of source tree and test coverage for test suite ";
                 std::cout << SuiteTypeAsString(options.GetSuiteFilter()).c_str() << ", this may take a moment...\n";
                 Runtime runtime(
-                    RuntimeConfigurationFactory(ReadFileContents<CommandLineOptionsException>(options.GetConfigurationFile())),
-                    options.GetDataFile(),
+                    RuntimeConfigurationFactory(ReadFileContents<CommandLineOptionsException>(options.GetConfigurationFilePath())),
+                    options.GetDataFilePath(),
                     options.GetSuiteFilter(),
                     options.GetExecutionFailurePolicy(),
                     options.GetFailedTestCoveragePolicy(),

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleMain.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleMain.cpp
@@ -9,14 +9,16 @@
 #include <TestImpactFramework/TestImpactException.h>
 #include <TestImpactFramework/TestImpactChangeListException.h>
 #include <TestImpactFramework/TestImpactConfigurationException.h>
+#include <TestImpactFramework/TestImpactSequenceReportException.h>
 #include <TestImpactFramework/TestImpactRuntimeException.h>
 #include <TestImpactFramework/TestImpactConsoleMain.h>
 #include <TestImpactFramework/TestImpactChangeListSerializer.h>
 #include <TestImpactFramework/TestImpactChangeList.h>
 #include <TestImpactFramework/TestImpactRuntime.h>
-#include <TestImpactFramework/TestImpactFileUtils.h>
+#include <TestImpactFramework/TestImpactUtils.h>
 #include <TestImpactFramework/TestImpactClientTestSelection.h>
 #include <TestImpactFramework/TestImpactRuntime.h>
+#include <TestImpactFramework/TestImpactClientSequenceReportSerializer.h>
 
 #include <TestImpactConsoleTestSequenceEventHandler.h>
 #include <TestImpactCommandLineOptions.h>
@@ -33,31 +35,6 @@ namespace TestImpact
 {
     namespace Console
     {
-        //! Generates a string to be used for printing to the console for the specified change list.
-        AZStd::string GenerateChangeListString(const ChangeList& changeList)
-        {
-            AZStd::string output;
-
-            const auto& outputFiles = [&output](const AZStd::vector<RepoPath>& files)
-            {
-                for (const auto& file : files)
-                {
-                    output += AZStd::string::format("\t%s\n", file.c_str());
-                }
-            };
-
-            output += AZStd::string::format("Created files (%u):\n", changeList.m_createdFiles.size());
-            outputFiles(changeList.m_createdFiles);
-
-            output += AZStd::string::format("Updated files (%u):\n", changeList.m_updatedFiles.size());
-            outputFiles(changeList.m_updatedFiles);
-
-            output += AZStd::string::format("Deleted files (%u):\n", changeList.m_deletedFiles.size());
-            outputFiles(changeList.m_deletedFiles);
-
-            return output;
-        }
-
         //! Gets the appropriate console return code for the specified test sequence result.
         ReturnCode GetReturnCodeForTestSequenceResult(TestSequenceResult result)
         {
@@ -75,6 +52,20 @@ namespace TestImpact
             }
         }
 
+        //! Wrapper around sequence reports to optionally serialize them and transform the result into a return code.
+        template<typename SequenceReportType>
+        ReturnCode ConsumeSequenceReportAndGetReturnCode(const SequenceReportType& sequenceReport, const CommandLineOptions& options)
+        {
+            if (options.HasSequenceReportFile())
+            {
+                std::cout << "Exporting sequence report '" << options.GetSequenceReportFile().value().c_str() << "'" << std::endl;
+                const auto sequenceReportJson = SerializeSequenceReport(sequenceReport);
+                WriteFileContents<SequenceReportException>(sequenceReportJson, options.GetSequenceReportFile().value());
+            }
+
+            return GetReturnCodeForTestSequenceResult(sequenceReport.GetResult());
+        }
+
         //! Wrapper around impact analysis sequences to handle the case where the safe mode option is active.
         ReturnCode WrappedImpactAnalysisTestSequence(
             const CommandLineOptions& options,
@@ -88,35 +79,34 @@ namespace TestImpact
                 CommandLineOptionsException,
                 "Expected a change list for impact analysis but none was provided");
 
-            TestSequenceResult result = TestSequenceResult::Failure;
             if (options.HasSafeMode())
             {
                 if (options.GetTestSequenceType() == TestSequenceType::ImpactAnalysis)
                 {
-                    auto safeImpactAnalysisSequenceReport = runtime.SafeImpactAnalysisTestSequence(
-                        changeList.value(),
-                        options.GetTestPrioritizationPolicy(),
-                        options.GetTestTargetTimeout(),
-                        options.GetGlobalTimeout(),
-                        SafeImpactAnalysisTestSequenceStartCallback,
-                        SafeImpactAnalysisTestSequenceCompleteCallback,
-                        TestRunCompleteCallback);
-        
-                    result = safeImpactAnalysisSequenceReport.GetResult();
+                    return ConsumeSequenceReportAndGetReturnCode(
+                        runtime.SafeImpactAnalysisTestSequence(
+                            changeList.value(),
+                            options.GetTestPrioritizationPolicy(),
+                            options.GetTestTargetTimeout(),
+                            options.GetGlobalTimeout(),
+                            SafeImpactAnalysisTestSequenceStartCallback,
+                            SafeImpactAnalysisTestSequenceCompleteCallback,
+                            TestRunCompleteCallback),
+                        options);
                 }
                 else if (options.GetTestSequenceType() == TestSequenceType::ImpactAnalysisNoWrite)
                 {
                     // A no-write impact analysis sequence with safe mode enabled is functionally identical to a regular sequence type
                     // due to a) the selected tests being run without instrumentation and b) the discarded tests also being run without
                     // instrumentation
-                    auto sequenceReport = runtime.RegularTestSequence(
-                        options.GetTestTargetTimeout(),
-                        options.GetGlobalTimeout(),
-                        TestSequenceStartCallback,
-                        TestSequenceCompleteCallback,
-                        TestRunCompleteCallback);
-
-                    result = sequenceReport.GetResult();
+                    return ConsumeSequenceReportAndGetReturnCode(
+                        runtime.RegularTestSequence(
+                            options.GetTestTargetTimeout(),
+                            options.GetGlobalTimeout(),
+                            TestSequenceStartCallback,
+                            RegularTestSequenceCompleteCallback,
+                            TestRunCompleteCallback),
+                        options);
                 }
                 else
                 {
@@ -139,20 +129,18 @@ namespace TestImpact
                     throw(Exception("Unexpected sequence type"));
                 }
         
-                auto impactAnalysisSequenceReport = runtime.ImpactAnalysisTestSequence(
-                    changeList.value(),
-                    options.GetTestPrioritizationPolicy(),
-                    dynamicDependencyMapPolicy,
-                    options.GetTestTargetTimeout(),
-                    options.GetGlobalTimeout(),
-                    ImpactAnalysisTestSequenceStartCallback,
-                    ImpactAnalysisTestSequenceCompleteCallback,
-                    TestRunCompleteCallback);
-
-                result = impactAnalysisSequenceReport.GetResult();
+                return ConsumeSequenceReportAndGetReturnCode(
+                    runtime.ImpactAnalysisTestSequence(
+                        changeList.value(),
+                        options.GetTestPrioritizationPolicy(),
+                        dynamicDependencyMapPolicy,
+                        options.GetTestTargetTimeout(),
+                        options.GetGlobalTimeout(),
+                        ImpactAnalysisTestSequenceStartCallback,
+                        ImpactAnalysisTestSequenceCompleteCallback,
+                        TestRunCompleteCallback),
+                    options);
             }
-        
-            return GetReturnCodeForTestSequenceResult(result);
         };
 
         //! Entry point for the test impact analysis framework console front end application.
@@ -167,25 +155,19 @@ namespace TestImpact
                 if (options.HasChangeListFile())
                 {
                     changeList = DeserializeChangeList(ReadFileContents<CommandLineOptionsException>(*options.GetChangeListFile()));
-                    if (options.HasOutputChangeList())
-                    {
-                        std::cout << "Change List:\n";
-                        std::cout << GenerateChangeListString(*changeList).c_str();
-
-                        if (options.GetTestSequenceType() == TestSequenceType::None)
-                        {
-                            return ReturnCode::Success;
-                        }
-                    }
                 }
 
-                // As of now, there are no other non-test operations other than printing a change list so getting this far is considered an error
-                AZ_TestImpact_Eval(options.GetTestSequenceType() != TestSequenceType::None, CommandLineOptionsException, "No action specified");
+                // As of now, there are no non-test operations but leave this door open for the future
+                if (options.GetTestSequenceType() == TestSequenceType::None)
+                {
+                    return ReturnCode::Success;
+                }
 
                 std::cout << "Constructing in-memory model of source tree and test coverage for test suite ";
-                std::cout << GetSuiteTypeName(options.GetSuiteFilter()).c_str() << ", this may take a moment...\n";
+                std::cout << SuiteTypeAsString(options.GetSuiteFilter()).c_str() << ", this may take a moment...\n";
                 Runtime runtime(
                     RuntimeConfigurationFactory(ReadFileContents<CommandLineOptionsException>(options.GetConfigurationFile())),
+                    options.GetDataFile(),
                     options.GetSuiteFilter(),
                     options.GetExecutionFailurePolicy(),
                     options.GetFailedTestCoveragePolicy(),
@@ -208,25 +190,25 @@ namespace TestImpact
                 {
                 case TestSequenceType::Regular:
                 {
-                    const auto sequenceReport = runtime.RegularTestSequence(
-                        options.GetTestTargetTimeout(),
-                        options.GetGlobalTimeout(),
-                        TestSequenceStartCallback,
-                        TestSequenceCompleteCallback,
-                        TestRunCompleteCallback);
-
-                    return GetReturnCodeForTestSequenceResult(sequenceReport.GetResult());
+                    return ConsumeSequenceReportAndGetReturnCode(
+                        runtime.RegularTestSequence(
+                            options.GetTestTargetTimeout(),
+                            options.GetGlobalTimeout(),
+                            TestSequenceStartCallback,
+                            RegularTestSequenceCompleteCallback,
+                            TestRunCompleteCallback),
+                        options);
                 }
                 case TestSequenceType::Seed:
                 {
-                    const auto sequenceReport = runtime.SeededTestSequence(
-                        options.GetTestTargetTimeout(),
-                        options.GetGlobalTimeout(),
-                        TestSequenceStartCallback,
-                        TestSequenceCompleteCallback,
-                        TestRunCompleteCallback);
-
-                    return GetReturnCodeForTestSequenceResult(sequenceReport.GetResult());
+                    return ConsumeSequenceReportAndGetReturnCode(
+                        runtime.SeededTestSequence(
+                            options.GetTestTargetTimeout(),
+                            options.GetGlobalTimeout(),
+                            TestSequenceStartCallback,
+                            SeedTestSequenceCompleteCallback,
+                            TestRunCompleteCallback),
+                        options);
                 }
                 case TestSequenceType::ImpactAnalysisNoWrite:
                 case TestSequenceType::ImpactAnalysis:
@@ -241,14 +223,14 @@ namespace TestImpact
                     }
                     else
                     {
-                        const auto sequenceReport = runtime.SeededTestSequence(
-                            options.GetTestTargetTimeout(),
-                            options.GetGlobalTimeout(),
-                            TestSequenceStartCallback,
-                            TestSequenceCompleteCallback,
-                            TestRunCompleteCallback);
-
-                        return GetReturnCodeForTestSequenceResult(sequenceReport.GetResult());
+                        return ConsumeSequenceReportAndGetReturnCode(
+                            runtime.SeededTestSequence(
+                                options.GetTestTargetTimeout(),
+                                options.GetGlobalTimeout(),
+                                TestSequenceStartCallback,
+                                SeedTestSequenceCompleteCallback,
+                                TestRunCompleteCallback),
+                            options);
                     }
                 }
                 default:

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleTestSequenceEventHandler.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleTestSequenceEventHandler.cpp
@@ -6,8 +6,9 @@
  *
  */
 
-#include <TestImpactConsoleTestSequenceEventHandler.h>
+#include <TestImpactFramework/TestImpactUtils.h>
 
+#include <TestImpactConsoleTestSequenceEventHandler.h>
 #include <TestImpactConsoleUtils.h>
 
 #include <iostream>
@@ -20,7 +21,7 @@ namespace TestImpact
         {
             void TestSuiteFilter(SuiteType filter)
             {
-                std::cout << "Test suite filter: " << GetSuiteTypeName(filter).c_str() << "\n";
+                std::cout << "Test suite filter: " << SuiteTypeAsString(filter).c_str() << "\n";
             }
 
             void ImpactAnalysisTestSelection(size_t numSelectedTests, size_t numDiscardedTests, size_t numExcludedTests, size_t numDraftedTests)
@@ -36,69 +37,66 @@ namespace TestImpact
             {
                 std::cout << "Sequence completed in " << (testRunReport.GetDuration().count() / 1000.f) << "s with";
 
-                if (!testRunReport.GetExecutionFailureTests().empty() ||
-                    !testRunReport.GetFailingTests().empty() ||
-                    !testRunReport.GetTimedOutTests().empty() ||
-                    !testRunReport.GetUnexecutedTests().empty())
+                if (!testRunReport.GetExecutionFailureTestRuns().empty() ||
+                    !testRunReport.GetFailingTestRuns().empty() ||
+                    !testRunReport.GetTimedOutTestRuns().empty() ||
+                    !testRunReport.GetUnexecutedTestRuns().empty())
                 {
                     std::cout << ":\n";
                     std::cout << SetColor(Foreground::White, Background::Red).c_str()
-                        << testRunReport.GetFailingTests().size()
+                        << testRunReport.GetFailingTestRuns().size()
                         << ResetColor().c_str() << " test failures\n";
 
                     std::cout << SetColor(Foreground::White, Background::Red).c_str()
-                        << testRunReport.GetExecutionFailureTests().size()
+                        << testRunReport.GetExecutionFailureTestRuns().size()
                         << ResetColor().c_str() << " execution failures\n";
 
                     std::cout << SetColor(Foreground::White, Background::Red).c_str()
-                        << testRunReport.GetTimedOutTests().size()
+                        << testRunReport.GetTimedOutTestRuns().size()
                         << ResetColor().c_str() << " test timeouts\n";
 
                     std::cout << SetColor(Foreground::White, Background::Red).c_str()
-                        << testRunReport.GetUnexecutedTests().size()
+                        << testRunReport.GetUnexecutedTestRuns().size()
                         << ResetColor().c_str() << " unexecuted tests\n";
 
-                    if (!testRunReport.GetFailingTests().empty())
+                    if (!testRunReport.GetFailingTestRuns().empty())
                     {
                         std::cout << "\nTest failures:\n";
-                        for (const auto& testRunFailure : testRunReport.GetFailingTests())
+                        for (const auto& testRunFailure : testRunReport.GetFailingTestRuns())
                         {
-                            for (const auto& testCaseFailure : testRunFailure.GetTestCaseFailures())
+                            for (const auto& test : testRunFailure.GetTests())
                             {
-                                for (const auto& testFailure : testCaseFailure.GetTestFailures())
+                                if (test.GetResult() == Client::TestResult::Failed)
                                 {
-                                    std::cout << "  "
-                                        << testRunFailure.GetTargetName().c_str()
-                                        << "." << testCaseFailure.GetName().c_str()
-                                        << "." << testFailure.GetName().c_str() << "\n";
+                                    std::cout << "  " << test.GetName().c_str() << "\n";
                                 }
                             }
                         }
                     }
 
-                    if (!testRunReport.GetExecutionFailureTests().empty())
+                    if (!testRunReport.GetExecutionFailureTestRuns().empty())
                     {
                         std::cout << "\nExecution failures:\n";
-                        for (const auto& executionFailure : testRunReport.GetExecutionFailureTests())
+                        for (const auto& executionFailure : testRunReport.GetExecutionFailureTestRuns())
                         {
                             std::cout << "  " << executionFailure.GetTargetName().c_str() << "\n";
                             std::cout << executionFailure.GetCommandString().c_str() << "\n";
                         }
                     }
 
-                    if (!testRunReport.GetTimedOutTests().empty())
+                    if (!testRunReport.GetTimedOutTestRuns().empty())
                     {
                         std::cout << "\nTimed out tests:\n";
-                        for (const auto& testTimeout : testRunReport.GetTimedOutTests())
+                        for (const auto& testTimeout : testRunReport.GetTimedOutTestRuns())
                         {
                             std::cout << "  " << testTimeout.GetTargetName().c_str() << "\n";
                         }
                     }
 
-                    if (!testRunReport.GetUnexecutedTests().empty())
+                    if (!testRunReport.GetUnexecutedTestRuns().empty())
                     {
                         std::cout << "\nUnexecuted tests:\n";
-                        for (const auto& unexecutedTest : testRunReport.GetUnexecutedTests())
+                        for (const auto& unexecutedTest : testRunReport.GetUnexecutedTestRuns())
                         {
                             std::cout << "  " << unexecutedTest.GetTargetName().c_str() << "\n";
                         }
@@ -106,7 +104,7 @@ namespace TestImpact
                 }
                 else
                 {
-                    std::cout << SetColor(Foreground::White, Background::Green).c_str() << " \100% passes!\n" << ResetColor().c_str() << "\n";
+                    std::cout << " " << SetColor(Foreground::White, Background::Green).c_str() << "100% passes!\n" << ResetColor().c_str() << "\n";
                 }
             }
         }
@@ -149,11 +147,15 @@ namespace TestImpact
                 draftedTests.size());
         }
 
-        void TestSequenceCompleteCallback(const Client::SequenceReport& sequenceReport)
+        void RegularTestSequenceCompleteCallback(const Client::RegularSequenceReport& sequenceReport)
         {
-            
             Output::FailureReport(sequenceReport.GetSelectedTestRunReport());
             std::cout << "Updating and serializing the test impact analysis data, this may take a moment...\n";
+        }
+
+        void SeedTestSequenceCompleteCallback(const Client::SeedSequenceReport& sequenceReport)
+        {
+            Output::FailureReport(sequenceReport.GetSelectedTestRunReport());
         }
 
         void ImpactAnalysisTestSequenceCompleteCallback(const Client::ImpactAnalysisSequenceReport& sequenceReport)

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleTestSequenceEventHandler.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleTestSequenceEventHandler.cpp
@@ -183,7 +183,7 @@ namespace TestImpact
             std::cout << "Updating and serializing the test impact analysis data, this may take a moment...\n";
         }
 
-        void TestRunCompleteCallback(const Client::TestRun& testRun, size_t numTestRunsCompleted, size_t totalNumTestRuns)
+        void TestRunCompleteCallback(const Client::TestRunBase& testRun, size_t numTestRunsCompleted, size_t totalNumTestRuns)
         {
             const auto progress =
                 AZStd::string::format("(%03u/%03u)", numTestRunsCompleted, totalNumTestRuns, testRun.GetTargetName().c_str());

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleTestSequenceEventHandler.h
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleTestSequenceEventHandler.h
@@ -38,8 +38,11 @@ namespace TestImpact
             const Client::TestRunSelection& discardedTests,
             const AZStd::vector<AZStd::string>& draftedTests);
 
-        //! Handler for TestSequenceCompleteCallback event.
-        void TestSequenceCompleteCallback(const Client::SequenceReport& sequenceReport);
+        //! Handler for RegularTestSequenceCompleteCallback event.
+        void RegularTestSequenceCompleteCallback(const Client::RegularSequenceReport& sequenceReport);
+
+        //! Handler for SeedTestSequenceCompleteCallback event.
+        void SeedTestSequenceCompleteCallback(const Client::SeedSequenceReport& sequenceReport);
 
         //! Handler for ImpactAnalysisTestSequenceCompleteCallback event.
         void ImpactAnalysisTestSequenceCompleteCallback(const Client::ImpactAnalysisSequenceReport& sequenceReport);

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleTestSequenceEventHandler.h
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactConsoleTestSequenceEventHandler.h
@@ -51,6 +51,6 @@ namespace TestImpact
         void SafeImpactAnalysisTestSequenceCompleteCallback(const Client::SafeImpactAnalysisSequenceReport& sequenceReport);
 
         //! Handler for TestRunCompleteCallback event.
-        void TestRunCompleteCallback(const Client::TestRun& testRun, size_t numTestRunsCompleted, size_t totalNumTestRuns);
+        void TestRunCompleteCallback(const Client::TestRunBase& testRun, size_t numTestRunsCompleted, size_t totalNumTestRuns);
     } // namespace Console
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactRuntimeConfigurationFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Code/Source/TestImpactRuntimeConfigurationFactory.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <TestImpactFramework/TestImpactConfigurationException.h>
+#include <TestImpactFramework/TestImpactUtils.h>
 
 #include <TestImpactRuntimeConfigurationFactory.h>
 
@@ -144,11 +145,11 @@ namespace TestImpact
     {
         AZStd::array<RepoPath, 3> sparTIAFiles;
         sparTIAFiles[static_cast<size_t>(SuiteType::Main)] =
-            GetAbsPathFromRelPath(root, sparTIAFile[GetSuiteTypeName(SuiteType::Main).c_str()].GetString());
+            GetAbsPathFromRelPath(root, sparTIAFile[SuiteTypeAsString(SuiteType::Main).c_str()].GetString());
         sparTIAFiles[static_cast<size_t>(SuiteType::Periodic)] =
-            GetAbsPathFromRelPath(root, sparTIAFile[GetSuiteTypeName(SuiteType::Periodic).c_str()].GetString());
+            GetAbsPathFromRelPath(root, sparTIAFile[SuiteTypeAsString(SuiteType::Periodic).c_str()].GetString());
         sparTIAFiles[static_cast<size_t>(SuiteType::Sandbox)] =
-            GetAbsPathFromRelPath(root, sparTIAFile[GetSuiteTypeName(SuiteType::Sandbox).c_str()].GetString());
+            GetAbsPathFromRelPath(root, sparTIAFile[SuiteTypeAsString(SuiteType::Sandbox).c_str()].GetString());
 
         return sparTIAFiles;
     }


### PR DESCRIPTION
This PR implements the console-side of TIAF sequence reporting (the comprehensive reports on the results of test sequence runs) with the following key changes:

* Outputting the change list has been removed as change lists are handled job-side.
* The command line now accepts two additional optional arguments for providing a coverage data file (for local testing and reproduction) and a sequence report file (to serialize the sequence report generated by the runtime that the job consumes and transmits to MARS).
* The sequence event handler has been modified to handle the refactored client reports.