### PR TITLE
Implement sequence reporting for the runtime sources

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/Artifact/Factory/TestImpactTestTargetMetaMapFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/Artifact/Factory/TestImpactTestTargetMetaMapFactory.cpp
@@ -6,6 +6,8 @@
  *
  */
 
+#include <TestImpactFramework/TestImpactUtils.h>
+
 #include <Artifact/Factory/TestImpactTestTargetMetaMapFactory.h>
 #include <Artifact/TestImpactArtifactException.h>
 
@@ -67,7 +69,7 @@ namespace TestImpact
             {
                 // Check to see if this test target has the suite we're looking for
                 if (const auto suiteName = suite[Keys[SuiteKey]].GetString();
-                    strcmp(GetSuiteTypeName(suiteType).c_str(), suiteName) == 0)
+                    strcmp(SuiteTypeAsString(suiteType).c_str(), suiteName) == 0)
                 {
                     testMeta.m_suite = suiteName;
                     testMeta.m_customArgs = suite[Keys[CommandKey]].GetString();

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.cpp
@@ -156,8 +156,6 @@ namespace TestImpact
                 {
                     coveringTestTargetIt->second.erase(source);
                 }
-
-                
             }
 
             // 2.

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactDynamicDependencyMap.h
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <TestImpactFramework/TestImpactChangeList.h>
-#include <TestImpactFramework/TestImpactTestSequence.h>
+#include <TestImpactFramework/TestImpactPolicy.h>
 
 #include <Artifact/Static/TestImpactProductionTargetDescriptor.h>
 #include <Artifact/Static/TestImpactTestTargetDescriptor.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactTestSelectorAndPrioritizer.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/Dependency/TestImpactTestSelectorAndPrioritizer.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <TestImpactFramework/TestImpactTestSequence.h>
+#include <TestImpactFramework/TestImpactPolicy.h>
 
 #include <Artifact/Static/TestImpactDependencyGraphData.h>
 #include <Dependency/TestImpactChangeDependencyList.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/Enumeration/TestImpactTestEnumerator.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/Enumeration/TestImpactTestEnumerator.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <TestImpactFramework/TestImpactFileUtils.h>
+#include <TestImpactFramework/TestImpactUtils.h>
 
 #include <Artifact/Factory/TestImpactTestEnumerationSuiteFactory.h>
 #include <TestEngine/TestImpactTestEngineException.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/Run/TestImpactInstrumentedTestRunner.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/Run/TestImpactInstrumentedTestRunner.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <TestImpactFramework/TestImpactFileUtils.h>
+#include <TestImpactFramework/TestImpactUtils.h>
 
 #include <Artifact/Factory/TestImpactModuleCoverageFactory.h>
 #include <Artifact/Factory/TestImpactTestRunSuiteFactory.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/Run/TestImpactTestRunner.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/Run/TestImpactTestRunner.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <TestImpactFramework/TestImpactFileUtils.h>
+#include <TestImpactFramework/TestImpactUtils.h>
 
 #include <Artifact/Factory/TestImpactTestRunSuiteFactory.h>
 #include <TestEngine/TestImpactTestEngineException.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/TestImpactTestEngine.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestEngine/TestImpactTestEngine.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <TestImpactFramework/TestImpactFileUtils.h>
+#include <TestImpactFramework/TestImpactUtils.h>
 
 #include <Target/TestImpactTestTarget.h>
 #include <TestEngine/TestImpactTestEngineException.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
@@ -11,7 +11,6 @@ namespace TestImpact
 {
     namespace Client
     {
-        //! Calculates the final sequence result for a composite of multiple sequences.
         TestSequenceResult CalculateMultiTestSequenceResult(const AZStd::vector<TestSequenceResult>& results)
         {
             // Order of precedence:
@@ -19,14 +18,12 @@ namespace TestImpact
             // 2. TestSequenceResult::Timeout
             // 3. TestSequenceResult::Success
 
-            if (const auto it = AZStd::find(results.begin(), results.end(), TestSequenceResult::Failure);
-                it != results.end())
+            if (const auto it = AZStd::find(results.begin(), results.end(), TestSequenceResult::Failure); it != results.end())
             {
                 return TestSequenceResult::Failure;
             }
-            
-            if (const auto it = AZStd::find(results.begin(), results.end(), TestSequenceResult::Timeout);
-                it != results.end())
+
+            if (const auto it = AZStd::find(results.begin(), results.end(), TestSequenceResult::Timeout); it != results.end())
             {
                 return TestSequenceResult::Timeout;
             }
@@ -38,20 +35,32 @@ namespace TestImpact
             TestSequenceResult result,
             AZStd::chrono::high_resolution_clock::time_point startTime,
             AZStd::chrono::milliseconds duration,
-            AZStd::vector<TestRun>&& passingTests,
-            AZStd::vector<TestRunWithTestFailures>&& failingTests,
-            AZStd::vector<TestRun>&& executionFailureTests,
-            AZStd::vector<TestRun>&& timedOutTests,
-            AZStd::vector<TestRun>&& unexecutedTests)
+            AZStd::vector<CompletedTestRun>&& passingTestRuns,
+            AZStd::vector<CompletedTestRun>&& failingTestRuns,
+            AZStd::vector<TestRunWithExecutonFailure>&& executionFailureTestRuns,
+            AZStd::vector<TimedOutTestRun>&& timedOutTestRuns,
+            AZStd::vector<UnexecutedTestRun>&& unexecutedTestRuns)
             : m_startTime(startTime)
             , m_result(result)
             , m_duration(duration)
-            , m_passingTests(AZStd::move(passingTests))
-            , m_failingTests(AZStd::move(failingTests))
-            , m_executionFailureTests(AZStd::move(executionFailureTests))
-            , m_timedOutTests(AZStd::move(timedOutTests))
-            , m_unexecutedTests(AZStd::move(unexecutedTests))
+            , m_passingTestRuns(AZStd::move(passingTestRuns))
+            , m_failingTestRuns(AZStd::move(failingTestRuns))
+            , m_executionFailureTestRuns(AZStd::move(executionFailureTestRuns))
+            , m_timedOutTestRuns(AZStd::move(timedOutTestRuns))
+            , m_unexecutedTestRuns(AZStd::move(unexecutedTestRuns))
         {
+            for (const auto& failingTestRun : m_failingTestRuns)
+            {
+                m_totalNumPassingTests += failingTestRun.GetTotalNumPassingTests();
+                m_totalNumFailingTests += failingTestRun.GetTotalNumFailingTests();
+                m_totalNumDisabledTests += failingTestRun.GetTotalNumDisabledTests();
+            }
+
+            for (const auto& passingTestRun : m_passingTestRuns)
+            {
+                m_totalNumPassingTests += passingTestRun.GetTotalNumPassingTests();
+                m_totalNumDisabledTests += passingTestRun.GetTotalNumDisabledTests();
+            }
         }
 
         TestSequenceResult TestRunReport::GetResult() const
@@ -74,234 +83,238 @@ namespace TestImpact
             return m_duration;
         }
 
-        size_t TestRunReport::GetNumPassingTests() const
+        size_t TestRunReport::GetTotalNumTestRuns() const
         {
-            return m_passingTests.size();
+            return
+                GetNumPassingTestRuns() +
+                GetNumFailingTestRuns() +
+                GetNumExecutionFailureTestRuns() +
+                GetNumTimedOutTestRuns() +
+                GetNumUnexecutedTestRuns();
         }
 
-        size_t TestRunReport::GetNumFailingTests() const
+        size_t TestRunReport::GetNumPassingTestRuns() const
         {
-            return m_failingTests.size();
+            return m_passingTestRuns.size();
         }
 
-        size_t TestRunReport::GetNumTimedOutTests() const
+        size_t TestRunReport::GetNumFailingTestRuns() const
         {
-            return m_timedOutTests.size();
+            return m_failingTestRuns.size();
         }
 
-        size_t TestRunReport::GetNumUnexecutedTests() const
+        size_t TestRunReport::GetNumExecutionFailureTestRuns() const
         {
-            return m_unexecutedTests.size();
+            return m_executionFailureTestRuns.size();
         }
 
-        const AZStd::vector<TestRun>& TestRunReport::GetPassingTests() const
+        size_t TestRunReport::TestRunReport::GetNumTimedOutTestRuns() const
         {
-            return m_passingTests;
+            return m_timedOutTestRuns.size();
         }
 
-        const AZStd::vector<TestRunWithTestFailures>& TestRunReport::GetFailingTests() const
+        size_t TestRunReport::GetNumUnexecutedTestRuns() const
         {
-            return m_failingTests;
+            return m_unexecutedTestRuns.size();
         }
 
-        const AZStd::vector<TestRun>& TestRunReport::GetExecutionFailureTests() const
+        const AZStd::vector<CompletedTestRun>& TestRunReport::GetPassingTestRuns() const
         {
-            return m_executionFailureTests;
+            return m_passingTestRuns;
         }
 
-        const AZStd::vector<TestRun>& TestRunReport::GetTimedOutTests() const
+        const AZStd::vector<CompletedTestRun>& TestRunReport::GetFailingTestRuns() const
         {
-            return m_timedOutTests;
+            return m_failingTestRuns;
         }
 
-        const AZStd::vector<TestRun>& TestRunReport::GetUnexecutedTests() const
+        const AZStd::vector<TestRunWithExecutonFailure>& TestRunReport::GetExecutionFailureTestRuns() const
         {
-            return m_unexecutedTests;
+            return m_executionFailureTestRuns;
         }
 
-        SequenceReport::SequenceReport(SuiteType suiteType, const TestRunSelection& selectedTests, TestRunReport&& selectedTestRunReport)
-            : m_suite(suiteType)
-            , m_selectedTests(selectedTests)
-            , m_selectedTestRunReport(AZStd::move(selectedTestRunReport))
+        const AZStd::vector<TimedOutTestRun>& TestRunReport::GetTimedOutTestRuns() const
         {
+            return m_timedOutTestRuns;
         }
 
-        TestSequenceResult SequenceReport::GetResult() const
+        const AZStd::vector<UnexecutedTestRun>& TestRunReport::GetUnexecutedTestRuns() const
         {
-            return m_selectedTestRunReport.GetResult();
+            return m_unexecutedTestRuns;
         }
 
-        AZStd::chrono::high_resolution_clock::time_point SequenceReport::GetStartTime() const
+        size_t TestRunReport::GetTotalNumPassingTests() const
         {
-            return m_selectedTestRunReport.GetStartTime();
+            return m_totalNumPassingTests;
         }
 
-        AZStd::chrono::high_resolution_clock::time_point SequenceReport::GetEndTime() const
+        size_t TestRunReport::GetTotalNumFailingTests() const
         {
-            return GetStartTime() + GetDuration();
+            return m_totalNumFailingTests;
         }
 
-        AZStd::chrono::milliseconds SequenceReport::GetDuration() const
+        size_t TestRunReport::GetTotalNumDisabledTests() const
         {
-            return m_selectedTestRunReport.GetDuration();
+            return m_totalNumDisabledTests;
         }
 
-        TestRunSelection SequenceReport::GetSelectedTests() const
-        {
-            return m_selectedTests;
-        }
-
-        TestRunReport SequenceReport::GetSelectedTestRunReport() const
-        {
-            return m_selectedTestRunReport;
-        }
-
-        size_t SequenceReport::GetTotalNumPassingTests() const
-        {
-            return m_selectedTestRunReport.GetNumPassingTests();
-        }
-
-        size_t SequenceReport::GetTotalNumFailingTests() const
-        {
-            return m_selectedTestRunReport.GetNumFailingTests();
-        }
-
-        size_t SequenceReport::GetTotalNumTimedOutTests() const
-        {
-            return m_selectedTestRunReport.GetNumTimedOutTests();
-        }
-
-        size_t SequenceReport::GetTotalNumUnexecutedTests() const
-        {
-            return m_selectedTestRunReport.GetNumUnexecutedTests();
-        }
-
-        DraftingSequenceReport::DraftingSequenceReport(
+        RegularSequenceReport::RegularSequenceReport(
+            size_t maxConcurrency,
+            const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
+            const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
+            const SequencePolicyState& policyState,
             SuiteType suiteType,
-            const TestRunSelection& selectedTests,
-            const AZStd::vector<AZStd::string>& draftedTests,
-            TestRunReport&& selectedTestRunReport,
-            TestRunReport&& draftedTestRunReport)
-            : SequenceReport(suiteType, selectedTests, AZStd::move(selectedTestRunReport))
-            , m_draftedTests(draftedTests)
-            , m_draftedTestRunReport(AZStd::move(draftedTestRunReport))
+            const TestRunSelection& selectedTestRuns,
+            TestRunReport&& selectedTestRunReport)
+            : SequenceReportBase(
+                  SequenceReportType::RegularSequence,
+                  maxConcurrency,
+                  testTargetTimeout,
+                  globalTimeout,
+                  policyState,
+                  suiteType,
+                  selectedTestRuns,
+                  AZStd::move(selectedTestRunReport))
         {
         }
 
-        TestSequenceResult DraftingSequenceReport::GetResult() const
+        SeedSequenceReport::SeedSequenceReport(
+            size_t maxConcurrency,
+            const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
+            const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
+            const SequencePolicyState& policyState,
+            SuiteType suiteType,
+            const TestRunSelection& selectedTestRuns,
+            TestRunReport&& selectedTestRunReport)
+            : SequenceReportBase(
+                  SequenceReportType::SeedSequence,
+                  maxConcurrency,
+                  testTargetTimeout,
+                  globalTimeout,
+                  policyState,
+                  suiteType,
+                  selectedTestRuns,
+                  AZStd::move(selectedTestRunReport))
         {
-            return CalculateMultiTestSequenceResult({SequenceReport::GetResult(), m_draftedTestRunReport.GetResult()});
-        }
-
-        AZStd::chrono::milliseconds DraftingSequenceReport::GetDuration() const
-        {
-            return SequenceReport::GetDuration() + m_draftedTestRunReport.GetDuration();
-        }
-
-        size_t DraftingSequenceReport::GetTotalNumPassingTests() const
-        {
-            return SequenceReport::GetTotalNumPassingTests() + m_draftedTestRunReport.GetNumPassingTests();
-        }
-
-        size_t DraftingSequenceReport::GetTotalNumFailingTests() const
-        {
-            return SequenceReport::GetTotalNumFailingTests() + m_draftedTestRunReport.GetNumFailingTests();
-        }
-
-        size_t DraftingSequenceReport::GetTotalNumTimedOutTests() const
-        {
-            return SequenceReport::GetTotalNumTimedOutTests() + m_draftedTestRunReport.GetNumTimedOutTests();
-        }
-
-        size_t DraftingSequenceReport::GetTotalNumUnexecutedTests() const
-        {
-            return SequenceReport::GetTotalNumUnexecutedTests() + m_draftedTestRunReport.GetNumUnexecutedTests();
-        }
-
-        const AZStd::vector<AZStd::string>& DraftingSequenceReport::GetDraftedTests() const
-        {
-            return m_draftedTests;
-        }
-
-        TestRunReport DraftingSequenceReport::GetDraftedTestRunReport() const
-        {
-            return m_draftedTestRunReport;
         }
 
         ImpactAnalysisSequenceReport::ImpactAnalysisSequenceReport(
+            size_t maxConcurrency,
+            const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
+            const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
+            const ImpactAnalysisSequencePolicyState& policyState,
             SuiteType suiteType,
-            const TestRunSelection& selectedTests,
-            const AZStd::vector<AZStd::string>& discardedTests,
-            const AZStd::vector<AZStd::string>& draftedTests,
+            const TestRunSelection& selectedTestRuns,
+            const AZStd::vector<AZStd::string>& discardedTestRuns,
+            const AZStd::vector<AZStd::string>& draftedTestRuns,
             TestRunReport&& selectedTestRunReport,
             TestRunReport&& draftedTestRunReport)
-            : DraftingSequenceReport(
-                  suiteType,
-                  selectedTests,
-                  draftedTests,
-                  AZStd::move(selectedTestRunReport),
-                  AZStd::move(draftedTestRunReport))
-            , m_discardedTests(discardedTests)
+            : DraftingSequenceReportBase(
+                SequenceReportType::ImpactAnalysisSequence,
+                maxConcurrency,
+                testTargetTimeout,
+                globalTimeout,
+                policyState,
+                suiteType,
+                selectedTestRuns,
+                draftedTestRuns,
+                AZStd::move(selectedTestRunReport),
+                AZStd::move(draftedTestRunReport))
+            , m_discardedTestRuns(discardedTestRuns)
         {
         }
 
-        const AZStd::vector<AZStd::string>& ImpactAnalysisSequenceReport::GetDiscardedTests() const
+        const AZStd::vector<AZStd::string>& ImpactAnalysisSequenceReport::GetDiscardedTestRuns() const
         {
-            return m_discardedTests;
+            return m_discardedTestRuns;
         }
 
         SafeImpactAnalysisSequenceReport::SafeImpactAnalysisSequenceReport(
+            size_t maxConcurrency,
+            const AZStd::optional<AZStd::chrono::milliseconds>& testTargetTimeout,
+            const AZStd::optional<AZStd::chrono::milliseconds>& globalTimeout,
+            const SafeImpactAnalysisSequencePolicyState& policyState,
             SuiteType suiteType,
-            const TestRunSelection& selectedTests,
-            const TestRunSelection& discardedTests,
-            const AZStd::vector<AZStd::string>& draftedTests,
+            const TestRunSelection& selectedTestRuns,
+            const TestRunSelection& discardedTestRuns,
+            const AZStd::vector<AZStd::string>& draftedTestRuns,
             TestRunReport&& selectedTestRunReport,
             TestRunReport&& discardedTestRunReport,
             TestRunReport&& draftedTestRunReport)
-            : DraftingSequenceReport(
-                  suiteType,
-                  selectedTests,
-                  draftedTests,
-                  AZStd::move(selectedTestRunReport),
-                  AZStd::move(draftedTestRunReport))
-            , m_discardedTests(discardedTests)
+            : DraftingSequenceReportBase(
+                SequenceReportType::SafeImpactAnalysisSequence,
+                maxConcurrency,
+                testTargetTimeout,
+                globalTimeout,
+                policyState,
+                suiteType,
+                selectedTestRuns,
+                draftedTestRuns,
+                AZStd::move(selectedTestRunReport),
+                AZStd::move(draftedTestRunReport))
+            , m_discardedTestRuns(discardedTestRuns)
             , m_discardedTestRunReport(AZStd::move(discardedTestRunReport))
         {
         }
 
         TestSequenceResult SafeImpactAnalysisSequenceReport::GetResult() const
         {
-            return CalculateMultiTestSequenceResult({ DraftingSequenceReport::GetResult(), m_discardedTestRunReport.GetResult() });
+            return CalculateMultiTestSequenceResult({ DraftingSequenceReportBase::GetResult(), m_discardedTestRunReport.GetResult() });
         }
 
         AZStd::chrono::milliseconds SafeImpactAnalysisSequenceReport::GetDuration() const
         {
-            return DraftingSequenceReport::GetDuration() + m_discardedTestRunReport.GetDuration();
+            return DraftingSequenceReportBase::GetDuration() + m_discardedTestRunReport.GetDuration();
+        }
+
+        size_t SafeImpactAnalysisSequenceReport::GetTotalNumTestRuns() const
+        {
+            return DraftingSequenceReportBase::GetTotalNumTestRuns() + m_discardedTestRunReport.GetTotalNumTestRuns();
         }
 
         size_t SafeImpactAnalysisSequenceReport::GetTotalNumPassingTests() const
         {
-            return DraftingSequenceReport::GetTotalNumPassingTests() + m_discardedTestRunReport.GetNumPassingTests();
+            return DraftingSequenceReportBase::GetTotalNumPassingTests() + m_discardedTestRunReport.GetTotalNumPassingTests();
         }
 
         size_t SafeImpactAnalysisSequenceReport::GetTotalNumFailingTests() const
         {
-            return DraftingSequenceReport::GetTotalNumFailingTests() + m_discardedTestRunReport.GetNumFailingTests();
+            return DraftingSequenceReportBase::GetTotalNumFailingTests() + m_discardedTestRunReport.GetTotalNumFailingTests();
         }
 
-        size_t SafeImpactAnalysisSequenceReport::GetTotalNumTimedOutTests() const
+        size_t SafeImpactAnalysisSequenceReport::GetTotalNumDisabledTests() const
         {
-            return DraftingSequenceReport::GetTotalNumTimedOutTests() + m_discardedTestRunReport.GetNumTimedOutTests();
+            return DraftingSequenceReportBase::GetTotalNumDisabledTests() + m_discardedTestRunReport.GetTotalNumDisabledTests();
         }
 
-        size_t SafeImpactAnalysisSequenceReport::GetTotalNumUnexecutedTests() const
+        size_t SafeImpactAnalysisSequenceReport::GetTotalNumPassingTestRuns() const
         {
-            return DraftingSequenceReport::GetTotalNumUnexecutedTests() + m_discardedTestRunReport.GetNumUnexecutedTests();
+            return DraftingSequenceReportBase::GetTotalNumPassingTestRuns() + m_discardedTestRunReport.GetNumPassingTestRuns();
+        }
+
+        size_t SafeImpactAnalysisSequenceReport::GetTotalNumFailingTestRuns() const
+        {
+            return DraftingSequenceReportBase::GetTotalNumFailingTestRuns() + m_discardedTestRunReport.GetNumFailingTestRuns();
+        }
+
+        size_t SafeImpactAnalysisSequenceReport::GetTotalNumExecutionFailureTestRuns() const
+        {
+            return DraftingSequenceReportBase::GetTotalNumExecutionFailureTestRuns() + m_discardedTestRunReport.GetNumExecutionFailureTestRuns();
+        }
+
+        size_t SafeImpactAnalysisSequenceReport::GetTotalNumTimedOutTestRuns() const
+        {
+            return DraftingSequenceReportBase::GetTotalNumTimedOutTestRuns() + m_discardedTestRunReport.GetNumTimedOutTestRuns();
+        }
+
+        size_t SafeImpactAnalysisSequenceReport::GetTotalNumUnexecutedTestRuns() const
+        {
+            return DraftingSequenceReportBase::GetTotalNumUnexecutedTestRuns() + m_discardedTestRunReport.GetNumUnexecutedTestRuns();
         }
         
-        const TestRunSelection SafeImpactAnalysisSequenceReport::GetDiscardedTests() const
+        const TestRunSelection SafeImpactAnalysisSequenceReport::GetDiscardedTestRuns() const
         {
-            return m_discardedTests;
+            return m_discardedTestRuns;
         }
 
         TestRunReport SafeImpactAnalysisSequenceReport::GetDiscardedTestRunReport() const

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReport.cpp
@@ -35,9 +35,9 @@ namespace TestImpact
             TestSequenceResult result,
             AZStd::chrono::high_resolution_clock::time_point startTime,
             AZStd::chrono::milliseconds duration,
-            AZStd::vector<CompletedTestRun>&& passingTestRuns,
-            AZStd::vector<CompletedTestRun>&& failingTestRuns,
-            AZStd::vector<TestRunWithExecutonFailure>&& executionFailureTestRuns,
+            AZStd::vector<PassingTestRun>&& passingTestRuns,
+            AZStd::vector<FailingTestRun>&& failingTestRuns,
+            AZStd::vector<TestRunWithExecutionFailure>&& executionFailureTestRuns,
             AZStd::vector<TimedOutTestRun>&& timedOutTestRuns,
             AZStd::vector<UnexecutedTestRun>&& unexecutedTestRuns)
             : m_startTime(startTime)
@@ -118,17 +118,17 @@ namespace TestImpact
             return m_unexecutedTestRuns.size();
         }
 
-        const AZStd::vector<CompletedTestRun>& TestRunReport::GetPassingTestRuns() const
+        const AZStd::vector<PassingTestRun>& TestRunReport::GetPassingTestRuns() const
         {
             return m_passingTestRuns;
         }
 
-        const AZStd::vector<CompletedTestRun>& TestRunReport::GetFailingTestRuns() const
+        const AZStd::vector<FailingTestRun>& TestRunReport::GetFailingTestRuns() const
         {
             return m_failingTestRuns;
         }
 
-        const AZStd::vector<TestRunWithExecutonFailure>& TestRunReport::GetExecutionFailureTestRuns() const
+        const AZStd::vector<TestRunWithExecutionFailure>& TestRunReport::GetExecutionFailureTestRuns() const
         {
             return m_executionFailureTestRuns;
         }

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -24,7 +24,7 @@ namespace TestImpact
             return AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(timePoint.time_since_epoch()).count();
         }
 
-        void SerializeTestRunMembers(const Client::TestRun& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        void SerializeTestRunMembers(const Client::TestRunBase& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             // Name
             writer.Key("name");
@@ -51,7 +51,7 @@ namespace TestImpact
             writer.String(TestRunResultAsString(testRun.GetResult()).c_str());
         }
 
-        void SerializeTestRun(const Client::TestRun& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        void SerializeTestRun(const Client::TestRunBase& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             writer.StartObject();
 

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
- * this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -181,13 +181,13 @@ namespace TestImpact
         void SerializeCompletedTestRun(const Client::CompletedTestRun& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             writer.StartObject();
-            
+            {
                 SerializeTestRunMembers(testRun, writer);
 
-                 // Number of passing test cases
+                // Number of passing test cases
                 writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumPassingTests]);
                 writer.Uint64(testRun.GetTotalNumPassingTests());
-            
+
                 // Number of failing test cases
                 writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumFailingTests]);
                 writer.Uint64(testRun.GetTotalNumFailingTests());
@@ -199,25 +199,25 @@ namespace TestImpact
                 // Tests
                 writer.Key(SequenceReportFields::Keys[SequenceReportFields::Tests]);
                 writer.StartArray();
-            
+
                 for (const auto& test : testRun.GetTests())
                 {
                     // Test
                     writer.StartObject();
-            
-                        // Name
-                        writer.Key(SequenceReportFields::Keys[SequenceReportFields::Name]);
-                        writer.String(test.GetName().c_str());
-            
-                        // Result
-                        writer.Key(SequenceReportFields::Keys[SequenceReportFields::Result]);
-                        writer.String(ClientTestResultAsString(test.GetResult()).c_str());
-            
+
+                    // Name
+                    writer.Key(SequenceReportFields::Keys[SequenceReportFields::Name]);
+                    writer.String(test.GetName().c_str());
+
+                    // Result
+                    writer.Key(SequenceReportFields::Keys[SequenceReportFields::Result]);
+                    writer.String(ClientTestResultAsString(test.GetResult()).c_str());
+
                     writer.EndObject(); // Test
                 }
-            
+
                 writer.EndArray(); // Tests
-            
+            }
             writer.EndObject();
         }
 
@@ -225,7 +225,7 @@ namespace TestImpact
             const Client::TestRunReport& testRunReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             writer.StartObject();
-
+            {
                 // Result
                 writer.Key(SequenceReportFields::Keys[SequenceReportFields::Result]);
                 writer.String(TestSequenceResultAsString(testRunReport.GetResult()).c_str());
@@ -318,7 +318,7 @@ namespace TestImpact
                 // Number of disabled tests
                 writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumDisabledTests]);
                 writer.Uint64(testRunReport.GetTotalNumDisabledTests());
-
+            }
             writer.EndObject();
         }
 
@@ -326,7 +326,7 @@ namespace TestImpact
             const Client::TestRunSelection& testSelection, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             writer.StartObject();
-
+            {
                 // Total number of test runs
                 writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumTestRuns]);
                 writer.Uint64(testSelection.GetTotalNumTests());
@@ -356,7 +356,7 @@ namespace TestImpact
                     writer.String(testRun.c_str());
                 }
                 writer.EndArray(); // Excluded test runs
-
+            }
             writer.EndObject();
         }
 
@@ -440,7 +440,9 @@ namespace TestImpact
             // Policies
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::Policy]);
             writer.StartObject();
+            {
                 SerializePolicyStateMembers(sequenceReport.GetPolicyState(), writer);
+            }
             writer.EndObject(); // Policies
 
             // Suite
@@ -535,7 +537,9 @@ namespace TestImpact
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(stringBuffer);
 
         writer.StartObject();
-        SerializeSequenceReportBaseMembers(sequenceReport, writer);
+        {
+            SerializeSequenceReportBaseMembers(sequenceReport, writer);
+        }
         writer.EndObject();
 
         return stringBuffer.GetString();
@@ -559,6 +563,7 @@ namespace TestImpact
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(stringBuffer);
 
         writer.StartObject();
+        {
             SerializeDraftingSequenceReportMembers(sequenceReport, writer);
 
             // Discarded test runs
@@ -569,7 +574,7 @@ namespace TestImpact
                 writer.String(testRun.c_str());
             }
             writer.EndArray(); // Discarded test runs
-
+        }
         writer.EndObject();
 
         return stringBuffer.GetString();
@@ -581,6 +586,7 @@ namespace TestImpact
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(stringBuffer);
 
         writer.StartObject();
+        {
             SerializeDraftingSequenceReportMembers(sequenceReport, writer);
 
             // Discarded test runs
@@ -590,7 +596,7 @@ namespace TestImpact
             // Discarded test run report
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRunReport]);
             SerializeTestRunReport(sequenceReport.GetDiscardedTestRunReport(), writer);
-
+        }
         writer.EndObject();
 
         return stringBuffer.GetString();

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -19,6 +19,124 @@ namespace TestImpact
 {
     namespace
     {
+        namespace SequenceReportFields
+        {
+            // Keys for pertinent JSON node and attribute names
+            constexpr const char* Keys[] =
+            {
+                "name",
+                "command_args",
+                "start_time",
+                "end_time",
+                "duration",
+                "result",
+                "num_passing_tests",
+                "num_failing_tests",
+                "num_disabled_tests",
+                "tests",
+                "num_passing_test_runs",
+                "num_failing_test_runs",
+                "num_execution_failure_test_runs",
+                "num_timed_out_test_runs",
+                "num_unexecuted_test_runs",
+                "passing_test_runs",
+                "failing_test_runs",
+                "execution_failure_test_runs",
+                "timed_out_test_runs",
+                "unexecuted_test_runs",
+                "total_num_passing_tests",
+                "total_num_failing_tests",
+                "total_num_disabled_tests",
+                "total_num_test_runs",
+                "num_included_test_runs",
+                "num_excluded_test_runs",
+                "included_test_runs",
+                "excluded_test_runs",
+                "execution_failure",
+                "coverage_failure",
+                "test_failure",
+                "integrity_failure",
+                "test_sharding",
+                "target_output_capture",
+                "test_prioritization",
+                "dynamic_dependency_map",
+                "type",
+                "test_target_timeout",
+                "global_timeout",
+                "max_concurrency",
+                "policy",
+                "suite",
+                "selected_test_runs",
+                "selected_test_run_report",
+                "total_num_passing_test_runs",
+                "total_num_failing_test_runs",
+                "total_num_execution_failure_test_runs",
+                "total_num_timed_out_test_runs",
+                "total_num_unexecuted_test_runs",
+                "drafted_test_runs",
+                "drafted_test_run_report",
+                "discarded_test_runs",
+                "discarded_test_run_report"
+            };
+
+            enum
+            {
+                Name,
+                CommandArgs,
+                StartTime,
+                EndTime,
+                Duration,
+                Result,
+                NumPassingTests,
+                NumFailingTests,
+                NumDisabledTests,
+                Tests,
+                NumPassingTestRuns,
+                NumFailingTestRuns,
+                NumExecutionFailureTestRuns,
+                NumTimedOutTestRuns,
+                NumUnexecutedTestRuns,
+                PassingTestRuns,
+                FailingTestRuns,
+                ExecutionFailureTestRuns,
+                TimedOutTestRuns,
+                UnexecutedTestRuns,
+                TotalNumPassingTests,
+                TotalNumFailingTests,
+                TotalNumDisabledTests,
+                TotalNumTestRuns,
+                NumIncludedTestRuns,
+                NumExcludedTestRuns,
+                IncludedTestRuns,
+                ExcludedTestRuns,
+                ExecutionFailure,
+                CoverageFailure,
+                TestFailure,
+                IntegrityFailure,
+                TestSharding,
+                TargetOutputCapture,
+                TestPrioritization,
+                DynamicDependencyMap,
+                Type,
+                TestTargetTimeout,
+                GlobalTimeout,
+                MaxConcurrency,
+                Policy,
+                Suite,
+                SelectedTestRuns,
+                SelectedTestRunReport,
+                TotalNumPassingTestRuns,
+                TotalNumFailingTestRuns,
+                TotalNumExecutionFailureTestRuns,
+                TotalNumTimedOutTestRuns,
+                TotalNumUnexecutedTestRuns,
+                DraftedTestRuns,
+                DraftedTestRunReport,
+                DiscardedTestRuns,
+                DiscardedTestRunReport
+            };
+        } // namespace
+
         AZ::u64 TimePointInMsAsInt64(AZStd::chrono::high_resolution_clock::time_point timePoint)
         {
             return AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(timePoint.time_since_epoch()).count();
@@ -27,27 +145,27 @@ namespace TestImpact
         void SerializeTestRunMembers(const Client::TestRunBase& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             // Name
-            writer.Key("name");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::Name]);
             writer.String(testRun.GetTargetName().c_str());
 
             // Command string
-            writer.Key("command_args");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::CommandArgs]);
             writer.String(testRun.GetCommandString().c_str());
 
             // Start time
-            writer.Key("start_time");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::StartTime]);
             writer.Int64(TimePointInMsAsInt64(testRun.GetStartTime()));
 
             // End time
-            writer.Key("end_time");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::EndTime]);
             writer.Int64(TimePointInMsAsInt64(testRun.GetEndTime()));
 
             // Duration
-            writer.Key("duration");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::Duration]);
             writer.Uint64(testRun.GetDuration().count());
 
             // Result
-            writer.Key("result");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::Result]);
             writer.String(TestRunResultAsString(testRun.GetResult()).c_str());
         }
 
@@ -67,19 +185,19 @@ namespace TestImpact
                 SerializeTestRunMembers(testRun, writer);
 
                  // Number of passing test cases
-                writer.Key("num_passing_tests");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumPassingTests]);
                 writer.Uint64(testRun.GetTotalNumPassingTests());
             
                 // Number of failing test cases
-                writer.Key("num_failing_tests");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumFailingTests]);
                 writer.Uint64(testRun.GetTotalNumFailingTests());
 
                 // Number of disabled test cases
-                writer.Key("num_disabled_tests");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumDisabledTests]);
                 writer.Uint64(testRun.GetTotalNumDisabledTests());
 
                 // Tests
-                writer.Key("tests");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::Tests]);
                 writer.StartArray();
             
                 for (const auto& test : testRun.GetTests())
@@ -88,11 +206,11 @@ namespace TestImpact
                     writer.StartObject();
             
                         // Name
-                        writer.Key("name");
+                        writer.Key(SequenceReportFields::Keys[SequenceReportFields::Name]);
                         writer.String(test.GetName().c_str());
             
                         // Result
-                        writer.Key("result");
+                        writer.Key(SequenceReportFields::Keys[SequenceReportFields::Result]);
                         writer.String(ClientTestResultAsString(test.GetResult()).c_str());
             
                     writer.EndObject(); // Test
@@ -109,43 +227,43 @@ namespace TestImpact
             writer.StartObject();
 
                 // Result
-                writer.Key("result");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::Result]);
                 writer.String(TestSequenceResultAsString(testRunReport.GetResult()).c_str());
 
                 // Start time
-                writer.Key("start_time");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::StartTime]);
                 writer.Int64(TimePointInMsAsInt64(testRunReport.GetStartTime()));
 
                 // End time
-                writer.Key("end_time");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::EndTime]);
                 writer.Int64(TimePointInMsAsInt64(testRunReport.GetEndTime()));
 
                 // Duration
-                writer.Key("duration");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::Duration]);
                 writer.Uint64(testRunReport.GetDuration().count());
 
                 // Number of passing test runs
-                writer.Key("num_passing_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumPassingTestRuns]);
                 writer.Uint64(testRunReport.GetNumPassingTestRuns());
 
                 // Number of failing test runs
-                writer.Key("num_failing_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumFailingTestRuns]);
                 writer.Uint64(testRunReport.GetNumFailingTestRuns());
 
                 // Number of test runs that failed to execute
-                writer.Key("num_execution_failure_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumExecutionFailureTestRuns]);
                 writer.Uint64(testRunReport.GetNumExecutionFailureTestRuns());
 
                 // Number of timed out test runs
-                writer.Key("num_timed_out_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumTimedOutTestRuns]);
                 writer.Uint64(testRunReport.GetNumTimedOutTestRuns());
 
                 // Number of unexecuted test runs
-                writer.Key("num_unexecuted_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumUnexecutedTestRuns]);
                 writer.Uint64(testRunReport.GetNumUnexecutedTestRuns());
 
                 // Passing test runs
-                writer.Key("passing_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::PassingTestRuns]);
                 writer.StartArray();
                 for (const auto& testRun : testRunReport.GetPassingTestRuns())
                 {
@@ -154,7 +272,7 @@ namespace TestImpact
                 writer.EndArray(); // Passing test runs
 
                 // Failing test runs
-                writer.Key("failing_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::FailingTestRuns]);
                 writer.StartArray();
                 for (const auto& testRun : testRunReport.GetFailingTestRuns())
                 {
@@ -163,7 +281,7 @@ namespace TestImpact
                 writer.EndArray(); // Failing test runs
 
                 // Execution failures
-                writer.Key("execution_failure_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::ExecutionFailureTestRuns]);
                 writer.StartArray();
                 for (const auto& testRun : testRunReport.GetExecutionFailureTestRuns())
                 {
@@ -172,7 +290,7 @@ namespace TestImpact
                 writer.EndArray(); // Execution failures
 
                 // Timed out test runs
-                writer.Key("timed_out_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::TimedOutTestRuns]);
                 writer.StartArray();
                 for (const auto& testRun : testRunReport.GetTimedOutTestRuns())
                 {
@@ -181,7 +299,7 @@ namespace TestImpact
                 writer.EndArray(); // Timed out test runs
 
                 // Unexecuted test runs
-                writer.Key("unexecuted_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::UnexecutedTestRuns]);
                 writer.StartArray();
                 for (const auto& testRun : testRunReport.GetUnexecutedTestRuns())
                 {
@@ -190,15 +308,15 @@ namespace TestImpact
                 writer.EndArray(); // Unexecuted test runs
 
                 // Number of passing tests
-                writer.Key("total_num_passing_tests");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumPassingTests]);
                 writer.Uint64(testRunReport.GetTotalNumPassingTests());
 
                 // Number of failing tests
-                writer.Key("total_num_failing_tests");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumFailingTests]);
                 writer.Uint64(testRunReport.GetTotalNumFailingTests());
 
                 // Number of disabled tests
-                writer.Key("total_num_disabled_tests");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumDisabledTests]);
                 writer.Uint64(testRunReport.GetTotalNumDisabledTests());
 
             writer.EndObject();
@@ -210,19 +328,19 @@ namespace TestImpact
             writer.StartObject();
 
                 // Total number of test runs
-                writer.Key("total_num_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumTestRuns]);
                 writer.Uint64(testSelection.GetTotalNumTests());
 
                 // Number of included test runs
-                writer.Key("num_included_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumIncludedTestRuns]);
                 writer.Uint64(testSelection.GetNumIncludedTestRuns());
 
                 // Number of excluded test runs
-                writer.Key("num_excluded_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::NumExcludedTestRuns]);
                 writer.Uint64(testSelection.GetNumExcludedTestRuns());
 
                 // Included test runs
-                writer.Key("included_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::IncludedTestRuns]);
                 writer.StartArray();
                 for (const auto& testRun : testSelection.GetIncludededTestRuns())
                 {
@@ -231,7 +349,7 @@ namespace TestImpact
                 writer.EndArray(); // Included test runs
 
                 // Excluded test runs
-                writer.Key("excluded_test_runs");
+                writer.Key(SequenceReportFields::Keys[SequenceReportFields::ExcludedTestRuns]);
                 writer.StartArray();
                 for (const auto& testRun : testSelection.GetExcludedTestRuns())
                 {
@@ -245,27 +363,27 @@ namespace TestImpact
         void SerializePolicyStateBaseMembers(const PolicyStateBase& policyState, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             // Execution failure
-            writer.Key("execution_failure");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::ExecutionFailure]);
             writer.String(ExecutionFailurePolicyAsString(policyState.m_executionFailurePolicy).c_str());
             
             // Failed test coverage
-            writer.Key("coverage_failure");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::CoverageFailure]);
             writer.String(FailedTestCoveragePolicyAsString(policyState.m_failedTestCoveragePolicy).c_str());
             
             // Test failure
-            writer.Key("test_failure");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestFailure]);
             writer.String(TestFailurePolicyAsString(policyState.m_testFailurePolicy).c_str());
             
             // Integrity failure
-            writer.Key("integrity_failure");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::IntegrityFailure]);
             writer.String(IntegrityFailurePolicyAsString(policyState.m_integrityFailurePolicy).c_str());
             
             // Test sharding
-            writer.Key("test_sharding");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestSharding]);
             writer.String(TestShardingPolicyAsString(policyState.m_testShardingPolicy).c_str());
             
             // Target output capture
-            writer.Key("target_output_capture");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TargetOutputCapture]);
             writer.String(TargetOutputCapturePolicyAsString(policyState.m_targetOutputCapture).c_str());
         }
 
@@ -281,7 +399,7 @@ namespace TestImpact
             SerializePolicyStateBaseMembers(policyState.m_basePolicies, writer);
 
             // Test prioritization
-            writer.Key("test_prioritization");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestPrioritization]);
             writer.String(TestPrioritizationPolicyAsString(policyState.m_testPrioritizationPolicy).c_str());
         }
 
@@ -291,11 +409,11 @@ namespace TestImpact
             SerializePolicyStateBaseMembers(policyState.m_basePolicies, writer);
 
             // Test prioritization
-            writer.Key("test_prioritization");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestPrioritization]);
             writer.String(TestPrioritizationPolicyAsString(policyState.m_testPrioritizationPolicy).c_str());
 
             // Dynamic dependency map
-            writer.Key("dynamic_dependency_map");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::DynamicDependencyMap]);
             writer.String(DynamicDependencyMapPolicyAsString(policyState.m_dynamicDependencyMap).c_str());
         }
 
@@ -304,89 +422,89 @@ namespace TestImpact
             const Client::SequenceReportBase<PolicyStateType>& sequenceReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             // Type
-            writer.Key("type");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::Type]);
             writer.String(SequenceReportTypeAsString(sequenceReport.GetType()).c_str());
 
             // Test target timeout
-            writer.Key("test_target_timeout");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TestTargetTimeout]);
             writer.Uint64(sequenceReport.GetTestTargetTimeout().value_or(AZStd::chrono::milliseconds{0}).count());
 
             // Global timeout
-            writer.Key("global_timeout");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::GlobalTimeout]);
             writer.Uint64(sequenceReport.GetGlobalTimeout().value_or(AZStd::chrono::milliseconds{ 0 }).count());
 
             // Maximum concurrency
-            writer.Key("max_concurrency");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::MaxConcurrency]);
             writer.Uint64(sequenceReport.GetMaxConcurrency());
 
             // Policies
-            writer.Key("policy");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::Policy]);
             writer.StartObject();
                 SerializePolicyStateMembers(sequenceReport.GetPolicyState(), writer);
             writer.EndObject(); // Policies
 
             // Suite
-            writer.Key("suite");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::Suite]);
             writer.String(SuiteTypeAsString(sequenceReport.GetSuite()).c_str());
 
             // Selected test runs
-            writer.Key("selected_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::SelectedTestRuns]);
             SerializeTestSelection(sequenceReport.GetSelectedTestRuns(), writer);
 
             // Selected test run report
-            writer.Key("selected_test_run_report");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::SelectedTestRunReport]);
             SerializeTestRunReport(sequenceReport.GetSelectedTestRunReport(), writer);
 
             // Start time
-            writer.Key("start_time");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::StartTime]);
             writer.Int64(TimePointInMsAsInt64(sequenceReport.GetStartTime()));
 
             // End time
-            writer.Key("end_time");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::EndTime]);
             writer.Int64(TimePointInMsAsInt64(sequenceReport.GetEndTime()));
 
             // Duration
-            writer.Key("duration");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::Duration]);
             writer.Uint64(sequenceReport.GetDuration().count());
 
             // Result
-            writer.Key("result");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::Result]);
             writer.String(TestSequenceResultAsString(sequenceReport.GetResult()).c_str());
 
             // Total number of test runs
-            writer.Key("total_num_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumTestRuns]);
             writer.Uint64(sequenceReport.GetTotalNumTestRuns());
 
             // Total number of passing test runs
-            writer.Key("total_num_passing_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumPassingTestRuns]);
             writer.Uint64(sequenceReport.GetTotalNumPassingTestRuns());
 
             // Total number of failing test runs
-            writer.Key("total_num_failing_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumFailingTestRuns]);
             writer.Uint64(sequenceReport.GetTotalNumFailingTestRuns());
 
             // Total number of test runs that failed to execute
-            writer.Key("total_num_execution_failure_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumExecutionFailureTestRuns]);
             writer.Uint64(sequenceReport.GetTotalNumExecutionFailureTestRuns());
 
             // Total number of timed out test runs
-            writer.Key("total_num_timed_out_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumTimedOutTestRuns]);
             writer.Uint64(sequenceReport.GetTotalNumTimedOutTestRuns());
 
             // Total number of unexecuted test runs
-            writer.Key("total_num_unexecuted_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumUnexecutedTestRuns]);
             writer.Uint64(sequenceReport.GetTotalNumUnexecutedTestRuns());
 
             // Total number of passing tests
-            writer.Key("total_num_passing_tests");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumPassingTests]);
             writer.Uint64(sequenceReport.GetTotalNumPassingTests());
 
             // Total number of failing tests
-            writer.Key("total_num_failing_tests");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumFailingTests]);
             writer.Uint64(sequenceReport.GetTotalNumFailingTests());
 
              // Total number of disabled tests
-            writer.Key("total_num_disabled_tests");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::TotalNumDisabledTests]);
             writer.Uint64(sequenceReport.GetTotalNumDisabledTests());
         }
 
@@ -397,7 +515,7 @@ namespace TestImpact
             SerializeSequenceReportBaseMembers(sequenceReport, writer);
 
             // Drafted test runs
-            writer.Key("drafted_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::DraftedTestRuns]);
             writer.StartArray();
             for (const auto& testRun : sequenceReport.GetDraftedTestRuns())
             {
@@ -406,7 +524,7 @@ namespace TestImpact
             writer.EndArray(); // Drafted test runs
 
             // Drafted test run report
-            writer.Key("drafted_test_run_report");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::DraftedTestRunReport]);
             SerializeTestRunReport(sequenceReport.GetDraftedTestRunReport(), writer);
         }
     }
@@ -444,7 +562,7 @@ namespace TestImpact
             SerializeDraftingSequenceReportMembers(sequenceReport, writer);
 
             // Discarded test runs
-            writer.Key("discarded_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRuns]);
             writer.StartArray();
             for (const auto& testRun : sequenceReport.GetDiscardedTestRuns())
             {
@@ -466,11 +584,11 @@ namespace TestImpact
             SerializeDraftingSequenceReportMembers(sequenceReport, writer);
 
             // Discarded test runs
-            writer.Key("discarded_test_runs");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRuns]);
             SerializeTestSelection(sequenceReport.GetDiscardedTestRuns(), writer);
 
             // Discarded test run report
-            writer.Key("discarded_test_run_report");
+            writer.Key(SequenceReportFields::Keys[SequenceReportFields::DiscardedTestRunReport]);
             SerializeTestRunReport(sequenceReport.GetDiscardedTestRunReport(), writer);
 
         writer.EndObject();

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -135,7 +135,7 @@ namespace TestImpact
                 DiscardedTestRuns,
                 DiscardedTestRunReport
             };
-        } // namespace
+        } // namespace SequenceReportFields
 
         AZ::u64 TimePointInMsAsInt64(AZStd::chrono::high_resolution_clock::time_point timePoint)
         {
@@ -172,9 +172,9 @@ namespace TestImpact
         void SerializeTestRun(const Client::TestRunBase& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
         {
             writer.StartObject();
-
+            {
                 SerializeTestRunMembers(testRun, writer);
-
+            }
             writer.EndObject();
         }
 
@@ -529,7 +529,7 @@ namespace TestImpact
             writer.Key(SequenceReportFields::Keys[SequenceReportFields::DraftedTestRunReport]);
             SerializeTestRunReport(sequenceReport.GetDraftedTestRunReport(), writer);
         }
-    }
+    } // namespace
 
     AZStd::string SerializeSequenceReport(const Client::RegularSequenceReport& sequenceReport)
     {
@@ -551,7 +551,9 @@ namespace TestImpact
         rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(stringBuffer);
 
         writer.StartObject();
+        {
             SerializeSequenceReportBaseMembers(sequenceReport, writer);
+        }
         writer.EndObject();
 
         return stringBuffer.GetString();

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientSequenceReportSerializer.cpp
@@ -1,0 +1,480 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
+ * this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <TestImpactFramework/TestImpactClientSequenceReportSerializer.h>
+#include <TestImpactFramework/TestImpactSequenceReportException.h>
+#include <TestImpactFramework/TestImpactUtils.h>
+
+#include <AzCore/JSON/document.h>
+#include <AzCore/JSON/prettywriter.h>
+#include <AzCore/JSON/rapidjson.h>
+#include <AzCore/JSON/stringbuffer.h>
+
+namespace TestImpact
+{
+    namespace
+    {
+        AZ::u64 TimePointInMsAsInt64(AZStd::chrono::high_resolution_clock::time_point timePoint)
+        {
+            return AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(timePoint.time_since_epoch()).count();
+        }
+
+        void SerializeTestRunMembers(const Client::TestRun& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            // Name
+            writer.Key("name");
+            writer.String(testRun.GetTargetName().c_str());
+
+            // Command string
+            writer.Key("command_args");
+            writer.String(testRun.GetCommandString().c_str());
+
+            // Start time
+            writer.Key("start_time");
+            writer.Int64(TimePointInMsAsInt64(testRun.GetStartTime()));
+
+            // End time
+            writer.Key("end_time");
+            writer.Int64(TimePointInMsAsInt64(testRun.GetEndTime()));
+
+            // Duration
+            writer.Key("duration");
+            writer.Uint64(testRun.GetDuration().count());
+
+            // Result
+            writer.Key("result");
+            writer.String(TestRunResultAsString(testRun.GetResult()).c_str());
+        }
+
+        void SerializeTestRun(const Client::TestRun& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            writer.StartObject();
+
+                SerializeTestRunMembers(testRun, writer);
+
+            writer.EndObject();
+        }
+
+        void SerializeCompletedTestRun(const Client::CompletedTestRun& testRun, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            writer.StartObject();
+            
+                SerializeTestRunMembers(testRun, writer);
+
+                 // Number of passing test cases
+                writer.Key("num_passing_tests");
+                writer.Uint64(testRun.GetTotalNumPassingTests());
+            
+                // Number of failing test cases
+                writer.Key("num_failing_tests");
+                writer.Uint64(testRun.GetTotalNumFailingTests());
+
+                // Number of disabled test cases
+                writer.Key("num_disabled_tests");
+                writer.Uint64(testRun.GetTotalNumDisabledTests());
+
+                // Tests
+                writer.Key("tests");
+                writer.StartArray();
+            
+                for (const auto& test : testRun.GetTests())
+                {
+                    // Test
+                    writer.StartObject();
+            
+                        // Name
+                        writer.Key("name");
+                        writer.String(test.GetName().c_str());
+            
+                        // Result
+                        writer.Key("result");
+                        writer.String(ClientTestResultAsString(test.GetResult()).c_str());
+            
+                    writer.EndObject(); // Test
+                }
+            
+                writer.EndArray(); // Tests
+            
+            writer.EndObject();
+        }
+
+        void SerializeTestRunReport(
+            const Client::TestRunReport& testRunReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            writer.StartObject();
+
+                // Result
+                writer.Key("result");
+                writer.String(TestSequenceResultAsString(testRunReport.GetResult()).c_str());
+
+                // Start time
+                writer.Key("start_time");
+                writer.Int64(TimePointInMsAsInt64(testRunReport.GetStartTime()));
+
+                // End time
+                writer.Key("end_time");
+                writer.Int64(TimePointInMsAsInt64(testRunReport.GetEndTime()));
+
+                // Duration
+                writer.Key("duration");
+                writer.Uint64(testRunReport.GetDuration().count());
+
+                // Number of passing test runs
+                writer.Key("num_passing_test_runs");
+                writer.Uint64(testRunReport.GetNumPassingTestRuns());
+
+                // Number of failing test runs
+                writer.Key("num_failing_test_runs");
+                writer.Uint64(testRunReport.GetNumFailingTestRuns());
+
+                // Number of test runs that failed to execute
+                writer.Key("num_execution_failure_test_runs");
+                writer.Uint64(testRunReport.GetNumExecutionFailureTestRuns());
+
+                // Number of timed out test runs
+                writer.Key("num_timed_out_test_runs");
+                writer.Uint64(testRunReport.GetNumTimedOutTestRuns());
+
+                // Number of unexecuted test runs
+                writer.Key("num_unexecuted_test_runs");
+                writer.Uint64(testRunReport.GetNumUnexecutedTestRuns());
+
+                // Passing test runs
+                writer.Key("passing_test_runs");
+                writer.StartArray();
+                for (const auto& testRun : testRunReport.GetPassingTestRuns())
+                {
+                    SerializeCompletedTestRun(testRun, writer);
+                }
+                writer.EndArray(); // Passing test runs
+
+                // Failing test runs
+                writer.Key("failing_test_runs");
+                writer.StartArray();
+                for (const auto& testRun : testRunReport.GetFailingTestRuns())
+                {
+                    SerializeCompletedTestRun(testRun, writer);
+                }
+                writer.EndArray(); // Failing test runs
+
+                // Execution failures
+                writer.Key("execution_failure_test_runs");
+                writer.StartArray();
+                for (const auto& testRun : testRunReport.GetExecutionFailureTestRuns())
+                {
+                    SerializeTestRun(testRun, writer);
+                }
+                writer.EndArray(); // Execution failures
+
+                // Timed out test runs
+                writer.Key("timed_out_test_runs");
+                writer.StartArray();
+                for (const auto& testRun : testRunReport.GetTimedOutTestRuns())
+                {
+                    SerializeTestRun(testRun, writer);
+                }
+                writer.EndArray(); // Timed out test runs
+
+                // Unexecuted test runs
+                writer.Key("unexecuted_test_runs");
+                writer.StartArray();
+                for (const auto& testRun : testRunReport.GetUnexecutedTestRuns())
+                {
+                    SerializeTestRun(testRun, writer);
+                }
+                writer.EndArray(); // Unexecuted test runs
+
+                // Number of passing tests
+                writer.Key("total_num_passing_tests");
+                writer.Uint64(testRunReport.GetTotalNumPassingTests());
+
+                // Number of failing tests
+                writer.Key("total_num_failing_tests");
+                writer.Uint64(testRunReport.GetTotalNumFailingTests());
+
+                // Number of disabled tests
+                writer.Key("total_num_disabled_tests");
+                writer.Uint64(testRunReport.GetTotalNumDisabledTests());
+
+            writer.EndObject();
+        }
+
+        void SerializeTestSelection(
+            const Client::TestRunSelection& testSelection, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            writer.StartObject();
+
+                // Total number of test runs
+                writer.Key("total_num_test_runs");
+                writer.Uint64(testSelection.GetTotalNumTests());
+
+                // Number of included test runs
+                writer.Key("num_included_test_runs");
+                writer.Uint64(testSelection.GetNumIncludedTestRuns());
+
+                // Number of excluded test runs
+                writer.Key("num_excluded_test_runs");
+                writer.Uint64(testSelection.GetNumExcludedTestRuns());
+
+                // Included test runs
+                writer.Key("included_test_runs");
+                writer.StartArray();
+                for (const auto& testRun : testSelection.GetIncludededTestRuns())
+                {
+                    writer.String(testRun.c_str());
+                }
+                writer.EndArray(); // Included test runs
+
+                // Excluded test runs
+                writer.Key("excluded_test_runs");
+                writer.StartArray();
+                for (const auto& testRun : testSelection.GetExcludedTestRuns())
+                {
+                    writer.String(testRun.c_str());
+                }
+                writer.EndArray(); // Excluded test runs
+
+            writer.EndObject();
+        }
+
+        void SerializePolicyStateBaseMembers(const PolicyStateBase& policyState, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            // Execution failure
+            writer.Key("execution_failure");
+            writer.String(ExecutionFailurePolicyAsString(policyState.m_executionFailurePolicy).c_str());
+            
+            // Failed test coverage
+            writer.Key("coverage_failure");
+            writer.String(FailedTestCoveragePolicyAsString(policyState.m_failedTestCoveragePolicy).c_str());
+            
+            // Test failure
+            writer.Key("test_failure");
+            writer.String(TestFailurePolicyAsString(policyState.m_testFailurePolicy).c_str());
+            
+            // Integrity failure
+            writer.Key("integrity_failure");
+            writer.String(IntegrityFailurePolicyAsString(policyState.m_integrityFailurePolicy).c_str());
+            
+            // Test sharding
+            writer.Key("test_sharding");
+            writer.String(TestShardingPolicyAsString(policyState.m_testShardingPolicy).c_str());
+            
+            // Target output capture
+            writer.Key("target_output_capture");
+            writer.String(TargetOutputCapturePolicyAsString(policyState.m_targetOutputCapture).c_str());
+        }
+
+        void SerializePolicyStateMembers(
+            const SequencePolicyState& policyState, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            SerializePolicyStateBaseMembers(policyState.m_basePolicies, writer);
+        }
+
+        void SerializePolicyStateMembers(
+            const SafeImpactAnalysisSequencePolicyState& policyState, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            SerializePolicyStateBaseMembers(policyState.m_basePolicies, writer);
+
+            // Test prioritization
+            writer.Key("test_prioritization");
+            writer.String(TestPrioritizationPolicyAsString(policyState.m_testPrioritizationPolicy).c_str());
+        }
+
+        void SerializePolicyStateMembers(
+            const ImpactAnalysisSequencePolicyState& policyState, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            SerializePolicyStateBaseMembers(policyState.m_basePolicies, writer);
+
+            // Test prioritization
+            writer.Key("test_prioritization");
+            writer.String(TestPrioritizationPolicyAsString(policyState.m_testPrioritizationPolicy).c_str());
+
+            // Dynamic dependency map
+            writer.Key("dynamic_dependency_map");
+            writer.String(DynamicDependencyMapPolicyAsString(policyState.m_dynamicDependencyMap).c_str());
+        }
+
+        template<typename PolicyStateType>
+        void SerializeSequenceReportBaseMembers(
+            const Client::SequenceReportBase<PolicyStateType>& sequenceReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            // Type
+            writer.Key("type");
+            writer.String(SequenceReportTypeAsString(sequenceReport.GetType()).c_str());
+
+            // Test target timeout
+            writer.Key("test_target_timeout");
+            writer.Uint64(sequenceReport.GetTestTargetTimeout().value_or(AZStd::chrono::milliseconds{0}).count());
+
+            // Global timeout
+            writer.Key("global_timeout");
+            writer.Uint64(sequenceReport.GetGlobalTimeout().value_or(AZStd::chrono::milliseconds{ 0 }).count());
+
+            // Maximum concurrency
+            writer.Key("max_concurrency");
+            writer.Uint64(sequenceReport.GetMaxConcurrency());
+
+            // Policies
+            writer.Key("policy");
+            writer.StartObject();
+                SerializePolicyStateMembers(sequenceReport.GetPolicyState(), writer);
+            writer.EndObject(); // Policies
+
+            // Suite
+            writer.Key("suite");
+            writer.String(SuiteTypeAsString(sequenceReport.GetSuite()).c_str());
+
+            // Selected test runs
+            writer.Key("selected_test_runs");
+            SerializeTestSelection(sequenceReport.GetSelectedTestRuns(), writer);
+
+            // Selected test run report
+            writer.Key("selected_test_run_report");
+            SerializeTestRunReport(sequenceReport.GetSelectedTestRunReport(), writer);
+
+            // Start time
+            writer.Key("start_time");
+            writer.Int64(TimePointInMsAsInt64(sequenceReport.GetStartTime()));
+
+            // End time
+            writer.Key("end_time");
+            writer.Int64(TimePointInMsAsInt64(sequenceReport.GetEndTime()));
+
+            // Duration
+            writer.Key("duration");
+            writer.Uint64(sequenceReport.GetDuration().count());
+
+            // Result
+            writer.Key("result");
+            writer.String(TestSequenceResultAsString(sequenceReport.GetResult()).c_str());
+
+            // Total number of test runs
+            writer.Key("total_num_test_runs");
+            writer.Uint64(sequenceReport.GetTotalNumTestRuns());
+
+            // Total number of passing test runs
+            writer.Key("total_num_passing_test_runs");
+            writer.Uint64(sequenceReport.GetTotalNumPassingTestRuns());
+
+            // Total number of failing test runs
+            writer.Key("total_num_failing_test_runs");
+            writer.Uint64(sequenceReport.GetTotalNumFailingTestRuns());
+
+            // Total number of test runs that failed to execute
+            writer.Key("total_num_execution_failure_test_runs");
+            writer.Uint64(sequenceReport.GetTotalNumExecutionFailureTestRuns());
+
+            // Total number of timed out test runs
+            writer.Key("total_num_timed_out_test_runs");
+            writer.Uint64(sequenceReport.GetTotalNumTimedOutTestRuns());
+
+            // Total number of unexecuted test runs
+            writer.Key("total_num_unexecuted_test_runs");
+            writer.Uint64(sequenceReport.GetTotalNumUnexecutedTestRuns());
+
+            // Total number of passing tests
+            writer.Key("total_num_passing_tests");
+            writer.Uint64(sequenceReport.GetTotalNumPassingTests());
+
+            // Total number of failing tests
+            writer.Key("total_num_failing_tests");
+            writer.Uint64(sequenceReport.GetTotalNumFailingTests());
+
+             // Total number of disabled tests
+            writer.Key("total_num_disabled_tests");
+            writer.Uint64(sequenceReport.GetTotalNumDisabledTests());
+        }
+
+        template<typename PolicyStateType>
+        void SerializeDraftingSequenceReportMembers(
+            const Client::DraftingSequenceReportBase<PolicyStateType>& sequenceReport, rapidjson::PrettyWriter<rapidjson::StringBuffer>& writer)
+        {
+            SerializeSequenceReportBaseMembers(sequenceReport, writer);
+
+            // Drafted test runs
+            writer.Key("drafted_test_runs");
+            writer.StartArray();
+            for (const auto& testRun : sequenceReport.GetDraftedTestRuns())
+            {
+                writer.String(testRun.c_str());
+            }
+            writer.EndArray(); // Drafted test runs
+
+            // Drafted test run report
+            writer.Key("drafted_test_run_report");
+            SerializeTestRunReport(sequenceReport.GetDraftedTestRunReport(), writer);
+        }
+    }
+
+    AZStd::string SerializeSequenceReport(const Client::RegularSequenceReport& sequenceReport)
+    {
+        rapidjson::StringBuffer stringBuffer;
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(stringBuffer);
+
+        writer.StartObject();
+        SerializeSequenceReportBaseMembers(sequenceReport, writer);
+        writer.EndObject();
+
+        return stringBuffer.GetString();
+    }
+
+    AZStd::string SerializeSequenceReport(const Client::SeedSequenceReport& sequenceReport)
+    {
+        rapidjson::StringBuffer stringBuffer;
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(stringBuffer);
+
+        writer.StartObject();
+            SerializeSequenceReportBaseMembers(sequenceReport, writer);
+        writer.EndObject();
+
+        return stringBuffer.GetString();
+    }
+
+    AZStd::string SerializeSequenceReport(const Client::ImpactAnalysisSequenceReport& sequenceReport)
+    {
+        rapidjson::StringBuffer stringBuffer;
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(stringBuffer);
+
+        writer.StartObject();
+            SerializeDraftingSequenceReportMembers(sequenceReport, writer);
+
+            // Discarded test runs
+            writer.Key("discarded_test_runs");
+            writer.StartArray();
+            for (const auto& testRun : sequenceReport.GetDiscardedTestRuns())
+            {
+                writer.String(testRun.c_str());
+            }
+            writer.EndArray(); // Discarded test runs
+
+        writer.EndObject();
+
+        return stringBuffer.GetString();
+    }
+
+    AZStd::string SerializeSequenceReport(const Client::SafeImpactAnalysisSequenceReport& sequenceReport)
+    {
+        rapidjson::StringBuffer stringBuffer;
+        rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(stringBuffer);
+
+        writer.StartObject();
+            SerializeDraftingSequenceReportMembers(sequenceReport, writer);
+
+            // Discarded test runs
+            writer.Key("discarded_test_runs");
+            SerializeTestSelection(sequenceReport.GetDiscardedTestRuns(), writer);
+
+            // Discarded test run report
+            writer.Key("discarded_test_run_report");
+            SerializeTestRunReport(sequenceReport.GetDiscardedTestRunReport(), writer);
+
+        writer.EndObject();
+
+        return stringBuffer.GetString();
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientTestRun.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientTestRun.cpp
@@ -14,7 +14,7 @@ namespace TestImpact
 {
     namespace Client
     {
-        TestRun::TestRun(
+        TestRunBase::TestRunBase(
             const AZStd::string& name,
             const AZStd::string& commandString,
             AZStd::chrono::high_resolution_clock::time_point startTime,
@@ -28,48 +28,48 @@ namespace TestImpact
         {
         }
 
-        const AZStd::string& TestRun::GetTargetName() const
+        const AZStd::string& TestRunBase::GetTargetName() const
         {
             return m_targetName;
         }
 
-        const AZStd::string& TestRun::GetCommandString() const
+        const AZStd::string& TestRunBase::GetCommandString() const
         {
             return m_commandString;
         }
 
-        AZStd::chrono::high_resolution_clock::time_point TestRun::GetStartTime() const
+        AZStd::chrono::high_resolution_clock::time_point TestRunBase::GetStartTime() const
         {
             return m_startTime;
         }
 
-        AZStd::chrono::high_resolution_clock::time_point TestRun::GetEndTime() const
+        AZStd::chrono::high_resolution_clock::time_point TestRunBase::GetEndTime() const
         {
             return m_startTime + m_duration;
         }
 
-        AZStd::chrono::milliseconds TestRun::GetDuration() const
+        AZStd::chrono::milliseconds TestRunBase::GetDuration() const
         {
             return m_duration;
         }
 
-        TestRunResult TestRun::GetResult() const
+        TestRunResult TestRunBase::GetResult() const
         {
             return m_result;
         }
 
-        TestRunWithExecutonFailure::TestRunWithExecutonFailure(TestRun&& testRun)
-            : TestRun(AZStd::move(testRun))
+        TestRunWithExecutionFailure::TestRunWithExecutionFailure(TestRunBase&& testRun)
+            : TestRunBase(AZStd::move(testRun))
         {
         }
 
-        TimedOutTestRun::TimedOutTestRun(TestRun&& testRun)
-            : TestRun(AZStd::move(testRun))
+        TimedOutTestRun::TimedOutTestRun(TestRunBase&& testRun)
+            : TestRunBase(AZStd::move(testRun))
         {
         }
 
-        UnexecutedTestRun::UnexecutedTestRun(TestRun&& testRun)
-            : TestRun(AZStd::move(testRun))
+        UnexecutedTestRun::UnexecutedTestRun(TestRunBase&& testRun)
+            : TestRunBase(AZStd::move(testRun))
         {
         }
 
@@ -121,14 +121,14 @@ namespace TestImpact
             AZStd::chrono::milliseconds duration,
             TestRunResult result,
             AZStd::vector<Test>&& tests)
-            : TestRun(name, commandString, startTime, duration, result)
+            : TestRunBase(name, commandString, startTime, duration, result)
             , m_tests(AZStd::move(tests))
         {
             AZStd::tie(m_totalNumPassingTests, m_totalNumFailingTests, m_totalNumDisabledTests) = CalculateNumPassingAndFailingTestCases(m_tests);
         }
 
-        CompletedTestRun::CompletedTestRun(TestRun&& testRun, AZStd::vector<Test>&& tests)
-            : TestRun(AZStd::move(testRun))
+        CompletedTestRun::CompletedTestRun(TestRunBase&& testRun, AZStd::vector<Test>&& tests)
+            : TestRunBase(AZStd::move(testRun))
             , m_tests(AZStd::move(tests))
         {
             AZStd::tie(m_totalNumPassingTests, m_totalNumFailingTests, m_totalNumDisabledTests) = CalculateNumPassingAndFailingTestCases(m_tests);
@@ -157,6 +157,16 @@ namespace TestImpact
         const AZStd::vector<Test>& CompletedTestRun::GetTests() const
         {
             return m_tests;
+        }
+
+        PassingTestRun::PassingTestRun(TestRunBase&& testRun, AZStd::vector<Test>&& tests)
+            : CompletedTestRun(AZStd::move(testRun), AZStd::move(tests))
+        {
+        }
+
+        FailingTestRun::FailingTestRun(TestRunBase&& testRun, AZStd::vector<Test>&& tests)
+            : CompletedTestRun(AZStd::move(testRun), AZStd::move(tests))
+        {
         }
     } // namespace Client
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientTestRun.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactClientTestRun.cpp
@@ -89,7 +89,7 @@ namespace TestImpact
             return m_result;
         }
 
-        AZStd::tuple<size_t, size_t, size_t> CalculateNumPassingAndFailingTestCases(const AZStd::vector<Test>& tests)
+        AZStd::tuple<size_t, size_t, size_t> CalculateTestCaseMetrics(const AZStd::vector<Test>& tests)
         {
             size_t totalNumPassingTests = 0;
             size_t totalNumFailingTests = 0;
@@ -124,14 +124,14 @@ namespace TestImpact
             : TestRunBase(name, commandString, startTime, duration, result)
             , m_tests(AZStd::move(tests))
         {
-            AZStd::tie(m_totalNumPassingTests, m_totalNumFailingTests, m_totalNumDisabledTests) = CalculateNumPassingAndFailingTestCases(m_tests);
+            AZStd::tie(m_totalNumPassingTests, m_totalNumFailingTests, m_totalNumDisabledTests) = CalculateTestCaseMetrics(m_tests);
         }
 
         CompletedTestRun::CompletedTestRun(TestRunBase&& testRun, AZStd::vector<Test>&& tests)
             : TestRunBase(AZStd::move(testRun))
             , m_tests(AZStd::move(tests))
         {
-            AZStd::tie(m_totalNumPassingTests, m_totalNumFailingTests, m_totalNumDisabledTests) = CalculateNumPassingAndFailingTestCases(m_tests);
+            AZStd::tie(m_totalNumPassingTests, m_totalNumFailingTests, m_totalNumDisabledTests) = CalculateTestCaseMetrics(m_tests);
         }
 
         size_t CompletedTestRun::GetTotalNumTests() const

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -110,7 +110,7 @@ namespace TestImpact
         return result;
     }
 
-    //!
+    //! Utility structure for holding the pertinent data for test run reports.
     template<typename TestJob>
     struct TestRunData
     {

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -285,15 +285,15 @@ namespace TestImpact
         {
             if (dataFile.has_value())
             {
-                m_sparTIAFile = dataFile.value().String();
+                m_sparTiaFile = dataFile.value().String();
             }
             else
             {
-                m_sparTIAFile = m_config.m_workspace.m_active.m_sparTIAFiles[static_cast<size_t>(m_suiteFilter)].String();
+                m_sparTiaFile = m_config.m_workspace.m_active.m_sparTiaFiles[static_cast<size_t>(m_suiteFilter)].String();
             }
            
             // Populate the dynamic dependency map with the existing source coverage data (if any)
-            const auto tiaDataRaw = ReadFileContents<Exception>(m_sparTIAFile);
+            const auto tiaDataRaw = ReadFileContents<Exception>(m_sparTiaFile);
             const auto tiaData = DeserializeSourceCoveringTestsList(tiaDataRaw);
             if (tiaData.GetNumSources())
             {
@@ -313,7 +313,7 @@ namespace TestImpact
             AZ_Printf(
                 LogCallSite,
                 AZStd::string::format(
-                    "No test impact analysis data found for suite '%s' at %s\n", SuiteTypeAsString(m_suiteFilter).c_str(), m_sparTIAFile.c_str()).c_str());
+                    "No test impact analysis data found for suite '%s' at %s\n", SuiteTypeAsString(m_suiteFilter).c_str(), m_sparTiaFile.c_str()).c_str());
         }
     }
 
@@ -411,7 +411,7 @@ namespace TestImpact
     void Runtime::ClearDynamicDependencyMapAndRemoveExistingFile()
     {
         m_dynamicDependencyMap->ClearAllSourceCoverage();
-        DeleteFile(m_sparTIAFile);
+        DeleteFile(m_sparTiaFile);
     }
 
     SourceCoveringTestsList Runtime::CreateSourceCoveringTestFromTestCoverages(const AZStd::vector<TestEngineInstrumentedRun>& jobs)
@@ -492,9 +492,9 @@ namespace TestImpact
             }
 
             m_dynamicDependencyMap->ReplaceSourceCoverage(sourceCoverageTestsList);
-            const auto sparTIA = m_dynamicDependencyMap->ExportSourceCoverage();
-            const auto sparTIAData = SerializeSourceCoveringTestsList(sparTIA);
-            WriteFileContents<RuntimeException>(sparTIAData, m_sparTIAFile);
+            const auto sparTia = m_dynamicDependencyMap->ExportSourceCoverage();
+            const auto sparTiaData = SerializeSourceCoveringTestsList(sparTia);
+            WriteFileContents<RuntimeException>(sparTiaData, m_sparTiaFile);
             m_hasImpactAnalysisData = true;
         }
         catch(const RuntimeException& e)
@@ -510,7 +510,7 @@ namespace TestImpact
         }
     }
 
-    PolicyStateBase Runtime::GeneratePolicyStateBase()
+    PolicyStateBase Runtime::GeneratePolicyStateBase() const
     {
         PolicyStateBase policyState;
 
@@ -524,19 +524,19 @@ namespace TestImpact
         return policyState;
     }
 
-    SequencePolicyState Runtime::GenerateSequencePolicyState()
+    SequencePolicyState Runtime::GenerateSequencePolicyState() const
     {
         return { GeneratePolicyStateBase() };
     }
 
     SafeImpactAnalysisSequencePolicyState Runtime::GenerateSafeImpactAnalysisSequencePolicyState(
-        Policy::TestPrioritization testPrioritizationPolicy)
+        Policy::TestPrioritization testPrioritizationPolicy) const
     {
         return { GeneratePolicyStateBase(), testPrioritizationPolicy };
     }
 
     ImpactAnalysisSequencePolicyState Runtime::GenerateImpactAnalysisSequencePolicyState(
-        Policy::TestPrioritization testPrioritizationPolicy, Policy::DynamicDependencyMap dynamicDependencyMapPolicy)
+        Policy::TestPrioritization testPrioritizationPolicy, Policy::DynamicDependencyMap dynamicDependencyMapPolicy) const
     {
         return { GeneratePolicyStateBase(), testPrioritizationPolicy, dynamicDependencyMapPolicy };
     }
@@ -805,7 +805,7 @@ namespace TestImpact
                 AZStd::ref(testRunCompleteHandler));
         };
 
-        //
+        // Functor for running instrumented test targets
         const auto gatherTestRunData = [&sequenceTimer]
         (const AZStd::vector<const TestTarget*>& testsTargets, const auto& testRunner, auto& testRunData)
         {

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -774,7 +774,7 @@ namespace TestImpact
         const size_t totalNumTestRuns = includedSelectedTestTargets.size() + draftedTestTargets.size() + includedDiscardedTestTargets.size();
         TestRunCompleteCallbackHandler testRunCompleteHandler(totalNumTestRuns, testCompleteCallback);
         
-		// Functor for running instrumented test targets
+        // Functor for running instrumented test targets
         const auto instrumentedTestRun =
             [this, &testTargetTimeout, &sequenceTimeout, &testRunCompleteHandler](const AZStd::vector<const TestTarget*>& testsTargets)
         {

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntime.cpp
@@ -81,7 +81,7 @@ namespace TestImpact
             {
                 if (m_testCompleteCallback.has_value())
                 {
-                    Client::TestRun testRun(
+                    Client::TestRunBase testRun(
                         testJob.GetTestTarget()->GetName(),
                         testJob.GetCommandString(),
                         testJob.GetStartTime(),

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.cpp
@@ -6,7 +6,7 @@
  *
  */
 
-#include <TestImpactFramework/TestImpactFileUtils.h>
+#include <TestImpactFramework/TestImpactUtils.h>
 #include <TestImpactFramework/TestImpactRuntimeException.h>
 
 #include <TestImpactRuntimeUtils.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactRuntimeUtils.h
@@ -85,9 +85,9 @@ namespace TestImpact
         AZStd::chrono::milliseconds duration,
         const AZStd::vector<TestJob>& testJobs)
     {
-        AZStd::vector<Client::CompletedTestRun> passingTests;
-        AZStd::vector<Client::CompletedTestRun> failingTests;
-        AZStd::vector<Client::TestRunWithExecutonFailure> executionFailureTests;
+        AZStd::vector<Client::PassingTestRun> passingTests;
+        AZStd::vector<Client::FailingTestRun> failingTests;
+        AZStd::vector<Client::TestRunWithExecutionFailure> executionFailureTests;
         AZStd::vector<Client::TimedOutTestRun> timedOutTests;
         AZStd::vector<Client::UnexecutedTestRun> unexecutedTests;
         
@@ -98,7 +98,7 @@ namespace TestImpact
                 AZStd::chrono::high_resolution_clock::time_point() +
                 AZStd::chrono::duration_cast<AZStd::chrono::milliseconds>(testJob.GetStartTime() - startTime);
 
-            Client::TestRun clientTestRun(
+            Client::TestRunBase clientTestRun(
                 testJob.GetTestTarget()->GetName(), testJob.GetCommandString(), relativeStartTime, testJob.GetDuration(),
                 testJob.GetTestResult());
 

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactUtils.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
+ * this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <TestImpactFramework/TestImpactException.h>
+#include <TestImpactFramework/TestImpactUtils.h>
+
+#include <AzCore/std/functional.h>
+
+namespace TestImpact
+{
+    //! Delete the files that match the pattern from the specified directory.
+    //! @param path The path to the directory to pattern match the files for deletion.
+    //! @param pattern The pattern to match files for deletion.
+    void DeleteFiles(const RepoPath& path, const AZStd::string& pattern)
+    {
+        AZ::IO::SystemFile::FindFiles(
+            AZStd::string::format("%s/%s", path.c_str(), pattern.c_str()).c_str(),
+            [&path](const char* file, bool isFile)
+            {
+                if (isFile)
+                {
+                    AZ::IO::SystemFile::Delete(AZStd::string::format("%s/%s", path.c_str(), file).c_str());
+                }
+
+                return true;
+            });
+    }
+
+    //! Deletes the specified file.
+    void DeleteFile(const RepoPath& file)
+    {
+        DeleteFiles(file.ParentPath(), file.Filename().Native());
+    }
+
+    //! User-friendly names for the test suite types.
+    AZStd::string SuiteTypeAsString(SuiteType suiteType)
+    {
+        switch (suiteType)
+        {
+        case SuiteType::Main:
+            return "main";
+        case SuiteType::Periodic:
+            return "periodic";
+        case SuiteType::Sandbox:
+            return "sandbox";
+        default:
+            throw(Exception("Unexpected suite type"));
+        }
+    }
+
+    AZStd::string SequenceReportTypeAsString(Client::SequenceReportType type)
+    {
+        switch (type)
+        {
+        case Client::SequenceReportType::RegularSequence:
+            return "regular";
+
+        case Client::SequenceReportType::SeedSequence:
+            return "seed";
+
+        case Client::SequenceReportType::ImpactAnalysisSequence:
+            return "impact_analysis";
+
+        case Client::SequenceReportType::SafeImpactAnalysisSequence:
+            return "safe_impact_analysis";
+
+        default:
+            throw(Exception(AZStd::string::format("Unexpected sequence report type: %u", aznumeric_cast<AZ::u32>(type))));
+        }
+    }
+
+    AZStd::string TestSequenceResultAsString(TestSequenceResult result)
+    {
+        switch (result)
+        {
+        case TestSequenceResult::Failure:
+            return "failure";
+
+        case TestSequenceResult::Success:
+            return "success";
+
+        case TestSequenceResult::Timeout:
+            return "timeout";
+
+        default:
+            throw(Exception(AZStd::string::format("Unexpected test sequence result: %u", aznumeric_cast<AZ::u32>(result))));
+        }
+    }
+
+    AZStd::string TestRunResultAsString(Client::TestRunResult result)
+    {
+        switch (result)
+        {
+        case Client::TestRunResult::AllTestsPass:
+            return "all_tests_pass";
+
+        case Client::TestRunResult::FailedToExecute:
+            return "failed_to_execute";
+
+        case Client::TestRunResult::NotRun:
+            return "not_run";
+
+        case Client::TestRunResult::TestFailures:
+            return "test_failures";
+
+        case Client::TestRunResult::Timeout:
+            return "timeout";
+
+        default:
+            throw(Exception(AZStd::string::format("Unexpected test run result: %u", aznumeric_cast<AZ::u32>(result))));
+        }
+    }
+
+    AZStd::string ExecutionFailurePolicyAsString(Policy::ExecutionFailure executionFailurePolicy)
+    {
+        switch (executionFailurePolicy)
+        {
+        case Policy::ExecutionFailure::Abort:
+            return "abort";
+
+        case Policy::ExecutionFailure::Continue:
+            return "continue";
+
+        case Policy::ExecutionFailure::Ignore:
+            return "ignore";
+
+        default:
+            throw(Exception(
+                AZStd::string::format("Unexpected execution failure policy: %u", aznumeric_cast<AZ::u32>(executionFailurePolicy))));
+        }
+    }
+
+    AZStd::string FailedTestCoveragePolicyAsString(Policy::FailedTestCoverage failedTestCoveragePolicy)
+    {
+        switch (failedTestCoveragePolicy)
+        {
+        case Policy::FailedTestCoverage::Discard:
+            return "discard";
+
+        case Policy::FailedTestCoverage::Keep:
+            return "keep";
+
+        default:
+            throw(Exception(
+                AZStd::string::format("Unexpected failed test coverage policy: %u", aznumeric_cast<AZ::u32>(failedTestCoveragePolicy))));
+        }
+    }
+
+    AZStd::string TestPrioritizationPolicyAsString(Policy::TestPrioritization testPrioritizationPolicy)
+    {
+        switch (testPrioritizationPolicy)
+        {
+        case Policy::TestPrioritization::DependencyLocality:
+            return "dependency_locality";
+
+        case Policy::TestPrioritization::None:
+            return "none";
+
+        default:
+            throw(Exception(
+                AZStd::string::format("Unexpected test prioritization policy: %u", aznumeric_cast<AZ::u32>(testPrioritizationPolicy))));
+        }
+    }
+
+    AZStd::string TestFailurePolicyAsString(Policy::TestFailure testFailurePolicy)
+    {
+        switch (testFailurePolicy)
+        {
+        case Policy::TestFailure::Abort:
+            return "abort";
+
+        case Policy::TestFailure::Continue:
+            return "continue";
+
+        default:
+            throw(
+                Exception(AZStd::string::format("Unexpected test failure policy: %u", aznumeric_cast<AZ::u32>(testFailurePolicy))));
+        }
+    }
+
+    AZStd::string IntegrityFailurePolicyAsString(Policy::IntegrityFailure integrityFailurePolicy)
+    {
+        switch (integrityFailurePolicy)
+        {
+        case Policy::IntegrityFailure::Abort:
+            return "abort";
+
+        case Policy::IntegrityFailure::Continue:
+            return "continue";
+
+        default:
+            throw(Exception(
+                AZStd::string::format("Unexpected integration failure policy: %u", aznumeric_cast<AZ::u32>(integrityFailurePolicy))));
+        }
+    }
+
+    AZStd::string DynamicDependencyMapPolicyAsString(Policy::DynamicDependencyMap dynamicDependencyMapPolicy)
+    {
+        switch (dynamicDependencyMapPolicy)
+        {
+        case Policy::DynamicDependencyMap::Discard:
+            return "discard";
+
+        case Policy::DynamicDependencyMap::Update:
+            return "update";
+
+        default:
+            throw(Exception(AZStd::string::format(
+                "Unexpected dynamic dependency map policy: %u", aznumeric_cast<AZ::u32>(dynamicDependencyMapPolicy))));
+        }
+    }
+
+    AZStd::string TestShardingPolicyAsString(Policy::TestSharding testShardingPolicy)
+    {
+        switch (testShardingPolicy)
+        {
+        case Policy::TestSharding::Always:
+            return "always";
+
+        case Policy::TestSharding::Never:
+            return "never";
+
+        default:
+            throw(Exception(
+                AZStd::string::format("Unexpected test sharding policy: %u", aznumeric_cast<AZ::u32>(testShardingPolicy))));
+        }
+    }
+
+    AZStd::string TargetOutputCapturePolicyAsString(Policy::TargetOutputCapture targetOutputCapturePolicy)
+    {
+        switch (targetOutputCapturePolicy)
+        {
+        case Policy::TargetOutputCapture::File:
+            return "file";
+
+        case Policy::TargetOutputCapture::None:
+            return "none";
+
+        case Policy::TargetOutputCapture::StdOut:
+            return "stdout";
+
+        case Policy::TargetOutputCapture::StdOutAndFile:
+            return "stdout_file";
+
+        default:
+            throw(Exception(
+                AZStd::string::format("Unexpected target output capture policy: %u", aznumeric_cast<AZ::u32>(targetOutputCapturePolicy))));
+        }
+    }
+
+    AZStd::string ClientTestResultAsString(Client::TestResult result)
+    {
+        switch (result)
+        {
+        case Client::TestResult::Failed:
+            return "failed";
+
+        case Client::TestResult::NotRun:
+            return "not_run";
+
+        case Client::TestResult::Passed:
+            return "passed";
+
+        default:
+            throw(Exception(AZStd::string::format("Unexpected client test case result: %u", aznumeric_cast<AZ::u32>(result))));
+        }
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactUtils.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
- * this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/Source/TestImpactUtils.cpp
@@ -16,19 +16,24 @@ namespace TestImpact
     //! Delete the files that match the pattern from the specified directory.
     //! @param path The path to the directory to pattern match the files for deletion.
     //! @param pattern The pattern to match files for deletion.
-    void DeleteFiles(const RepoPath& path, const AZStd::string& pattern)
+    size_t DeleteFiles(const RepoPath& path, const AZStd::string& pattern)
     {
+        size_t numFilesDeleted = 0;
+
         AZ::IO::SystemFile::FindFiles(
             AZStd::string::format("%s/%s", path.c_str(), pattern.c_str()).c_str(),
-            [&path](const char* file, bool isFile)
+            [&path, &numFilesDeleted](const char* file, bool isFile)
             {
                 if (isFile)
                 {
                     AZ::IO::SystemFile::Delete(AZStd::string::format("%s/%s", path.c_str(), file).c_str());
+                    numFilesDeleted++;
                 }
 
                 return true;
             });
+
+        return numFilesDeleted;
     }
 
     //! Deletes the specified file.
@@ -59,16 +64,12 @@ namespace TestImpact
         {
         case Client::SequenceReportType::RegularSequence:
             return "regular";
-
         case Client::SequenceReportType::SeedSequence:
             return "seed";
-
         case Client::SequenceReportType::ImpactAnalysisSequence:
             return "impact_analysis";
-
         case Client::SequenceReportType::SafeImpactAnalysisSequence:
             return "safe_impact_analysis";
-
         default:
             throw(Exception(AZStd::string::format("Unexpected sequence report type: %u", aznumeric_cast<AZ::u32>(type))));
         }
@@ -80,13 +81,10 @@ namespace TestImpact
         {
         case TestSequenceResult::Failure:
             return "failure";
-
         case TestSequenceResult::Success:
             return "success";
-
         case TestSequenceResult::Timeout:
             return "timeout";
-
         default:
             throw(Exception(AZStd::string::format("Unexpected test sequence result: %u", aznumeric_cast<AZ::u32>(result))));
         }
@@ -98,19 +96,14 @@ namespace TestImpact
         {
         case Client::TestRunResult::AllTestsPass:
             return "all_tests_pass";
-
         case Client::TestRunResult::FailedToExecute:
             return "failed_to_execute";
-
         case Client::TestRunResult::NotRun:
             return "not_run";
-
         case Client::TestRunResult::TestFailures:
             return "test_failures";
-
         case Client::TestRunResult::Timeout:
             return "timeout";
-
         default:
             throw(Exception(AZStd::string::format("Unexpected test run result: %u", aznumeric_cast<AZ::u32>(result))));
         }
@@ -122,13 +115,10 @@ namespace TestImpact
         {
         case Policy::ExecutionFailure::Abort:
             return "abort";
-
         case Policy::ExecutionFailure::Continue:
             return "continue";
-
         case Policy::ExecutionFailure::Ignore:
             return "ignore";
-
         default:
             throw(Exception(
                 AZStd::string::format("Unexpected execution failure policy: %u", aznumeric_cast<AZ::u32>(executionFailurePolicy))));
@@ -141,10 +131,8 @@ namespace TestImpact
         {
         case Policy::FailedTestCoverage::Discard:
             return "discard";
-
         case Policy::FailedTestCoverage::Keep:
             return "keep";
-
         default:
             throw(Exception(
                 AZStd::string::format("Unexpected failed test coverage policy: %u", aznumeric_cast<AZ::u32>(failedTestCoveragePolicy))));
@@ -157,10 +145,8 @@ namespace TestImpact
         {
         case Policy::TestPrioritization::DependencyLocality:
             return "dependency_locality";
-
         case Policy::TestPrioritization::None:
             return "none";
-
         default:
             throw(Exception(
                 AZStd::string::format("Unexpected test prioritization policy: %u", aznumeric_cast<AZ::u32>(testPrioritizationPolicy))));
@@ -173,10 +159,8 @@ namespace TestImpact
         {
         case Policy::TestFailure::Abort:
             return "abort";
-
         case Policy::TestFailure::Continue:
             return "continue";
-
         default:
             throw(
                 Exception(AZStd::string::format("Unexpected test failure policy: %u", aznumeric_cast<AZ::u32>(testFailurePolicy))));
@@ -189,10 +173,8 @@ namespace TestImpact
         {
         case Policy::IntegrityFailure::Abort:
             return "abort";
-
         case Policy::IntegrityFailure::Continue:
             return "continue";
-
         default:
             throw(Exception(
                 AZStd::string::format("Unexpected integration failure policy: %u", aznumeric_cast<AZ::u32>(integrityFailurePolicy))));
@@ -205,10 +187,8 @@ namespace TestImpact
         {
         case Policy::DynamicDependencyMap::Discard:
             return "discard";
-
         case Policy::DynamicDependencyMap::Update:
             return "update";
-
         default:
             throw(Exception(AZStd::string::format(
                 "Unexpected dynamic dependency map policy: %u", aznumeric_cast<AZ::u32>(dynamicDependencyMapPolicy))));
@@ -221,10 +201,8 @@ namespace TestImpact
         {
         case Policy::TestSharding::Always:
             return "always";
-
         case Policy::TestSharding::Never:
             return "never";
-
         default:
             throw(Exception(
                 AZStd::string::format("Unexpected test sharding policy: %u", aznumeric_cast<AZ::u32>(testShardingPolicy))));
@@ -237,16 +215,12 @@ namespace TestImpact
         {
         case Policy::TargetOutputCapture::File:
             return "file";
-
         case Policy::TargetOutputCapture::None:
             return "none";
-
         case Policy::TargetOutputCapture::StdOut:
             return "stdout";
-
         case Policy::TargetOutputCapture::StdOutAndFile:
             return "stdout_file";
-
         default:
             throw(Exception(
                 AZStd::string::format("Unexpected target output capture policy: %u", aznumeric_cast<AZ::u32>(targetOutputCapturePolicy))));
@@ -259,13 +233,10 @@ namespace TestImpact
         {
         case Client::TestResult::Failed:
             return "failed";
-
         case Client::TestResult::NotRun:
             return "not_run";
-
         case Client::TestResult::Passed:
             return "passed";
-
         default:
             throw(Exception(AZStd::string::format("Unexpected client test case result: %u", aznumeric_cast<AZ::u32>(result))));
         }

--- a/Code/Tools/TestImpactFramework/Runtime/Code/testimpactframework_runtime_files.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Code/testimpactframework_runtime_files.cmake
@@ -16,11 +16,14 @@ set(FILES
     Include/TestImpactFramework/TestImpactChangelist.h
     Include/TestImpactFramework/TestImpactChangelistSerializer.h
     Include/TestImpactFramework/TestImpactChangelistException.h
+    Include/TestImpactFramework/TestImpactPolicy.h
     Include/TestImpactFramework/TestImpactTestSequence.h
     Include/TestImpactFramework/TestImpactClientTestSelection.h
     Include/TestImpactFramework/TestImpactClientTestRun.h
     Include/TestImpactFramework/TestImpactClientSequenceReport.h
-    Include/TestImpactFramework/TestImpactFileUtils.h
+    Include/TestImpactFramework/TestImpactUtils.h
+    Include/TestImpactFramework/TestImpactClientSequenceReportSerializer.h
+    Include/TestImpactFramework/TestImpactSequenceReportException.h
     Source/Artifact/TestImpactArtifactException.h
     Source/Artifact/Factory/TestImpactBuildTargetDescriptorFactory.cpp
     Source/Artifact/Factory/TestImpactBuildTargetDescriptorFactory.h
@@ -125,5 +128,7 @@ set(FILES
     Source/TestImpactClientTestRun.cpp
     Source/TestImpactClientSequenceReport.cpp
     Source/TestImpactChangeListSerializer.cpp
+    Source/TestImpactClientSequenceReportSerializer.cpp
     Source/TestImpactRepoPath.cpp
+    Source/TestImpactUtils.cpp
 )


### PR DESCRIPTION
This PR implements the sources runtime-side of TIAF sequence reporting (the comprehensive reports on the results of test sequence runs) with the following key changes:

* The sequence reports now have serializers to allow the console front end to output JSON files for sequences for consumption of the job before transmitting to MARS.
* The client test run types are now full abstractions of the test targets used to run the tests (along with test reporting) to facilitate data gathering and diagnosis in MARS.
