### PR TITLE
lyn-4831: AWS Core fix issues with resolve path and code cleanup

### DIFF
--- a/Gems/AWSCore/Code/Include/Private/AWSCoreModule.h
+++ b/Gems/AWSCore/Code/Include/Private/AWSCoreModule.h
@@ -24,7 +24,7 @@ namespace AWSCore
         /**
          * Add required SystemComponents to the SystemEntity.
          */
-        virtual AZ::ComponentTypeList GetRequiredSystemComponents() const override;
+        AZ::ComponentTypeList GetRequiredSystemComponents() const override;
     };
 }
 

--- a/Gems/AWSCore/Code/Include/Private/Configuration/AWSCoreConfiguration.h
+++ b/Gems/AWSCore/Code/Include/Private/Configuration/AWSCoreConfiguration.h
@@ -42,7 +42,7 @@ namespace AWSCore
 
 
         AWSCoreConfiguration();
-        ~AWSCoreConfiguration() = default;
+        ~AWSCoreConfiguration() override = default;
 
         void ActivateConfig();
         void DeactivateConfig();

--- a/Gems/AWSCore/Code/Include/Private/Credential/AWSCVarCredentialHandler.h
+++ b/Gems/AWSCore/Code/Include/Private/Credential/AWSCVarCredentialHandler.h
@@ -21,7 +21,7 @@ namespace AWSCore
     {
     public:
         AWSCVarCredentialHandler() = default;
-        ~AWSCVarCredentialHandler() = default;
+        ~AWSCVarCredentialHandler() override = default;
 
         //! Activate handler and its credentials provider, make sure activation
         //! invoked after AWSNativeSDK init to avoid memory leak

--- a/Gems/AWSCore/Code/Include/Private/Credential/AWSDefaultCredentialHandler.h
+++ b/Gems/AWSCore/Code/Include/Private/Credential/AWSDefaultCredentialHandler.h
@@ -23,7 +23,7 @@ namespace AWSCore
     {
     public:
         AWSDefaultCredentialHandler();
-        ~AWSDefaultCredentialHandler() = default;
+        ~AWSDefaultCredentialHandler() override = default;
 
         //! Activate handler and its credentials provider, make sure activation
         //! invoked after AWSNativeSDK init to avoid memory leak

--- a/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSAttributionServiceApi.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSAttributionServiceApi.h
@@ -16,7 +16,7 @@ namespace AWSCore
     namespace ServiceAPI
     {
         //! Struct for storing the success response.
-        struct AWSAtrributionSuccessResponse
+        struct AWSAttributionSuccessResponse
         {
             //! Identify the expected property type and provide a location where the property value can be stored.
             //! @param key Name of the property.
@@ -58,7 +58,7 @@ namespace AWSCore
                 AttributionMetric metric;
             };
 
-            AWSAtrributionSuccessResponse result;
+            AWSAttributionSuccessResponse result;
             Parameters parameters; //! Request parameter.
         };
 

--- a/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionConsentDialog.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionConsentDialog.h
@@ -15,13 +15,11 @@
 namespace AWSCore
 {
     //! Defines AWSCoreAttributionConsent QT dialog as QT message box.
-    class AWSCoreAttributionConsentDialog :
-        public QMessageBox
+    class AWSCoreAttributionConsentDialog : public QMessageBox
     {
     public:
         AZ_CLASS_ALLOCATOR(AWSCoreAttributionConsentDialog, AZ::SystemAllocator, 0);
         AWSCoreAttributionConsentDialog();
-        virtual ~AWSCoreAttributionConsentDialog() = default;
-       
+        ~AWSCoreAttributionConsentDialog() override = default;
     };
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionConstant.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionConstant.h
@@ -18,4 +18,4 @@ namespace AWSCore
     static constexpr char AwsAttributionAttributeKeyActiveAWSGems[] = "aws_gems";
     static constexpr char AwsAttributionAttributeKeyTimestamp[] = "timestamp";
 
-} // namespace AWSCOre
+} // namespace AWSCore

--- a/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionManager.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/Attribution/AWSCoreAttributionManager.h
@@ -8,7 +8,6 @@
 
 #pragma once
 #include <AzCore/std/string/string.h>
-#include <AzCore/std/containers/vector.h>
 
 #include <Editor/Attribution/AWSAttributionServiceApi.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>

--- a/Gems/AWSCore/Code/Include/Private/Editor/UI/AWSCoreEditorMenu.h
+++ b/Gems/AWSCore/Code/Include/Private/Editor/UI/AWSCoreEditorMenu.h
@@ -33,7 +33,7 @@ namespace AWSCore
             "Failed to launch Resource Mapping Tool, please check <a href=\"file:///%s\">logs</a> for details.";
 
         AWSCoreEditorMenu(const QString& text);
-        ~AWSCoreEditorMenu();
+        ~AWSCoreEditorMenu() override;
 
     private:
         QAction* AddExternalLinkAction(const AZStd::string& name, const AZStd::string& url, const AZStd::string& icon = "");

--- a/Gems/AWSCore/Code/Include/Private/ResourceMapping/AWSResourceMappingManager.h
+++ b/Gems/AWSCore/Code/Include/Private/ResourceMapping/AWSResourceMappingManager.h
@@ -71,7 +71,7 @@ namespace AWSCore
         };
 
         AWSResourceMappingManager();
-        ~AWSResourceMappingManager() = default;
+        ~AWSResourceMappingManager() override = default;
 
         void ActivateManager();
         void DeactivateManager();

--- a/Gems/AWSCore/Code/Include/Public/AWSCoreBus.h
+++ b/Gems/AWSCore/Code/Include/Public/AWSCoreBus.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/std/string/string.h>
 #include <AzCore/EBus/EBus.h>
 
 namespace AZ

--- a/Gems/AWSCore/Code/Include/Public/Framework/AWSApiClientJobConfig.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/AWSApiClientJobConfig.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <AzCore/std/smart_ptr/make_shared.h>
+#include <aws/core/auth/AWSCredentials.h>
 #include <Framework/AWSApiJobConfig.h>
 
 // Forward declarations
@@ -24,30 +24,24 @@ namespace Aws
     {
         class HttpClient;
     }
-    namespace Auth
-    {
-        class AWSCredentials;
-    }
-
 }
 
 namespace AWSCore
 {
-
     /// Provides configuration for AWS jobs using a specific client type.
     template<class ClientType>
     class IAwsApiClientJobConfig
         : public virtual IAwsApiJobConfig
     {
-
     public:
         //! Returns the created AWS client for the Job
         virtual std::shared_ptr<ClientType> GetClient() = 0;
     };
 
-    // warning C4250: 'AWSCore::AwsApiClientJobConfig<ClientType>': inherits 'AWSCore::AwsApiJobConfig::AWSCore::AwsApiJobConfig::GetJobContext' via dominance
-    // Thanks to http://stackoverflow.com/questions/11965596/diamond-inheritance-scenario-compiles-fine-in-g-but-produces-warnings-errors for the explanation
-    // This is the expected and desired behavior. The warning is superfluous.
+    // warning C4250: 'AWSCore::AwsApiClientJobConfig<ClientType>': inherits
+    // 'AWSCore::AwsApiJobConfig::AWSCore::AwsApiJobConfig::GetJobContext' via dominance Thanks to
+    // http://stackoverflow.com/questions/11965596/diamond-inheritance-scenario-compiles-fine-in-g-but-produces-warnings-errors for the
+    // explanation This is the expected and desired behavior. The warning is superfluous.
     AZ_PUSH_DISABLE_WARNING(4250, "-Wunknown-warning-option")
     /// Configuration for AWS jobs using a specific client type.
     template<class ClientType>
@@ -55,7 +49,6 @@ namespace AWSCore
         : public AwsApiJobConfig
         , public virtual IAwsApiClientJobConfig<ClientType>
     {
-
     public:
         AZ_CLASS_ALLOCATOR(AwsApiClientJobConfig, AZ::SystemAllocator, 0);
 
@@ -63,9 +56,6 @@ namespace AWSCore
         using InitializerFunction = AZStd::function<void(AwsApiClientJobConfigType& config)>;
 
         /// Initialize an AwsApiClientJobConfig object.
-        ///
-        /// \param DefaultConfigType - the type of the config object from which
-        /// default values will be taken.
         ///
         /// \param defaultConfig - the config object that provides values when
         /// no override has been set in this object. The default is nullptr, which
@@ -83,10 +73,10 @@ namespace AWSCore
             }
         }
 
-        virtual ~AwsApiClientJobConfig() = default;
+        ~AwsApiClientJobConfig() override = default;
 
         /// Gets a client initialized used currently applied settings. If
-        /// any settings change after first use, code must call 
+        /// any settings change after first use, code must call
         /// ApplySettings before those changes will take effect.
         std::shared_ptr<ClientType> GetClient() override
         {
@@ -112,7 +102,7 @@ namespace AWSCore
             }
             else
             {
-                // If no explict credenitals are provided then AWS C++ SDK will perform standard search
+                // If no explicit credentials are provided then AWS C++ SDK will perform standard search
                 return std::make_shared<ClientType>(Aws::Auth::AWSCredentials(), GetClientConfiguration());
             }
         }

--- a/Gems/AWSCore/Code/Include/Public/Framework/AWSApiJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/AWSApiJob.h
@@ -14,14 +14,11 @@
 
 namespace AWSCore
 {
-
-    /// Base class for all AWS jobs. Primarily exists so that 
+    /// Base class for all AWS jobs. Primarily exists so that
     /// AwsApiJob::s_config can be used for settings that apply to
     /// all AWS jobs.
-    class AwsApiJob
-        : public AZ::Job
+    class AwsApiJob : public AZ::Job
     {
-
     public:
         // To use a different allocator, extend this class and use this macro.
         AZ_CLASS_ALLOCATOR(AwsApiJob, AZ::SystemAllocator, 0);
@@ -33,11 +30,10 @@ namespace AWSCore
 
     protected:
         AwsApiJob(bool isAutoDelete, IConfig* config = GetDefaultConfig());
-        virtual ~AwsApiJob();
+        ~AwsApiJob() override = default;
 
         /// Used for error messages.
         static const char* COMPONENT_DISPLAY_NAME;
-
     };
 
 } // namespace AWSCore

--- a/Gems/AWSCore/Code/Include/Public/Framework/AWSApiJobConfig.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/AWSApiJobConfig.h
@@ -21,7 +21,6 @@
 AZ_PUSH_DISABLE_WARNING(4251 4996, "-Wunknown-warning-option")
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/http/Scheme.h>
-#include <aws/core/Region.h>
 #include <aws/core/http/HttpTypes.h>
 AZ_POP_DISABLE_WARNING
 
@@ -93,9 +92,6 @@ namespace AWSCore
 
         /// Initialize an AwsApiClientJobConfig object.
         ///
-        /// \param DefaultConfigType - the type of the config object from which
-        /// default values will be taken.
-        ///
         /// \param defaultConfig - the config object that provides values when
         /// no override has been set in this object. The default is nullptr, which
         /// will cause a default value to be used.
@@ -139,7 +135,7 @@ namespace AWSCore
         Override<bool> followRedirects;
         Override<Aws::String> caFile;
 
-        /// Applys settings changes made after first use.
+        /// Applies settings changes made after first use.
         virtual void ApplySettings();
 
         //////////////////////////////////////////////////////////////////////////
@@ -210,7 +206,7 @@ namespace AWSCore
         : protected AWSCoreNotificationsBus::Handler
     {
     public:
-        ~AwsApiJobConfigHolder()
+        ~AwsApiJobConfigHolder() override
         {
             AWSCoreNotificationsBus::Handler::BusDisconnect();
         }

--- a/Gems/AWSCore/Code/Include/Public/Framework/AWSApiRequestJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/AWSApiRequestJob.h
@@ -145,10 +145,10 @@ namespace AWSCore
     AWS_API_REQUEST_TRAITS_TEMPLATE_DEFINITION_HELPER
         typename AWS_API_REQUEST_TRAITS_TEMPLATE_INSTANCE_HELPER::AsyncFunctionType AWS_API_REQUEST_TRAITS_TEMPLATE_INSTANCE_HELPER::AsyncFunction = _AsyncFunction;
 
-    /// Macro that simplifies the declaration of an AwsRequstJob that has a result.
+    /// Macro that simplifies the declaration of an AwsRequestJob that has a result.
 #define AWS_API_REQUEST_JOB(SERVICE, REQUEST) AWSCore::AwsApiRequestJob<AWS_API_REQUEST_TRAITS(SERVICE, REQUEST)>
 
-/// Macro that simplifies the declaration of an AwsRequstJob that has no result.
+    /// Macro that simplifies the declaration of an AwsRequestJob that has no result.
 #define AWS_API_REQUEST_JOB_NO_RESULT(SERVICE, REQUEST) AWSCore::AwsApiRequestJob<AWS_API_REQUEST_TRAITS_NO_RESULT(SERVICE, REQUEST)>
 
 /// An Az::Job that that executes a specific AWS request.
@@ -201,7 +201,7 @@ namespace AWSCore
         }
 
         /// Determines if the request was successful.
-        bool WasSuccess()
+        bool WasSuccess() const
         {
             return m_wasSuccess;
         }
@@ -256,8 +256,6 @@ namespace AWSCore
         /// are made to the request object. Override to defer the preparation
         /// of request data until your running on the job's worker thread,
         /// instead of setting the request data before calling Start.
-        ///
-        /// \param true if the request should be made.
         virtual bool PrepareRequest()
         {
             return true;
@@ -284,7 +282,8 @@ namespace AWSCore
 
         /// A specialization of AwsApiRequestJob that lets you provide functions
         /// that are called on success or failure of the request.
-        class Function : public AwsApiRequestJob
+        class Function
+            : public AwsApiRequestJob
         {
 
         public:

--- a/Gems/AWSCore/Code/Include/Public/Framework/Error.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/Error.h
@@ -12,7 +12,6 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/RTTI/BehaviorContext.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
 namespace AWSCore

--- a/Gems/AWSCore/Code/Include/Public/Framework/HttpClientComponent.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/HttpClientComponent.h
@@ -12,10 +12,7 @@
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Memory/SystemAllocator.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
-
-
 
 #include <Framework/AWSApiClientJob.h>
 
@@ -29,8 +26,10 @@ namespace AWSCore
         : public AZ::ComponentBus
     {
     public:
-        virtual ~HttpClientComponentRequests() {}
-        virtual void MakeHttpRequest(AZStd::string url, AZStd::string method, AZStd::string jsonBody) {}
+        ~HttpClientComponentRequests() override = default;
+        virtual void MakeHttpRequest(AZStd::string url, AZStd::string method, AZStd::string jsonBody)
+        {
+        }
     };
 
     using HttpClientComponentRequestBus = AZ::EBus<HttpClientComponentRequests>;
@@ -39,9 +38,14 @@ namespace AWSCore
         : public AZ::ComponentBus
     {
     public:
-        virtual ~HttpClientComponentNotifications() {}
-        virtual void OnHttpRequestSuccess(int responseCode, AZStd::string responseBody) {}
-        virtual void OnHttpRequestFailure(int responseCode) {}
+        ~HttpClientComponentNotifications() override = default;
+        virtual void OnHttpRequestSuccess(int responseCode, AZStd::string responseBody)
+        {
+        }
+
+        virtual void OnHttpRequestFailure(int responseCode)
+        {
+        }
     };
 
     using HttpClientComponentNotificationBus = AZ::EBus<HttpClientComponentNotifications>;
@@ -55,7 +59,7 @@ namespace AWSCore
     {
     public:
         AZ_COMPONENT(HttpClientComponent, "{23ECDBDF-129A-4670-B9B4-1E0B541ACD61}");
-        virtual ~HttpClientComponent() = default;
+        ~HttpClientComponent() override = default;
 
         void Init() override;
         void Activate() override;

--- a/Gems/AWSCore/Code/Include/Public/Framework/HttpRequestJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/HttpRequestJob.h
@@ -178,7 +178,7 @@ namespace AWSCore
         };
 
         /// Override to process the response to the HTTP request before callbacks are fired.
-        /// WARNING: This gets called on the job's thread, so observe thread safety precations.
+        /// WARNING: This gets called on the job's thread, so observe thread safety precautions.
         virtual void ProcessResponse(const std::shared_ptr<Aws::Http::HttpResponse>& response)
         {
             AZ_UNUSED(response);

--- a/Gems/AWSCore/Code/Include/Public/Framework/JobExecuter.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/JobExecuter.h
@@ -56,8 +56,9 @@ namespace AWSCore
         /// Called by the AWS SDK to queue a callback for execution.
         bool SubmitToThread(std::function<void()>&& callback) override
         {
-            ExecuterJob* job = aznew ExecuterJob(callback, true, m_context);
+            const auto job = aznew ExecuterJob(callback, true, m_context);
             job->Start();
+            return true;
         }
 
     };

--- a/Gems/AWSCore/Code/Include/Public/Framework/JsonObjectHandler.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/JsonObjectHandler.h
@@ -28,25 +28,25 @@ namespace AWSCore
 
         Ch Peek() const
         {
-            int c = m_is.peek();
-            return c == std::char_traits<char>::eof() ? '\0' : (Ch)c;
+            const int c = m_is.peek();
+            return c == std::char_traits<char>::eof() ? '\0' : static_cast<Ch>(c);
         }
 
         Ch Take()
         {
-            int c = m_is.get();
-            return c == std::char_traits<char>::eof() ? '\0' : (Ch)c;
+            const int c = m_is.get();
+            return c == std::char_traits<char>::eof() ? '\0' : static_cast<Ch>(c);
         }
 
         size_t Tell() const
         {
-            return (size_t)m_is.tellg();
+            return static_cast<size_t>(m_is.tellg());
         }
 
         Ch* PutBegin()
         {
             AZ_Assert(false, "Not Implemented");
-            return 0;
+            return nullptr;
         }
 
         void Put(Ch)

--- a/Gems/AWSCore/Code/Include/Public/Framework/JsonWriter.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/JsonWriter.h
@@ -161,7 +161,7 @@ namespace AWSCore
         }
 
         /// Write JSON format content directly to the writer's output stream.
-        /// This can be used to efficently output static content.
+        /// This can be used to efficiently output static content.
         bool WriteJson(const Ch* json)
         {
             if (json)
@@ -182,7 +182,7 @@ namespace AWSCore
         }
 
         /// Write an object. The object can implement a WriteJson function
-        /// or you can provide an GobalWriteJson template function 
+        /// or you can provide an GlobalWriteJson template function 
         /// specialization.
         template<class ObjectType>
         bool Object(const ObjectType& obj)

--- a/Gems/AWSCore/Code/Include/Public/Framework/RequestBuilder.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/RequestBuilder.h
@@ -36,8 +36,7 @@ namespace AWSCore
     class RequestBuilder
     {
     public:
-        RequestBuilder() = default;
-
+        RequestBuilder();
         /// Converts the provided object to JSON and sends it as the
         /// body of the request. The object can implement the following
         /// function to enable serialization:
@@ -79,7 +78,7 @@ namespace AWSCore
             return true;
         }
 
-        const Aws::String& GetRequestUrl()
+        const Aws::String& GetRequestUrl() const
         {
             return m_requestUrl;
         }
@@ -111,7 +110,7 @@ namespace AWSCore
         bool AddQueryParameter(const char* name, unsigned value);
         bool AddQueryParameter(const char* name, uint64_t value);
 
-        Aws::Http::HttpMethod GetHttpMethod()
+        Aws::Http::HttpMethod GetHttpMethod() const
         {
             return m_httpMethod;
         }
@@ -121,7 +120,7 @@ namespace AWSCore
             m_httpMethod = httpMethod;
         }
 
-        const AZStd::string& GetErrorMessage()
+        const AZStd::string& GetErrorMessage() const
         {
             return m_errorMessage;
         }

--- a/Gems/AWSCore/Code/Include/Public/Framework/ServiceClientJobConfig.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/ServiceClientJobConfig.h
@@ -20,7 +20,7 @@ namespace AWSCore
     {
 
     public:
-        virtual const AZStd::string GetServiceUrl() = 0;
+        virtual AZStd::string GetServiceUrl() = 0;
     };
 
     /// Encapsulates what code needs to know about a service in order to 
@@ -81,9 +81,6 @@ namespace AWSCore
 
         /// Initialize an ServiceClientJobConfig object.
         ///
-        /// \param DefaultConfigType - the type of the config object from which
-        /// default values will be taken.
-        ///
         /// \param defaultConfig - the config object that provides values when
         /// no override has been set in this object. The default is nullptr, which
         /// will cause a default value to be used.
@@ -102,7 +99,7 @@ namespace AWSCore
 
         /// This implementation assumes the caller will cache this value as 
         /// needed. See it's use in ServiceRequestJobConfig.
-        const AZStd::string GetServiceUrl() override
+        AZStd::string GetServiceUrl() override
         {
             if (endpointOverride.has_value())
             {

--- a/Gems/AWSCore/Code/Include/Public/Framework/ServiceJobUtil.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/ServiceJobUtil.h
@@ -16,11 +16,11 @@ namespace AWSCore
 {
     inline void ConfigureJsonServiceRequest(HttpRequestJob& request, AZStd::string jsonBody)
     {
-        size_t len = jsonBody.length();
+        const size_t len = jsonBody.length();
 
         if (len > 0)
         {
-            AZStd::string lenStr = AZStd::string::format("%zu", len);
+            const AZStd::string lenStr = AZStd::string::format("%zu", len);
             request.SetContentLength(lenStr);
             request.SetContentType("application/json");
             request.SetBody(std::move(jsonBody));
@@ -35,15 +35,15 @@ namespace AWSCore
         // Assumes that API Gateway URLs have either of the following two forms:
         // https://{custom_domain_name}/{region}.{stage}.{rest-api-id}/{path}
         // https://{rest-api-id}.execute-api.{region}.amazonaws.com/{stage}/{path}
-        const int ExpectedUrlSections = 3;
+        constexpr int ExpectedUrlSections = 3;
 
         AZStd::vector<AZStd::string> urlSections;
-        AZStd::string url(serviceUrl.c_str());
+        const AZStd::string url(serviceUrl.c_str());
         AZStd::tokenize(url, AZStd::string("/"), urlSections);
 
         if (urlSections.size() > ExpectedUrlSections)
         {
-            int i = static_cast<int>(urlSections[ExpectedUrlSections - 1].find('.'));
+            const int i = static_cast<int>(urlSections[ExpectedUrlSections - 1].find('.'));
             if (i != -1)
             {
                 // Handle APIGateway URLs with custom domains:
@@ -54,7 +54,7 @@ namespace AWSCore
             {
                 // API Gateway URLs have the form:
                 // https://{rest-api-id}.execute-api.{region}.amazonaws.com/{stage}/{path}
-                const int RegionIndex = 2;
+                constexpr int RegionIndex = 2;
 
                 AZStd::vector<AZStd::string> domainSections;
                 AZStd::tokenize(urlSections[ExpectedUrlSections - 2], AZStd::string("."), domainSections);

--- a/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJob.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJob.h
@@ -9,9 +9,7 @@
 #pragma once
 
 
-#include <AzCore/std/functional.h>
 #include <AzCore/std/string/regex.h>
-#include <AzCore/std/string/tokenize.h>
 #include <AzCore/JSON/document.h>
 #include <AzCore/JSON/prettywriter.h>
 #include <AzCore/Component/TickBus.h>
@@ -119,7 +117,7 @@ namespace AWSCore
         Error error;
 
         /// Determines if the AWS credentials, as supplied by the credentialsProvider from
-        /// the ServiceReqestJobConfig object (which defaults to the user's credentials), 
+        /// the ServiceRequestJobConfig object (which defaults to the user's credentials), 
         /// are used to sign the request. The default is true. Override this and return false 
         /// if calling a public API and want to avoid the overhead of signing requests.
         bool UseAWSCredentials() {
@@ -187,7 +185,7 @@ namespace AWSCore
                 return false;
             }
 
-            auto awsCredentials = config->GetCredentialsProvider()->GetAWSCredentials();
+            const auto awsCredentials = config->GetCredentialsProvider()->GetAWSCredentials();
 
             return !(awsCredentials.GetAWSAccessKeyId().empty() || awsCredentials.GetAWSSecretKey().empty());
         }
@@ -305,7 +303,7 @@ namespace AWSCore
                 );
 #endif
 
-                int responseCode = static_cast<int>(response->GetResponseCode());
+                const int responseCode = static_cast<int>(response->GetResponseCode());
                 Aws::IOStream& responseBody = response->GetResponseBody();
 #ifdef _DEBUG
                 std::istreambuf_iterator<AZStd::string::value_type> eos;
@@ -382,7 +380,7 @@ namespace AWSCore
 
                 // This is determined by AZ::g_maxMessageLength defined in in dev\Code\Framework\AzCore\AzCore\Debug\Trace.cpp.
                 // It has the value 4096, but there is the timestamp, etc., to account for so we reduce it by a few characters.
-                const int MAX_MESSAGE_LENGTH = 4096 - 128;
+                constexpr int MAX_MESSAGE_LENGTH = 4096 - 128;
 
                 // Replace the character "%" with "%%" to prevent the error when printing the string that contains the percentage sign
                 message = EscapePercentCharsInString(message);
@@ -565,13 +563,11 @@ namespace AWSCore
             }
 
             AZStd::string requestContent;
-            AZStd::string responseContent;
-
-            std::istreambuf_iterator<AZStd::string::value_type> eos;
 
             std::shared_ptr<Aws::IOStream> requestStream = response->GetOriginatingRequest().GetContentBody();
             if (requestStream)
             {
+                std::istreambuf_iterator<AZStd::string::value_type> eos;
                 requestStream->clear();
                 requestStream->seekg(0);
                 requestContent = AZStd::string{ std::istreambuf_iterator<AZStd::string::value_type>(*requestStream.get()),eos };
@@ -584,7 +580,7 @@ namespace AWSCore
             Aws::IOStream& responseStream = response->GetResponseBody();
             responseStream.clear();
             responseStream.seekg(0);
-            responseContent = AZStd::string{ std::istreambuf_iterator<AZStd::string::value_type>(responseStream),responseEos };
+            AZStd::string responseContent = AZStd::string{ std::istreambuf_iterator<AZStd::string::value_type>(responseStream), responseEos };
             responseContent = EscapePercentCharsInString(responseContent);
             responseStream.seekg(0);
 

--- a/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJobConfig.h
+++ b/Gems/AWSCore/Code/Include/Public/Framework/ServiceRequestJobConfig.h
@@ -44,9 +44,6 @@ namespace AWSCore
 
         /// Initialize an ServiceRequestJobConfig object.
         ///
-        /// \param DefaultConfigType - the type of the config object from which
-        /// default values will be taken.
-        ///
         /// \param defaultConfig - the config object that provides values when
         /// no override has been set in this object. The default is nullptr, which
         /// will cause a default value to be used.
@@ -75,7 +72,7 @@ namespace AWSCore
             return (m_requestUrl.length() > 0);
         }
 
-        std::shared_ptr<Aws::Auth::AWSCredentialsProvider> GetCredentialsProvider()
+        std::shared_ptr<Aws::Auth::AWSCredentialsProvider> GetCredentialsProvider() override
         {
             ServiceClientJobConfigType::EnsureSettingsApplied();
             return m_credentialsProvider;

--- a/Gems/AWSCore/Code/Source/AWSCoreEditorSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/AWSCoreEditorSystemComponent.cpp
@@ -79,7 +79,7 @@ namespace AWSCore
         QMenuBar* menuBar = mainWindow->menuBar();
         QList<QAction*> actionList = menuBar->actions();
         QAction* insertPivot = nullptr;
-        for (QList<QAction*>::iterator itr = actionList.begin(); itr != actionList.end(); itr++)
+        for (QList<QAction*>::iterator itr = actionList.begin(); itr != actionList.end(); ++itr)
         {
             if (QString::compare((*itr)->text(), EDITOR_HELP_MENU_TEXT) == 0)
             {

--- a/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.cpp
+++ b/Gems/AWSCore/Code/Source/Configuration/AWSCoreConfiguration.cpp
@@ -8,7 +8,6 @@
 
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/IO/Path/Path.h>
-#include <AzCore/Settings/SettingsRegistryImpl.h>
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSAttributionServiceApi.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSAttributionServiceApi.cpp
@@ -15,7 +15,7 @@ namespace AWSCore
     {
         constexpr char AwsAttributionServiceResultResponseKey[] = "statusCode";
 
-        bool AWSAtrributionSuccessResponse::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
+        bool AWSAttributionSuccessResponse::OnJsonKey(const char* key, AWSCore::JsonReader& reader)
         {
             if (strcmp(key, AwsAttributionServiceResultResponseKey) == 0)
             {

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionConsentDialog.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionConsentDialog.cpp
@@ -35,7 +35,7 @@ namespace AWSCore
         this->setDefaultButton(QMessageBox::Save);
         this->button(QMessageBox::Cancel)->hide();
         this->setIcon(QMessageBox::Information);
-        QGridLayout* layout = (QGridLayout*)this->layout();
+        QGridLayout* layout = static_cast<QGridLayout*>(this->layout());
         if (layout)
         {
             layout->setVerticalSpacing(20);

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionManager.cpp
@@ -10,7 +10,6 @@
 #include <Editor/Attribution/AWSCoreAttributionManager.h>
 #include <Editor/Attribution/AWSCoreAttributionConsentDialog.h>
 #include <AzCore/std/string/string.h>
-#include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzCore/IO/FileIO.h>
 #include <AzCore/PlatformId/PlatformId.h>
 #include <AzCore/Settings/SettingsRegistry.h>
@@ -21,7 +20,6 @@
 #include <AzCore/IO/ByteContainerStream.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Module/ModuleManagerBus.h>
-#include <ResourceMapping/AWSResourceMappingUtils.h>
 #include <Credential/AWSCredentialBus.h>
 
 #include <QSysInfo>
@@ -71,7 +69,8 @@ namespace AWSCore
         AZStd::string editorAWSPreferencesFilePath =
             AZStd::string::format("@user@/%s/%s", AZ::SettingsRegistryInterface::RegistryFolder, EditorAWSPreferencesFileName);
         AZStd::array<char, AZ::IO::MaxPathLength> resolvedPathAWSPreference{};
-        if (!fileIO->ResolvePath(editorAWSPreferencesFilePath.c_str(), resolvedPathAWSPreference.data(), resolvedPathAWSPreference.size()))
+        if (!fileIO->ResolvePath(
+                editorAWSPreferencesFilePath.c_str(), resolvedPathAWSPreference.data(), AZ_ARRAY_SIZE(resolvedPathAWSPreference)))
         {
             AZ_Warning("AWSAttributionManager", false, "Error resolving path %s", resolvedPathAWSPreference.data());
             return;
@@ -202,7 +201,11 @@ namespace AWSCore
                 // Resolve path to editor_aws_preferences.setreg
                 AZStd::string editorPreferencesFilePath = AZStd::string::format("@user@/%s/%s", AZ::SettingsRegistryInterface::RegistryFolder, EditorAWSPreferencesFileName);
                 AZStd::array<char, AZ::IO::MaxPathLength> resolvedPath {};
-                fileIO->ResolvePath(editorPreferencesFilePath.c_str(), resolvedPath.data(), resolvedPath.size());
+                if (!fileIO->ResolvePath(editorPreferencesFilePath.c_str(), resolvedPath.data(), AZ_ARRAY_SIZE(resolvedPath)))
+                {
+                    AZ_Warning("AWSAttributionManager", false, "Error resolving path %s", resolvedPath.data());
+                    return;
+                }
 
                 AZ::SettingsRegistryMergeUtils::DumperSettings dumperSettings;
                 dumperSettings.m_prettifyOutput = true;

--- a/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionSystemComponent.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/Attribution/AWSCoreAttributionSystemComponent.cpp
@@ -10,7 +10,6 @@
 #include <Editor/Attribution/AWSCoreAttributionSystemComponent.h>
 
 #include <AzCore/IO/FileIO.h>
-#include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/EditContextConstants.inl>
 #include <AzCore/Serialization/SerializeContext.h>

--- a/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
+++ b/Gems/AWSCore/Code/Source/Editor/UI/AWSCoreEditorMenu.cpp
@@ -6,9 +6,7 @@
  *
  */
 
-#include <AzCore/Debug/Trace.h>
 #include <AzCore/IO/FileIO.h>
-#include <AzCore/Jobs/JobFunction.h>
 #include <AzCore/Settings/SettingsRegistry.h>
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/StringFunc/StringFunc.h>
@@ -54,7 +52,7 @@ namespace AWSCore
         {
             if (m_resourceMappingToolWatcher->IsProcessRunning())
             {
-                m_resourceMappingToolWatcher->TerminateProcess(AZ::u32(-1));
+                m_resourceMappingToolWatcher->TerminateProcess(static_cast<AZ::u32>(-1));
             }
             m_resourceMappingToolWatcher.reset();
         }
@@ -214,7 +212,7 @@ namespace AWSCore
     QMenu* AWSCoreEditorMenu::SetAWSFeatureSubMenu(const AZStd::string& menuText)
     {
         auto actionList = this->actions();
-        for (QList<QAction*>::iterator itr = actionList.begin(); itr != actionList.end(); itr++)
+        for (QList<QAction*>::iterator itr = actionList.begin(); itr != actionList.end(); ++itr)
         {
             if (QString::compare((*itr)->text(), menuText.c_str()) == 0)
             {

--- a/Gems/AWSCore/Code/Source/Framework/AWSApiJob.cpp
+++ b/Gems/AWSCore/Code/Source/Framework/AWSApiJob.cpp
@@ -22,10 +22,6 @@ namespace AWSCore
     {
     }
 
-    AwsApiJob::~AwsApiJob()
-    {
-    }
-
     AwsApiJob::Config* AwsApiJob::GetDefaultConfig()
     {
         static AwsApiJobConfigHolder<AwsApiJob::Config> s_configHolder{};

--- a/Gems/AWSCore/Code/Source/Framework/JsonObjectHandler.cpp
+++ b/Gems/AWSCore/Code/Source/Framework/JsonObjectHandler.cpp
@@ -6,7 +6,6 @@
  *
  */
 #include <AzCore/Casting/numeric_cast.h>
-#include <AzCore/JSON/error/error.h>
 
 #include <Framework/JsonObjectHandler.h>
 

--- a/Gems/AWSCore/Code/Source/Framework/MultipartFormData.cpp
+++ b/Gems/AWSCore/Code/Source/Framework/MultipartFormData.cpp
@@ -49,7 +49,7 @@ namespace AWSCore
     {
         m_fileFields.emplace_back(FileField{ std::move(fieldName), std::move(fileName) , AZStd::vector<char>{} });
         m_fileFields.back().m_fileData.reserve(length);
-        m_fileFields.back().m_fileData.assign((const char*)bytes, (const char*)bytes + length);
+        m_fileFields.back().m_fileData.assign(static_cast<const char*>(bytes), static_cast<const char*>(bytes) + length);
     }
 
     void MultipartFormData::SetCustomBoundary(AZStd::string boundary)

--- a/Gems/AWSCore/Code/Source/Framework/RequestBuilder.cpp
+++ b/Gems/AWSCore/Code/Source/Framework/RequestBuilder.cpp
@@ -10,6 +10,11 @@
 
 namespace AWSCore
 {
+    RequestBuilder::RequestBuilder()
+        : m_httpMethod(Aws::Http::HttpMethod::HTTP_GET)
+    {
+        
+    }
 
     bool RequestBuilder::SetPathParameterUnescaped(const char* key, const char* value)
     {

--- a/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.cpp
+++ b/Gems/AWSCore/Code/Source/ResourceMapping/AWSResourceMappingManager.cpp
@@ -26,7 +26,6 @@ namespace AWSCore
         : m_status(Status::NotLoaded)
         , m_defaultAccountId("")
         , m_defaultRegion("")
-        , m_resourceMappings()
     {
     }
 
@@ -164,7 +163,7 @@ namespace AWSCore
         m_defaultRegion = jsonDocument.FindMember(ResourceMappingRegionKeyName)->value.GetString();
 
         auto resourceMappings = jsonDocument.FindMember(ResourceMappingResourcesKeyName)->value.GetObject();
-        for (auto mappingIter = resourceMappings.MemberBegin(); mappingIter != resourceMappings.MemberEnd(); mappingIter++)
+        for (auto mappingIter = resourceMappings.MemberBegin(); mappingIter != resourceMappings.MemberEnd(); ++mappingIter)
         {
             auto mappingValue = mappingIter->value.GetObject();
             if (mappingValue.MemberCount() != 0)

--- a/Gems/AWSCore/Code/Source/ScriptCanvas/AWSScriptBehaviorDynamoDB.cpp
+++ b/Gems/AWSCore/Code/Source/ScriptCanvas/AWSScriptBehaviorDynamoDB.cpp
@@ -9,7 +9,6 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 
-#include <aws/core/auth/AWSCredentials.h>
 #include <aws/dynamodb/DynamoDBClient.h>
 #include <aws/dynamodb/model/GetItemRequest.h>
 #include <aws/dynamodb/model/GetItemResult.h>
@@ -71,7 +70,7 @@ namespace AWSCore
             [](DynamoDBGetItemRequestJob* job) // OnSuccess handler
             {
                 auto item = job->result.GetItem();
-                if (item.size() > 0)
+                if (!item.empty())
                 {
                     DynamoDBAttributeValueMap result;
                     for (const auto& itermPair : item)

--- a/Gems/AWSCore/Code/Source/ScriptCanvas/AWSScriptBehaviorLambda.cpp
+++ b/Gems/AWSCore/Code/Source/ScriptCanvas/AWSScriptBehaviorLambda.cpp
@@ -13,7 +13,6 @@
 #include <aws/lambda/model/InvokeRequest.h>
 #include <aws/lambda/model/InvokeResult.h>
 #include <aws/core/utils/Outcome.h>
-#include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
 
 #include <Framework/AWSApiRequestJob.h>

--- a/Gems/AWSCore/Code/Source/ScriptCanvas/AWSScriptBehaviorS3.cpp
+++ b/Gems/AWSCore/Code/Source/ScriptCanvas/AWSScriptBehaviorS3.cpp
@@ -12,7 +12,6 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/StringFunc/StringFunc.h>
 
-#include <aws/core/auth/AWSCredentials.h>
 #include <aws/s3/S3Client.h>
 #include <aws/s3/model/GetObjectRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>

--- a/Gems/AWSCore/Code/Tests/AWSCoreSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/AWSCoreSystemComponentTest.cpp
@@ -9,19 +9,15 @@
 #include <AzCore/Jobs/JobManager.h>
 #include <AzCore/Jobs/JobContext.h>
 #include <AzCore/Jobs/JobManagerBus.h>
-#include <AzCore/Jobs/JobCancelGroup.h>
 #include <AzCore/Component/ComponentApplication.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
 #include <AzTest/AzTest.h>
 
 #include <AWSCoreSystemComponent.h>
-#include <Configuration/AWSCoreConfiguration.h>
 #include <Credential/AWSCredentialManager.h>
 #include <Framework/AWSApiJob.h>
-#include <ResourceMapping/AWSResourceMappingManager.h>
 #include <TestFramework/AWSCoreFixture.h>
 
 using namespace AWSCore;
@@ -39,7 +35,7 @@ public:
         AWSCoreNotificationsBus::Handler::BusConnect();
     }
 
-    ~AWSCoreNotificationsBusMock()
+    ~AWSCoreNotificationsBusMock() override
     {
         AWSCoreNotificationsBus::Handler::BusDisconnect();
     }
@@ -95,6 +91,9 @@ protected:
     }
 
 public:
+    AWSCoreSystemComponentTest()
+        : m_entity(nullptr) {}
+
     AZStd::unique_ptr<AWSCoreSystemComponent> m_coreSystemsComponent;
     AZ::Entity* m_entity;
     AWSCoreNotificationsBusMock m_notifications;
@@ -122,13 +121,13 @@ TEST_F(AWSCoreSystemComponentTest, ComponentActivateTest)
 
 TEST_F(AWSCoreSystemComponentTest, GetDefaultJobContext_Call_JobContextIsNotNullptr)
 {
-    auto actualContext = m_coreSystemsComponent->GetDefaultJobContext();
+    const auto actualContext = m_coreSystemsComponent->GetDefaultJobContext();
     EXPECT_TRUE(actualContext);
 }
 
 TEST_F(AWSCoreSystemComponentTest, GetDefaultConfig_Call_GetConfigWithExpectedValue)
 {
-    auto actualDefaultConfig = m_coreSystemsComponent->GetDefaultConfig();
+    const auto actualDefaultConfig = m_coreSystemsComponent->GetDefaultConfig();
     EXPECT_TRUE(actualDefaultConfig->userAgent == "/O3DE_AwsApiJob");
     EXPECT_TRUE(actualDefaultConfig->requestTimeoutMs == 30000);
     EXPECT_TRUE(actualDefaultConfig->connectTimeoutMs == 30000);

--- a/Gems/AWSCore/Code/Tests/Credential/AWSCredentialBusTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Credential/AWSCredentialBusTest.cpp
@@ -43,7 +43,7 @@ public:
 
     std::shared_ptr<Aws::Auth::AWSCredentialsProvider> GetCredentialsProvider()
     {
-        m_handlerCounter++;
+        ++m_handlerCounter;
         return m_credentialsProvider;
     }
 
@@ -79,7 +79,7 @@ public:
 
     std::shared_ptr<Aws::Auth::AWSCredentialsProvider> GetCredentialsProvider()
     {
-        m_handlerCounter++;
+        ++m_handlerCounter;
         return m_credentialsProvider;
     }
 
@@ -115,7 +115,7 @@ public:
 
 TEST_F(AWSCredentialBusTest, GetCredentialsProvider_CallFromMultithread_GetExpectedCredentialsProviderAndNumberOfCalls)
 {
-    int testThreadNumber = 10;
+    constexpr int testThreadNumber = 10;
     AZStd::atomic<int> actualEbusCalls = 0;
     AZStd::vector<AZStd::thread> testThreadPool;
     for (int index = 0; index < testThreadNumber; index++)
@@ -125,7 +125,7 @@ TEST_F(AWSCredentialBusTest, GetCredentialsProvider_CallFromMultithread_GetExpec
             AWSCredentialRequestBus::BroadcastResult(result, &AWSCredentialRequests::GetCredentialsProvider);
             ASSERT_TRUE(result.result);
             EXPECT_TRUE(result.result == m_handlerOne->m_credentialsProvider);
-            actualEbusCalls++;
+            ++actualEbusCalls;
         }));
     }
 

--- a/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorManagerTest.cpp
@@ -9,7 +9,6 @@
 #include <AzTest/AzTest.h>
 
 #include <Editor/AWSCoreEditorManager.h>
-#include <Editor/UI/AWSCoreEditorMenu.h>
 #include <Editor/UI/AWSCoreEditorUIFixture.h>
 #include <TestFramework/AWSCoreFixture.h>
 

--- a/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/AWSCoreEditorSystemComponentTest.cpp
@@ -7,14 +7,12 @@
  */
 
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 #include <AzTest/AzTest.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 
 #include <AWSCoreEditorSystemComponent.h>
 #include <Editor/AWSCoreEditorManager.h>
-#include <Editor/UI/AWSCoreEditorMenu.h>
 #include <Editor/UI/AWSCoreEditorUIFixture.h>
 #include <TestFramework/AWSCoreFixture.h>
 

--- a/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSAttributionServiceApiTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSAttributionServiceApiTest.cpp
@@ -42,7 +42,7 @@ namespace AWSCoreUnitTest
 
     TEST_F(AWSAttributionServiceApiTest, AWSAtrributionSuccessResponse_Serialization)
     {
-        ServiceAPI::AWSAtrributionSuccessResponse response;
+        ServiceAPI::AWSAttributionSuccessResponse response;
         response.result = "ok";
 
         EXPECT_CALL(JsonReader, Accept(response.result)).Times(1);
@@ -53,7 +53,7 @@ namespace AWSCoreUnitTest
 
     TEST_F(AWSAttributionServiceApiTest, AWSAtrributionSuccessResponse_Serialization_Ignore)
     {
-        ServiceAPI::AWSAtrributionSuccessResponse response;
+        ServiceAPI::AWSAttributionSuccessResponse response;
         response.result = "ok";
 
         EXPECT_CALL(JsonReader, Accept(response.result)).Times(0);

--- a/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionManagerTest.cpp
@@ -18,9 +18,7 @@
 #include <AzCore/Settings/SettingsRegistryMergeUtils.h>
 #include <AzCore/Serialization/Json/JsonSystemComponent.h>
 #include <AzCore/Serialization/Json/RegistrationContext.h>
-#include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Jobs/JobManager.h>
-#include <AzCore/Jobs/JobManagerBus.h>
 #include <AzCore/Jobs/JobContext.h>
 #include <AzCore/Utils/Utils.h>
 #include <AzCore/UnitTest/TestTypes.h>
@@ -91,7 +89,7 @@ namespace AWSAttributionUnitTest
             ON_CALL(*this, EnumerateModules(testing::_)).WillByDefault(testing::Invoke(this, &ModuleManagerRequestBusMock::EnumerateModulesMock));
         }
 
-        ~ModuleManagerRequestBusMock()
+        ~ModuleManagerRequestBusMock() override
         {
             AZ::ModuleManagerRequestBus::Handler::BusDisconnect();
         }
@@ -103,19 +101,19 @@ namespace AWSAttributionUnitTest
         MOCK_METHOD1(IsModuleLoaded, bool(const char* modulePath));
     };
 
-    class AWSCredentialRquestsBusMock
+    class AWSCredentialRequestsBusMock
         : public AWSCore::AWSCredentialRequestBus::Handler
     {
     public:
-        AWSCredentialRquestsBusMock()
+        AWSCredentialRequestsBusMock()
         {
-            m_provider = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>("TestAccessKey", "TestSecreKey", "TestSession");
+            m_provider = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>("TestAccessKey", "TestSecretKey", "TestSession");
             AWSCore::AWSCredentialRequestBus::Handler::BusConnect();
             ON_CALL(*this, GetCredentialsProvider()).WillByDefault(testing::Return(m_provider));
             ON_CALL(*this, GetCredentialHandlerOrder()).WillByDefault(testing::Return(CredentialHandlerOrder::DEFAULT_CREDENTIAL_HANDLER));
         }
 
-        ~AWSCredentialRquestsBusMock()
+        ~AWSCredentialRequestsBusMock() override
         {
             AWSCore::AWSCredentialRequestBus::Handler::BusDisconnect();
             m_provider.reset();
@@ -156,7 +154,7 @@ namespace AWSAttributionUnitTest
     {
     public:
 
-        virtual ~AttributionManagerTest() = default;
+        ~AttributionManagerTest() override = default;
 
     protected:
         AZStd::shared_ptr<AZ::SerializeContext> m_serializeContext;
@@ -166,7 +164,7 @@ namespace AWSAttributionUnitTest
         AZStd::unique_ptr<AZ::JobManager> m_jobManager;
         AZStd::array<char, AZ::IO::MaxPathLength> m_resolvedSettingsPath;
         ModuleManagerRequestBusMock m_moduleManagerRequestBusMock;
-        AWSCredentialRquestsBusMock m_credentialRequestBusMock;
+        AWSCredentialRequestsBusMock m_credentialRequestBusMock;
 
         void SetUp() override
         {

--- a/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionSystemComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/Attribution/AWSCoreAttributionSystemComponentTest.cpp
@@ -61,7 +61,7 @@ namespace AWSCoreUnitTest
             AZ_UNUSED(dependent);
         }
 
-        ~AWSCoreSystemComponentMock() = default;
+        ~AWSCoreSystemComponentMock() override = default;
 
         MOCK_METHOD0(Init, void());
         MOCK_METHOD0(Activate, void());

--- a/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreResourceMappingToolActionTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Editor/UI/AWSCoreResourceMappingToolActionTest.cpp
@@ -7,13 +7,10 @@
  */
 
 #include <AzTest/AzTest.h>
-#include <AzFramework/StringFunc/StringFunc.h>
 
 #include <Editor/UI/AWSCoreResourceMappingToolAction.h>
 #include <Editor/UI/AWSCoreEditorUIFixture.h>
 #include <TestFramework/AWSCoreFixture.h>
-
-#include <QAction>
 
 using namespace AWSCore;
 

--- a/Gems/AWSCore/Code/Tests/Framework/AWSApiClientJobConfigTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Framework/AWSApiClientJobConfigTest.cpp
@@ -23,6 +23,11 @@ class AWSApiClientJobConfigTest
     , public AWSCredentialRequestBus::Handler
 {
 public:
+    AWSApiClientJobConfigTest()
+        : m_credentialHandlerCounter(0)
+    {
+    }
+
     void SetUp() override
     {
         AWSNativeSDKInit::InitializationManager::InitAwsApi();

--- a/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Framework/ServiceClientJobConfigTest.cpp
@@ -8,7 +8,6 @@
 
 #include <AzTest/AzTest.h>
 
-#include <AWSCoreBus.h>
 #include <Framework/ServiceClientJobConfig.h>
 #include <ResourceMapping/AWSResourceMappingBus.h>
 #include <TestFramework/AWSCoreFixture.h>

--- a/Gems/AWSCore/Code/Tests/Framework/ServiceRequestJobTest.cpp
+++ b/Gems/AWSCore/Code/Tests/Framework/ServiceRequestJobTest.cpp
@@ -8,7 +8,6 @@
 
 #include <AzTest/AzTest.h>
 
-#include <AWSCoreBus.h>
 #include <Framework/ServiceRequestJob.h>
 #include <TestFramework/AWSCoreFixture.h>
 

--- a/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingManagerTest.cpp
@@ -11,7 +11,6 @@
 #include <AzTest/AzTest.h>
 
 #include <Configuration/AWSCoreConfiguration.h>
-#include <ResourceMapping/AWSResourceMappingConstants.h>
 #include <ResourceMapping/AWSResourceMappingManager.h>
 #include <TestFramework/AWSCoreFixture.h>
 
@@ -204,7 +203,7 @@ TEST_F(AWSResourceMappingManagerTest, ActivateManager_ParseValidConfigFile_Confi
             AZStd::string actualAccountId;
             AWSResourceMappingRequestBus::BroadcastResult(actualAccountId, &AWSResourceMappingRequests::GetDefaultAccountId);
             EXPECT_FALSE(actualAccountId.empty());
-            actualEbusCalls++;
+            ++actualEbusCalls;
         }));
     }
 

--- a/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingUtilsTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ResourceMapping/AWSResourceMappingUtilsTest.cpp
@@ -44,19 +44,19 @@ TEST_F(AWSResourceMappingUtilsTest, FormatRESTApiUrl_PassingInvalidRESTApiId_Ret
 {
     auto actualUrl = AWSResourceMappingUtils::FormatRESTApiUrl("", TEST_VALID_RESTAPI_REGION, TEST_VALID_RESTAPI_STAGE);
 
-    EXPECT_TRUE(actualUrl == "");
+    EXPECT_TRUE(actualUrl.empty());
 }
 
 TEST_F(AWSResourceMappingUtilsTest, FormatRESTApiUrl_PassingInvalidRESTApiRegion_ReturnEmptyResult)
 {
     auto actualUrl = AWSResourceMappingUtils::FormatRESTApiUrl(TEST_VALID_RESTAPI_ID, "", TEST_VALID_RESTAPI_STAGE);
 
-    EXPECT_TRUE(actualUrl == "");
+    EXPECT_TRUE(actualUrl.empty());
 }
 
 TEST_F(AWSResourceMappingUtilsTest, FormatRESTApiUrl_PassingInvalidRESTApiStage_ReturnEmptyResult)
 {
     auto actualUrl = AWSResourceMappingUtils::FormatRESTApiUrl(TEST_VALID_RESTAPI_ID, TEST_VALID_RESTAPI_REGION, "");
 
-    EXPECT_TRUE(actualUrl == "");
+    EXPECT_TRUE(actualUrl.empty());
 }

--- a/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorDynamoDBTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorDynamoDBTest.cpp
@@ -23,7 +23,7 @@ public:
         AWSScriptBehaviorDynamoDBNotificationBus::Handler::BusConnect();
     }
 
-    ~AWSScriptBehaviorDynamoDBNotificationBusHandlerMock()
+    ~AWSScriptBehaviorDynamoDBNotificationBusHandlerMock() override
     {
         AWSScriptBehaviorDynamoDBNotificationBus::Handler::BusDisconnect();
     }

--- a/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorLambdaTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorLambdaTest.cpp
@@ -22,7 +22,7 @@ public:
         AWSScriptBehaviorLambdaNotificationBus::Handler::BusConnect();
     }
 
-    ~AWSScriptBehaviorLambdaNotificationBusHandlerMock()
+    ~AWSScriptBehaviorLambdaNotificationBusHandlerMock() override
     {
         AWSScriptBehaviorLambdaNotificationBus::Handler::BusDisconnect();
     }

--- a/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorS3Test.cpp
+++ b/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorS3Test.cpp
@@ -24,7 +24,7 @@ public:
         AWSScriptBehaviorS3NotificationBus::Handler::BusConnect();
     }
 
-    ~AWSScriptBehaviorS3NotificationBusHandlerMock()
+    ~AWSScriptBehaviorS3NotificationBusHandlerMock() override
     {
         AWSScriptBehaviorS3NotificationBus::Handler::BusDisconnect();
     }

--- a/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorsComponentTest.cpp
+++ b/Gems/AWSCore/Code/Tests/ScriptCanvas/AWSScriptBehaviorsComponentTest.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AzCore/Component/ComponentApplication.h>
-#include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzTest/AzTest.h>
 

--- a/Gems/AWSCore/Code/Tests/TestFramework/AWSCoreFixture.h
+++ b/Gems/AWSCore/Code/Tests/TestFramework/AWSCoreFixture.h
@@ -108,7 +108,7 @@ class AWSCoreFixture
 {
 public:
     AWSCoreFixture() {}
-    virtual ~AWSCoreFixture() = default;
+    ~AWSCoreFixture() override = default;
 
     void SetUp() override
     {


### PR DESCRIPTION
Fix issues with ResolvePath to aid fail on error and to pass the size of the buffer correctly.

Also fixes a number of other issues found by static analysis:
* Unnecessary includes
* Missing overrides
* Minor spelling issues
* Convert c style casts to static_casts
* Some const fixes
* Fix some missing return values
* Fixes for Ctors that didn't initialize all members

Ran unit tests for editor and static code. Built and launched editor on Windows