### PR TITLE
{lyn5392} Adding PrefabGroup scene manifest rule

### DIFF
--- a/Gems/Prefab/PrefabBuilder/CMakeLists.txt
+++ b/Gems/Prefab/PrefabBuilder/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 ly_add_target(
     NAME PrefabBuilder.Static STATIC
     NAMESPACE Gem
+    INCLUDE_DIRECTORIES
+        PRIVATE
+            .
     FILES_CMAKE
         prefabbuilder_files.cmake
     BUILD_DEPENDENCIES
@@ -20,6 +23,9 @@ ly_add_target(
             AZ::AzCore
             AZ::AzToolsFramework
             AZ::AssetBuilderSDK
+            AZ::SceneCore
+            AZ::SceneData
+            3rdParty::RapidJSON
 )
 
 ly_add_target(

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/IPrefabGroup.h
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/IPrefabGroup.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <AzCore/RTTI/RTTI.h>
+#include <SceneAPI/SceneCore/DataTypes/Groups/ISceneNodeGroup.h>
+#include <AzToolsFramework/Prefab/PrefabDomTypes.h>
+
+namespace AZ::SceneAPI::DataTypes
+{
+    class IPrefabGroup
+        : public ISceneNodeGroup
+    {
+    public:
+        AZ_RTTI(IPrefabGroup, "{7E50FAEF-3379-4521-99C5-B428FDEE3B7B}", ISceneNodeGroup);
+
+        ~IPrefabGroup() override = default;
+        virtual const AzToolsFramework::Prefab::PrefabDom& GetPrefabDom() const = 0;
+    };
+}

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroup.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroup.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <PrefabGroup/PrefabGroup.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/JSON/error/error.h>
+#include <AzCore/JSON/error/en.h>
+
+namespace AZ::SceneAPI::SceneData
+{
+     PrefabGroup::PrefabGroup()
+        : m_id(Uuid::CreateNull())
+        , m_name()
+    {
+         m_prefabDom.SetNull();
+    }
+
+    const AZStd::string& PrefabGroup::GetName() const
+    {
+        return m_name;
+    }
+
+    void PrefabGroup::SetName(AZStd::string name)
+    {
+        m_name = AZStd::move(name);
+    }
+
+    const Uuid& PrefabGroup::GetId() const
+    {
+        return m_id;
+    }
+
+    void PrefabGroup::SetId(Uuid id)
+    {
+        m_id = AZStd::move(id);
+    }
+
+    Containers::RuleContainer& PrefabGroup::GetRuleContainer()
+    {
+        return m_rules;
+    }
+
+    const Containers::RuleContainer& PrefabGroup::GetRuleContainerConst() const
+    {
+        return m_rules;
+    }
+            
+    DataTypes::ISceneNodeSelectionList& PrefabGroup::GetSceneNodeSelectionList()
+    {
+        return m_nodeSelectionList;
+    }
+
+    const DataTypes::ISceneNodeSelectionList& PrefabGroup::GetSceneNodeSelectionList() const
+    {
+        return m_nodeSelectionList;
+    }
+
+    void PrefabGroup::SetPrefabDom(AzToolsFramework::Prefab::PrefabDom prefabDom)
+    {
+        m_prefabDom = AZStd::move(prefabDom);
+        m_prefabDomBuffer.clear();
+    }
+
+    void PrefabGroup::SetPrefabDomBuffer(AZStd::string prefabDomBuffer)
+    {
+        m_prefabDomBuffer = AZStd::move(prefabDomBuffer);
+        m_prefabDom.SetNull();
+    }
+
+    const AzToolsFramework::Prefab::PrefabDom& PrefabGroup::GetPrefabDom() const
+    {
+        if (!m_prefabDom.HasParseError() && !m_prefabDom.IsNull())
+        {
+            // DOM is ready
+            return m_prefabDom;
+        }
+        else if (m_prefabDomBuffer.empty())
+        {
+            m_prefabDom.SetNull();
+            return m_prefabDom;
+        }
+
+        m_prefabDom.Parse<rapidjson::kParseCommentsFlag>(m_prefabDomBuffer.c_str());
+        if (m_prefabDom.HasParseError())
+        {
+            AZ_Warning(
+                "prefab",
+                false,
+                "JSON error during parsing at offset %zu: %s",
+                m_prefabDom.GetErrorOffset(),
+                rapidjson::GetParseError_En(m_prefabDom.GetParseError()));
+
+            m_prefabDom.SetNull();
+            return m_prefabDom;
+        }
+
+        return m_prefabDom;
+    }
+
+    void PrefabGroup::Reflect(ReflectContext* context)
+    {
+        SerializeContext* serializeContext = azrtti_cast<SerializeContext*>(context);
+        if (serializeContext)
+        {
+            serializeContext->Class<DataTypes::IPrefabGroup, DataTypes::ISceneNodeGroup>()
+                ->Version(1);
+
+            serializeContext->Class<PrefabGroup, DataTypes::IPrefabGroup>()
+                ->Version(1)
+                ->Field("name", &PrefabGroup::m_name)
+                ->Field("nodeSelectionList", &PrefabGroup::m_nodeSelectionList)
+                ->Field("rules", &PrefabGroup::m_rules)
+                ->Field("id", &PrefabGroup::m_id)
+                ->Field("prefabDomBuffer", &PrefabGroup::m_prefabDomBuffer);
+        }
+
+        BehaviorContext* behaviorContext = azrtti_cast<BehaviorContext*>(context);
+        if (behaviorContext)
+        {
+            behaviorContext->Class<PrefabGroup>()
+                ->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::All)
+                ->Attribute(Script::Attributes::Scope, Script::Attributes::ScopeFlags::Common)
+                ->Attribute(Script::Attributes::Module, "prefab")
+                ->Property("name", BehaviorValueProperty(&PrefabGroup::m_name))
+                ->Property("id", BehaviorValueProperty(&PrefabGroup::m_id))
+                ->Property("prefabDomBuffer", BehaviorValueProperty(&PrefabGroup::m_prefabDomBuffer));
+        }
+    }
+}

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroup.h
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroup.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#pragma once
+
+#include <PrefabGroup/IPrefabGroup.h>
+#include <AzCore/Memory/Memory.h>
+#include <AzCore/Memory/SystemAllocator.h>
+#include <AzCore/std/containers/vector.h>
+#include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <SceneAPI/SceneCore/Containers/RuleContainer.h>
+#include <SceneAPI/SceneData/ManifestBase/SceneNodeSelectionList.h>
+
+namespace AZ
+{
+    class ReflectContext;
+}
+
+namespace AZ::SceneAPI::Containers
+{
+    class Scene;
+}
+
+namespace AZ::SceneAPI::SceneData
+{
+    class PrefabGroup final
+        : public DataTypes::IPrefabGroup
+    {
+    public:
+        AZ_RTTI(PrefabGroup, "{99FE3C6F-5B55-4D8B-8013-2708010EC715}", DataTypes::IPrefabGroup);
+        AZ_CLASS_ALLOCATOR(PrefabGroup, SystemAllocator, 0);
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        PrefabGroup();
+        ~PrefabGroup() override = default;
+
+        // DataTypes::IPrefabGroup
+        const AzToolsFramework::Prefab::PrefabDom& GetPrefabDom() const override;
+        const AZStd::string& GetName() const override;
+        const Uuid& GetId() const override;
+        Containers::RuleContainer& GetRuleContainer() override;
+        const Containers::RuleContainer& GetRuleContainerConst() const override;
+        DataTypes::ISceneNodeSelectionList& GetSceneNodeSelectionList() override;
+        const DataTypes::ISceneNodeSelectionList& GetSceneNodeSelectionList() const override;
+
+        // Concrete API
+        void SetId(Uuid id);
+        void SetName(AZStd::string name);
+        void SetPrefabDom(AzToolsFramework::Prefab::PrefabDom prefabDom);
+        void SetPrefabDomBuffer(AZStd::string prefabDomBuffer);
+        const AZStd::string& GetPrefabDomBuffer() const { return m_prefabDomBuffer; }
+
+    private:
+        SceneNodeSelectionList m_nodeSelectionList;
+        Containers::RuleContainer m_rules;
+        AZStd::string m_name;
+        Uuid m_id;
+        AZStd::string m_prefabDomBuffer;
+        mutable AzToolsFramework::Prefab::PrefabDom m_prefabDom;
+    };
+
+}

--- a/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupTests.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroup/PrefabGroupTests.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <PrefabBuilderTests.h>
+#include <PrefabGroup/IPrefabGroup.h>
+#include <PrefabGroup/PrefabGroup.h>
+#include <AzCore/Serialization/Json/JsonSystemComponent.h>
+
+namespace UnitTest
+{
+    TEST_F(PrefabBuilderTests, PrefabGroup_FindsRequiredReflection_True)
+    {
+        using namespace AZ::SceneAPI;
+        auto* serializeContext = m_app.GetSerializeContext();
+        ASSERT_NE(nullptr, serializeContext);
+        SceneData::PrefabGroup::Reflect(serializeContext);
+        ASSERT_NE(nullptr, serializeContext->FindClassData(azrtti_typeid<DataTypes::IPrefabGroup>()));
+        ASSERT_NE(nullptr, serializeContext->FindClassData(azrtti_typeid<SceneData::PrefabGroup>()));
+
+        auto findElementWithName = [](const AZ::SerializeContext::ClassData* classData, const char* name)
+        {
+            auto it = AZStd::find_if(classData->m_elements.begin(), classData->m_elements.end(), [name](const auto& element)
+            {
+                return strcmp(element.m_name, name) == 0;
+            });
+            return it != classData->m_elements.end();
+        };
+
+        auto* prefabGroupClassData = serializeContext->FindClassData(azrtti_typeid<SceneData::PrefabGroup>());
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "name"));
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "nodeSelectionList"));
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "rules"));
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "id"));
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "prefabDomBuffer"));
+    }
+
+    TEST_F(PrefabBuilderTests, PrefabGroup_JsonWithPrefabArbitraryPrefab_Works)
+    {
+        using namespace AZ::SceneAPI;
+        auto* serializeContext = m_app.GetSerializeContext();
+        ASSERT_NE(nullptr, serializeContext);
+        SceneData::PrefabGroup::Reflect(serializeContext);
+
+        // fill out a PrefabGroup using JSON
+        AZStd::string_view input = R"JSON(
+        {
+            "name" : "tester",
+            "id" : "{49698DBC-B447-49EF-9B56-25BB29342AFB}",
+            "prefabDomBuffer" : "{\"foo\":\"bar\"}"
+        })JSON";
+
+        rapidjson::Document document;
+        document.Parse<rapidjson::kParseCommentsFlag>(input.data(), input.size());
+        ASSERT_FALSE(document.HasParseError());
+
+        SceneData::PrefabGroup instancePrefabGroup;
+        AZ::JsonSerialization::Load(instancePrefabGroup, document);
+
+        const auto& dom = instancePrefabGroup.GetPrefabDom();
+        EXPECT_TRUE(dom.GetObject().HasMember("foo"));
+        EXPECT_STREQ(dom.GetObject().FindMember("foo")->value.GetString(), "bar");
+        EXPECT_STREQ(instancePrefabGroup.GetName().c_str(), "tester");
+        EXPECT_STREQ(
+            instancePrefabGroup.GetId().ToString<AZStd::string>().c_str(),
+            "{49698DBC-B447-49EF-9B56-25BB29342AFB}");
+        EXPECT_TRUE(instancePrefabGroup.GetPrefabDom().IsObject());
+    }
+
+    TEST_F(PrefabBuilderTests, PrefabGroup_InvalidPrefabJson_Detected)
+    {
+        using namespace AZ::SceneAPI;
+
+        AZStd::string_view input = R"JSON(
+        {
+            bad json that will not parse
+        })JSON";
+
+        rapidjson::Document document;
+        document.Parse<rapidjson::kParseCommentsFlag>(input.data(), input.size());
+
+        SceneData::PrefabGroup prefabGroup;
+        prefabGroup.SetId(AZStd::move(AZ::Uuid::CreateRandom()));
+        prefabGroup.SetName(AZStd::move("tester"));
+        prefabGroup.SetPrefabDom(AZStd::move(document));
+
+        const auto& dom = prefabGroup.GetPrefabDom();
+        EXPECT_TRUE(dom.IsNull());
+        EXPECT_STREQ("tester", prefabGroup.GetName().c_str());
+    }
+
+    TEST_F(PrefabBuilderTests, PrefabGroup_InvalidPrefabJsonBuffer_Detected)
+    {
+        using namespace AZ::SceneAPI;
+
+        AZStd::string_view inputJson = R"JSON(
+        {
+            bad json that will not parse
+        })JSON";
+
+        SceneData::PrefabGroup prefabGroup;
+        prefabGroup.SetId(AZStd::move(AZ::Uuid::CreateRandom()));
+        prefabGroup.SetName(AZStd::move("tester"));
+        prefabGroup.SetPrefabDomBuffer(std::move(inputJson));
+
+        const auto& dom = prefabGroup.GetPrefabDom();
+        EXPECT_TRUE(dom.IsNull());
+        EXPECT_STREQ("tester", prefabGroup.GetName().c_str());
+    }
+
+    struct PrefabBuilderBehaviorTests
+        : public PrefabBuilderTests
+    {
+        void SetUp() override
+        {
+            using namespace AZ::SceneAPI;
+
+            PrefabBuilderTests::SetUp();
+            SceneData::PrefabGroup::Reflect(m_app.GetSerializeContext());
+            SceneData::PrefabGroup::Reflect(m_app.GetBehaviorContext());
+            m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
+            m_scriptContext->BindTo(m_app.GetBehaviorContext());
+        }
+
+        void TearDown() override
+        {
+            m_scriptContext.reset();
+            PrefabBuilderTests::TearDown();
+        }
+
+        void ExpectExecute(AZStd::string_view script)
+        {
+            EXPECT_TRUE(m_scriptContext->Execute(script.data()));
+        }
+
+        AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext;
+    };
+
+    TEST_F(PrefabBuilderBehaviorTests, PrefabGroup_PrefabGroupClass_Exists)
+    {
+        ExpectExecute("group = PrefabGroup()");
+        ExpectExecute("assert(group)");
+        ExpectExecute("assert(group.name)");
+        ExpectExecute("assert(group.id)");
+        ExpectExecute("assert(group.prefabDomBuffer)");
+    }
+
+    TEST_F(PrefabBuilderBehaviorTests, PrefabGroup_PrefabGroupAssignment_Works)
+    {
+        ExpectExecute("group = PrefabGroup()");
+        ExpectExecute("group.name = 'tester'");
+        ExpectExecute("group.id = Uuid.CreateString('{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}', 0)");
+        ExpectExecute("group.prefabDomBuffer = '{}'");
+        ExpectExecute("assert(group.name == 'tester')");
+        ExpectExecute("assert(tostring(group.id) == '{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}')");
+        ExpectExecute("assert(group.prefabDomBuffer == '{}')");
+    }
+}

--- a/Gems/Prefab/PrefabBuilder/PrefabGroupTests.cpp
+++ b/Gems/Prefab/PrefabBuilder/PrefabGroupTests.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <PrefabGroup/PrefabBuilderTests.h>
+#include <PrefabGroup/IPrefabGroup.h>
+#include <PrefabGroup/PrefabGroup.h>
+#include <AzCore/Serialization/Json/JsonSystemComponent.h>
+
+namespace UnitTest
+{
+    TEST_F(PrefabBuilderTests, PrefabGroup_FindsRequiredReflection_True)
+    {
+        using namespace AZ::SceneAPI;
+        auto* serializeContext = m_app.GetSerializeContext();
+        ASSERT_NE(nullptr, serializeContext);
+        SceneData::PrefabGroup::Reflect(serializeContext);
+        ASSERT_NE(nullptr, serializeContext->FindClassData(azrtti_typeid<DataTypes::IPrefabGroup>()));
+        ASSERT_NE(nullptr, serializeContext->FindClassData(azrtti_typeid<SceneData::PrefabGroup>()));
+
+        auto findElementWithName = [](const AZ::SerializeContext::ClassData* classData, const char* name)
+        {
+            auto it = AZStd::find_if(classData->m_elements.begin(), classData->m_elements.end(), [name](const auto& element)
+            {
+                return strcmp(element.m_name, name) == 0;
+            });
+            return it != classData->m_elements.end();
+        };
+
+        auto* prefabGroupClassData = serializeContext->FindClassData(azrtti_typeid<SceneData::PrefabGroup>());
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "name"));
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "nodeSelectionList"));
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "rules"));
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "id"));
+        EXPECT_TRUE(findElementWithName(prefabGroupClassData, "prefabDomBuffer"));
+    }
+
+    TEST_F(PrefabBuilderTests, PrefabGroup_JsonWithPrefabArbitraryPrefab_Works)
+    {
+        using namespace AZ::SceneAPI;
+        auto* serializeContext = m_app.GetSerializeContext();
+        ASSERT_NE(nullptr, serializeContext);
+        SceneData::PrefabGroup::Reflect(serializeContext);
+
+        // fill out a PrefabGroup using JSON
+        AZStd::string_view input = R"JSON(
+        {
+            "name" : "tester",
+            "id" : "{49698DBC-B447-49EF-9B56-25BB29342AFB}",
+            "prefabDomBuffer" : "{\"foo\":\"bar\"}"
+        })JSON";
+
+        rapidjson::Document document;
+        document.Parse<rapidjson::kParseCommentsFlag>(input.data(), input.size());
+        ASSERT_FALSE(document.HasParseError());
+
+        SceneData::PrefabGroup instancePrefabGroup;
+        AZ::JsonSerialization::Load(instancePrefabGroup, document);
+
+        const auto& dom = instancePrefabGroup.GetPrefabDom();
+        EXPECT_TRUE(dom.GetObject().HasMember("foo"));
+        EXPECT_STREQ(dom.GetObject().FindMember("foo")->value.GetString(), "bar");
+        EXPECT_STREQ(instancePrefabGroup.GetName().c_str(), "tester");
+        EXPECT_STREQ(
+            instancePrefabGroup.GetId().ToString<AZStd::string>().c_str(),
+            "{49698DBC-B447-49EF-9B56-25BB29342AFB}");
+        EXPECT_TRUE(instancePrefabGroup.GetPrefabDom().IsObject());
+    }
+
+    TEST_F(PrefabBuilderTests, PrefabGroup_InvalidPrefabJson_Detected)
+    {
+        using namespace AZ::SceneAPI;
+
+        AZStd::string_view input = R"JSON(
+        {
+            bad json that will not parse
+        })JSON";
+
+        rapidjson::Document document;
+        document.Parse<rapidjson::kParseCommentsFlag>(input.data(), input.size());
+
+        SceneData::PrefabGroup prefabGroup;
+        prefabGroup.SetId(AZStd::move(AZ::Uuid::CreateRandom()));
+        prefabGroup.SetName(AZStd::move("tester"));
+        prefabGroup.SetPrefabDom(AZStd::move(document));
+
+        const auto& dom = prefabGroup.GetPrefabDom();
+        EXPECT_TRUE(dom.IsNull());
+        EXPECT_STREQ("tester", prefabGroup.GetName().c_str());
+    }
+
+    TEST_F(PrefabBuilderTests, PrefabGroup_InvalidPrefabJsonBuffer_Detected)
+    {
+        using namespace AZ::SceneAPI;
+
+        AZStd::string_view inputJson = R"JSON(
+        {
+            bad json that will not parse
+        })JSON";
+
+        SceneData::PrefabGroup prefabGroup;
+        prefabGroup.SetId(AZStd::move(AZ::Uuid::CreateRandom()));
+        prefabGroup.SetName(AZStd::move("tester"));
+        prefabGroup.SetPrefabDomBuffer(std::move(inputJson));
+
+        const auto& dom = prefabGroup.GetPrefabDom();
+        EXPECT_TRUE(dom.IsNull());
+        EXPECT_STREQ("tester", prefabGroup.GetName().c_str());
+    }
+
+    struct PrefabBuilderBehaviorTests
+        : public PrefabBuilderTests
+    {
+        void SetUp() override
+        {
+            using namespace AZ::SceneAPI;
+
+            PrefabBuilderTests::SetUp();
+            SceneData::PrefabGroup::Reflect(m_app.GetSerializeContext());
+            SceneData::PrefabGroup::Reflect(m_app.GetBehaviorContext());
+            m_scriptContext = AZStd::make_unique<AZ::ScriptContext>();
+            m_scriptContext->BindTo(m_app.GetBehaviorContext());
+        }
+
+        void TearDown() override
+        {
+            m_scriptContext.reset();
+            PrefabBuilderTests::TearDown();
+        }
+
+        void ExpectExecute(AZStd::string_view script)
+        {
+            EXPECT_TRUE(m_scriptContext->Execute(script.data()));
+        }
+
+        AZStd::unique_ptr<AZ::ScriptContext> m_scriptContext;
+    };
+
+    TEST_F(PrefabBuilderBehaviorTests, PrefabGroup_PrefabGroupClass_Exists)
+    {
+        ExpectExecute("group = PrefabGroup()");
+        ExpectExecute("assert(group)");
+        ExpectExecute("assert(group.name)");
+        ExpectExecute("assert(group.id)");
+        ExpectExecute("assert(group.prefabDomBuffer)");
+    }
+
+    TEST_F(PrefabBuilderBehaviorTests, PrefabGroup_PrefabGroupAssignment_Works)
+    {
+        ExpectExecute("group = PrefabGroup()");
+        ExpectExecute("group.name = 'tester'");
+        ExpectExecute("group.id = Uuid.CreateString('{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}', 0)");
+        ExpectExecute("group.prefabDomBuffer = '{}'");
+        ExpectExecute("assert(group.name == 'tester')");
+        ExpectExecute("assert(tostring(group.id) == '{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}')");
+        ExpectExecute("assert(group.prefabDomBuffer == '{}')");
+    }
+}

--- a/Gems/Prefab/PrefabBuilder/prefabbuilder_files.cmake
+++ b/Gems/Prefab/PrefabBuilder/prefabbuilder_files.cmake
@@ -9,4 +9,7 @@
 set(FILES
     PrefabBuilderComponent.h
     PrefabBuilderComponent.cpp
+    PrefabGroup/IPrefabGroup.h
+    PrefabGroup/PrefabGroup.cpp
+    PrefabGroup/PrefabGroup.h
 )

--- a/Gems/Prefab/PrefabBuilder/prefabbuilder_tests_files.cmake
+++ b/Gems/Prefab/PrefabBuilder/prefabbuilder_tests_files.cmake
@@ -9,4 +9,5 @@
 set(FILES
     PrefabBuilderTests.h
     PrefabBuilderTests.cpp
+    PrefabGroup/PrefabGroupTests.cpp
 )


### PR DESCRIPTION
* Adding PrefabGroup abstraction and concrete classes to fill out in a scene manifest
* has reflections for serialization & behavior
* testing the behavior using Lua
* testing the serialization using JSON

Signed-off-by: jackalbe <23512001+jackalbe@users.noreply.github.com>