### PR TITLE
Hair - PPLLIndexCounter buffer going data driven via the pass declarations

### DIFF
--- a/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassLibrary.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Public/Pass/PassLibrary.cpp
@@ -412,7 +412,7 @@ namespace AZ
                 {
                     RHI::Format format = slot.m_bufferViewDesc->m_elementFormat;
                     AZStd::string formatLocation = AZStd::string::format("BufferViewDescriptor on Slot [%s] in PassTemplate [%s]", slot.m_name.GetCStr(), passTemplate->m_name.GetCStr());
-                    RHI::FormatCapabilities capabilities = RHI::GetCapabilities(slot.m_scopeAttachmentUsage, slot.GetAttachmentAccess(), RHI::AttachmentType::Image);
+                    RHI::FormatCapabilities capabilities = RHI::GetCapabilities(slot.m_scopeAttachmentUsage, slot.GetAttachmentAccess(), RHI::AttachmentType::Buffer);
                     slot.m_bufferViewDesc->m_elementFormat = RHI::ValidateFormat(format, formatLocation.c_str(), slot.m_formatFallbacks, capabilities);
                 }
             }

--- a/Gems/AtomTressFX/Assets/Passes/HairFillPPLL.pass
+++ b/Gems/AtomTressFX/Assets/Passes/HairFillPPLL.pass
@@ -39,7 +39,19 @@
                     "Name": "PPLLIndexCounter",
                     "ShaderInputName": "m_linkedListCounter",
                     "SlotType": "Output",
-                    "ScopeAttachmentUsage": "Shader"
+                    "ScopeAttachmentUsage": "Shader",
+                    "BufferViewDesc": {
+                        "m_elementOffset": "0",
+                        "m_elementCount": "1",
+                        "m_elementSize": "4",
+                        "m_elementFormat": "R32_UINT" // Unknown is not accpeted and the pass compilation failsd
+                    },
+                    "LoadStoreAction": {
+                        "ClearValue": {
+                            "Value": [ 0, 0, 0, 0 ]
+                        },
+                        "LoadAction": "Clear"
+                    }
                 },
                 {
                     "Name": "PerPixelListHead",
@@ -66,6 +78,16 @@
                     "ScopeAttachmentUsage": "Shader"
                 }
             ],
+            "BufferAttachments": [
+                {
+                    "Name": "PPLLIndexCounter",
+                    "BufferDescriptor": {
+                        "m_bindFlags": "ShaderReadWrite",
+                        "m_byteCount": "4",
+                        "m_alignment": "0" // or size of the buffer element
+                    }
+                }
+            ],
             "ImageAttachments": [
                 {
                     "Name": "PerPixelListHead",
@@ -88,6 +110,13 @@
                     "AttachmentRef": {
                         "Pass": "This",
                         "Attachment": "PerPixelListHead"
+                    }
+                },
+                {
+                    "LocalSlot": "PPLLIndexCounter",
+                    "AttachmentRef": {
+                        "Pass": "This",
+                        "Attachment": "PPLLIndexCounter"
                     }
                 }
             ],

--- a/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
@@ -49,7 +49,7 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
     //! Originally used space3 for raster pass linked lists and space0 for the resolve pass.
     RWTexture2D<uint>               m_fragmentListHead;
     RWStructuredBuffer<PPLL_STRUCT> m_linkedListNodes;
-    RWStructuredBuffer<uint>        m_linkedListCounter;  // [To Do] - change to RWBuffer
+    RWBuffer<uint>                  m_linkedListCounter;
 
     // Linear depth is used for getting the screen to world transform
     Texture2D<float>                m_linearDepth;

--- a/Gems/AtomTressFX/Code/Components/HairSystemComponent.cpp
+++ b/Gems/AtomTressFX/Code/Components/HairSystemComponent.cpp
@@ -87,6 +87,8 @@ namespace AZ
             void HairSystemComponent::Deactivate()
             {
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<Hair::HairFeatureProcessor>();
+
+                m_loadTemplatesHandler.Disconnect();
             }
         } // namespace Hair
     } // End Render namespace

--- a/Gems/AtomTressFX/Code/Components/HairSystemComponent.cpp
+++ b/Gems/AtomTressFX/Code/Components/HairSystemComponent.cpp
@@ -53,6 +53,15 @@ namespace AZ
                 required.push_back(AZ_CRC("EMotionFXAnimationService", 0x3f8a6369));
             }
 
+            void HairSystemComponent::LoadPassTemplateMappings()
+            {
+                auto* passSystem = RPI::PassSystemInterface::Get();
+                AZ_Assert(passSystem, "Cannot get the pass system.");
+
+                const char* passTemplatesFile = "Passes/AtomTressFX_PassTemplates.azasset";
+                passSystem->LoadPassTemplateMappings(passTemplatesFile);
+            }
+
             void HairSystemComponent::Init()
             {
             }
@@ -63,8 +72,13 @@ namespace AZ
                 AZ::RPI::FeatureProcessorFactory::Get()->RegisterFeatureProcessor<Hair::HairFeatureProcessor>();
 
                 auto* passSystem = RPI::PassSystemInterface::Get();
-
                 AZ_Assert(passSystem, "Cannot get the pass system.");
+
+                // Setup handler for load pass templates mappings
+                m_loadTemplatesHandler = RPI::PassSystemInterface::OnReadyLoadTemplatesEvent::Handler([this]() { this->LoadPassTemplateMappings(); });
+                passSystem->ConnectEvent(m_loadTemplatesHandler);
+
+                // Load the AtomTressFX pass classes
                 passSystem->AddPassCreator(Name("HairSkinningComputePass"), &HairSkinningComputePass::Create);
                 passSystem->AddPassCreator(Name("HairPPLLRasterPass"), &HairPPLLRasterPass::Create);
                 passSystem->AddPassCreator(Name("HairPPLLResolvePass"), &HairPPLLResolvePass::Create);

--- a/Gems/AtomTressFX/Code/Components/HairSystemComponent.h
+++ b/Gems/AtomTressFX/Code/Components/HairSystemComponent.h
@@ -10,6 +10,8 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Asset/AssetCommon.h>
 
+#include <Atom/RPI.Public/Pass/PassSystemInterface.h>
+
 namespace AZ
 {
     namespace Render
@@ -34,6 +36,8 @@ namespace AZ
                 static void GetRequiredServices(ComponentDescriptor::DependencyArrayType& required);
 
             private:
+                //! Loads the pass templates mapping file 
+                void LoadPassTemplateMappings();
 
                 ////////////////////////////////////////////////////////////////////////
                 // Component interface implementation
@@ -41,6 +45,9 @@ namespace AZ
                 void Activate() override;
                 void Deactivate() override;
                 ////////////////////////////////////////////////////////////////////////
+
+                //! Used for loading the pass templates of the hair gem.
+                RPI::PassSystemInterface::OnReadyLoadTemplatesEvent::Handler m_loadTemplatesHandler;
             };
         } // namespace Hair
     } // End Render namespace

--- a/Gems/AtomTressFX/Code/Passes/HairPPLLRasterPass.cpp
+++ b/Gems/AtomTressFX/Code/Passes/HairPPLLRasterPass.cpp
@@ -101,7 +101,6 @@ namespace AZ
                 }
 
                 // Output
-                AttachBufferToSlot(Name{ "PPLLIndexCounter" }, m_featureProcessor->GetPerPixelCounterBuffer());
                 AttachBufferToSlot(Name{ "PerPixelLinkedList" }, m_featureProcessor->GetPerPixelListBuffer());
             }
 
@@ -143,7 +142,7 @@ namespace AZ
 
                 // Per Pass Srg
                 {
-                    // Need to use 'PerPass' naming as currently RasterPass assumes specific naming!
+                    // Using 'PerPass' naming since currently RasterPass assumes that the pass Srg is always named 'PassSrg'
                     // [To Do] - RasterPass should use srg slot index and not name - currently this will
                     //  result in a crash in one of the Atom existing MSAA passes that requires further dive. 
                     // m_shaderResourceGroup = UtilityClass::CreateShaderResourceGroup(m_shader, "HairPerPassSrg", "Hair Gem");
@@ -256,17 +255,10 @@ namespace AZ
                     newObject->BindPerObjectSrgForRaster();
                     BuildDrawPacket(newObject);
                 }
-                // Clear the objects, hence this is only done once per object/shader lifetime
-                m_newRenderObjects.clear();
 
-                // Reset the hair PPLL items current index.
-                // [To Do] Hair - using be pass data driven avoid th following code
-                if (auto ppllCounterBuffer = m_featureProcessor->GetPerPixelCounterBuffer())
-                {   
-                    uint32_t sourceData = 0;
-                    bool updateSuccess = ppllCounterBuffer->UpdateData(&sourceData, sizeof(uint32_t), 0);
-                    AZ_Error("Hair Gem", updateSuccess, "HairPPLLRasterPass::CompileResources could not reset PPLL counter");
-                }
+                // Clear the new added objects - BuildDrawPacket should only be carried out once per
+                // object/shader lifetime
+                m_newRenderObjects.clear();
 
                 // Refresh current view every frame
                 if (!(m_currentView = GetView()) || !m_currentView->HasDrawListTag(m_drawListTag))

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -390,20 +390,6 @@ namespace AZ
                     }
                 }
 
-                // PPLL index counter
-                {
-                    descriptor = SrgBufferDescriptor(
-                        RPI::CommonBufferPoolType::ReadWrite, RHI::Format::Unknown,
-                        sizeof(uint32_t), 1,
-                        Name{ "LinkedListCounterPPLL" + instanceNumber }, Name{ "m_linkedListCounter" }, 0, 0
-                    );
-                    m_linkedListCounterBuffer = UtilityClass::CreateBuffer("Hair Gem", descriptor, nullptr );
-                    if (!m_linkedListCounterBuffer)
-                    {
-                        AZ_Error("Hair Gem", false, "Failed to bind buffer view for [%s]", descriptor.m_bufferName.GetCStr());
-                        return false;
-                    }
-                }
                 m_sharedResourcesCreated = true;
                 return true;
             }

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
@@ -120,7 +120,6 @@ namespace AZ
                 void FillHairMaterialsArray(std::vector<const AMD::TressFXRenderParams*>& renderSettings);
 
                 Data::Instance<RPI::Buffer> GetPerPixelListBuffer() { return m_linkedListNodesBuffer; }
-                Data::Instance<RPI::Buffer> GetPerPixelCounterBuffer() { return m_linkedListCounterBuffer;  }
                 HairUniformBuffer<AMD::TressFXShadeParams>& GetMaterialsArray() { return m_hairObjectsMaterialsCB;  }
 
                 void ForceRebuildRenderData() { m_forceRebuildRenderData = true; }
@@ -176,9 +175,6 @@ namespace AZ
 
                 //! PPLL single buffer containing all the PPLL elements
                 Data::Instance<RPI::Buffer> m_linkedListNodesBuffer = nullptr;
-                //! shared counter representing the next free index in the buffer
-                //! 
-                Data::Instance<RPI::Buffer> m_linkedListCounterBuffer = nullptr;
                 //--------------------------------------------------------------
 
                 //! Per frame delta time for the physics simulation - updated every frame


### PR DESCRIPTION
- Moving PPLLIndexCounter from code creation and attachment to be data driven
- Fixed RPI typo bug that can prevent using buffers this way

Signed-off-by: Adi-Amazon <barlev@amazon.com>