### PR TITLE
Prefab dependency viewer now uses root template for child instances and asset rendering bug fix

### DIFF
--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/MetaData.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/MetaData.cpp
@@ -10,16 +10,10 @@
 
 namespace PrefabDependencyViewer::Utils
 {
-    PrefabMetaData::PrefabMetaData(TemplateId tid, AZStd::string source)
+    PrefabMetaData::PrefabMetaData(AZStd::string source)
         : MetaData()
-        , m_tid(tid)
         , m_source(AZStd::move(source))
     {
-    }
-
-    TemplateId PrefabMetaData::GetTemplateId() const
-    {
-        return m_tid;
     }
 
     AZStd::string_view PrefabMetaData::GetSource() const

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/MetaData.h
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/MetaData.h
@@ -35,7 +35,7 @@ namespace PrefabDependencyViewer::Utils
     {
     public:
         AZ_CLASS_ALLOCATOR(PrefabMetaData, AZ::SystemAllocator, 0);
-        PrefabMetaData(AZStd::string source);
+        explicit PrefabMetaData(AZStd::string source);
 
         AZStd::string_view GetSource() const;
         AZStd::string_view GetDisplayName() const override;

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/MetaData.h
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/MetaData.h
@@ -35,14 +35,12 @@ namespace PrefabDependencyViewer::Utils
     {
     public:
         AZ_CLASS_ALLOCATOR(PrefabMetaData, AZ::SystemAllocator, 0);
-        PrefabMetaData(TemplateId tid, AZStd::string source);
+        PrefabMetaData(AZStd::string source);
 
-        TemplateId GetTemplateId() const;
         AZStd::string_view GetSource() const;
         AZStd::string_view GetDisplayName() const override;
 
     private:
-        TemplateId m_tid;
         AZStd::string m_source;
     };
 

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/Node.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/Node.cpp
@@ -42,9 +42,9 @@ namespace PrefabDependencyViewer::Utils
         return m_children;
     }
 
-    /* static */ NodePtr Node::CreatePrefabNode(TemplateId tid, AZStd::string source, Node* parent)
+    /* static */ NodePtr Node::CreatePrefabNode(AZStd::string source, Node* parent)
     {
-        return AZStd::make_shared<Node>(aznew PrefabMetaData(tid, AZStd::move(source)), parent);
+        return AZStd::make_shared<Node>(aznew PrefabMetaData(AZStd::move(source)), parent);
     }
 
     /* static */ NodePtr Node::CreateAssetNode(AZStd::string source)

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/Node.h
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/Node.h
@@ -56,7 +56,7 @@ namespace PrefabDependencyViewer::Utils
 
         const ChildrenList& GetChildren() const;
 
-        static NodePtr CreatePrefabNode(TemplateId tid, AZStd::string source, Node* parent = nullptr);
+        static NodePtr CreatePrefabNode(AZStd::string source, Node* parent = nullptr);
         static NodePtr CreateAssetNode(AZStd::string source);
     private:
         AZStd::unique_ptr<MetaData> m_metaData;

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
@@ -56,8 +56,8 @@ namespace PrefabDependencyViewer
         auto&& source = sourceIterator->value;
         const char* sourceFileName = source.GetString();
 
-        // Create a new node for the current Template. (Use 0 as a placeholder for TemplateId for now)
-        NodePtr parent = Utils::Node::CreatePrefabNode(0, sourceFileName);
+        // Create a new node for the current Template.
+        NodePtr parent = Utils::Node::CreatePrefabNode(sourceFileName);
 
         // Go through current Template's nested instances.
         // Get and recurse on their PrefabDoms. If successful,

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.cpp
@@ -20,7 +20,7 @@ namespace PrefabDependencyViewer
         else
         {
             // Create a deep copy of the root Prefab Dom so the Template
-            // can be modified in the GenerateTreAndSetRootRecursive method.
+            // can be modified in the GenerateTreeAndSetRootRecursive method.
             PrefabDom rootPrefabDom;
             rootPrefabDom.CopyFrom(prefabSystemComponentInterface->FindTemplateDom(tid),
                                     rootPrefabDom.GetAllocator());

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
@@ -36,17 +36,17 @@ namespace PrefabDependencyViewer
     class PrefabDependencyTree : public Utils::DirectedTree
     {
     public:
-        static TreeOutcome GenerateTreeAndSetRoot(TemplateId tid, PrefabSystemComponentInterface* s_prefabSystemComponentInterface);
+        static TreeOutcome GenerateTreeAndSetRoot(TemplateId tid,
+                               PrefabSystemComponentInterface* s_prefabSystemComponentInterface);
 
     private:
-        static NodePtrOutcome GenerateTreeAndSetRootRecursive(
-            TemplateId templateId,
-            PrefabSystemComponentInterface* prefabSystemComponentInterface,
-            AssetDescriptionCountMap& count);
+        static NodePtrOutcome GenerateTreeAndSetRootRecursive(PrefabDom& prefabDom,
+                                                               AssetDescriptionCountMap& count);
 
         static AssetDescriptionCountMap GetAssetsDescriptionCountMap(AssetList allNestedAssets);
+
         static void AddAssetNodeToPrefab(const PrefabDom& prefabDom, NodePtr node,
-                                AssetDescriptionCountMap& assetDescriptionCountMap);
+                                            AssetDescriptionCountMap& assetDescriptionCountMap);
 
         static AssetList GetAssets(const PrefabDom& prefabDom);
     };

--- a/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
+++ b/Gems/Prefab/PrefabDependencyViewer/Code/Source/PrefabDependencyTree.h
@@ -49,7 +49,7 @@ namespace PrefabDependencyViewer
 
     private:
         static NodePtrOutcome GenerateTreeAndSetRootRecursive(const rapidjson::Value& prefabDom,
-                                                           AssetDescriptionCountMap& parentCount);
+                                                  AssetDescriptionCountMap& parentAssetCountMap);
 
         static AssetDescriptionCountMap GetAssetsDescriptionCountMap(AssetList allNestedAssets);
 
@@ -58,8 +58,8 @@ namespace PrefabDependencyViewer
 
         static AssetList GetAssets(const rapidjson::Value& prefabDom);
 
-        static void DecreaseParentAssetCount(AssetDescriptionCountMap& parentCount,
-                                        const AssetDescriptionCountMap& childCount);
+        static void DecreaseParentAssetCount(AssetDescriptionCountMap& parentAssetCountMap,
+                                        const AssetDescriptionCountMap& childAssetCountMap);
 
         static bool LoadInstanceFromPrefabDom(
             Instance& instance, const rapidjson::Value& prefabDom,


### PR DESCRIPTION
Before Prefab Dependency Viewer was using Prefab System Component Interface to get Template Id's using GetTemplateIdFromFilePath in order to be able to retrieve the child instance template later on.

The problem with this approach is asset changes from patches to the child instance will be lost. Also, it's inefficient to go to the PrefabSystemComponentInterface to ask for the TemplateId if we already have the whole Template.

Note there is some overhead associated with deep copying the root Prefab Dom but it guarantees correct functionality without disrupting the template system.

There was a bug with asset rendering where I was using global assetCount. The problem with this approach is that when 2 Prefabs A and B at different levels(one higher up in the tree and one lower) but with same asset type would decrease the count of the asset for the Prefab Node A as the parent of the Prefab B would claim that asset first.

To fix this issue, first decrease the Parent Prefab Asset Count with the child Prefab Asset Count and recurse on the child Prefab Asset count.

![prefabTemplateContainsAllTheData](https://user-images.githubusercontent.com/85369837/128761735-ff9c7207-489e-41a2-9297-3eff2a47d8a9.PNG)