### PR TITLE
[Hair - resolved the multi pipeline mismatches and crashes + cleaned initialization & leftovers

### DIFF
--- a/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
+++ b/Gems/Atom/Bootstrap/Code/Source/BootstrapSystemComponent.cpp
@@ -86,6 +86,7 @@ namespace AZ
                 dependent.push_back(AZ_CRC("CoreLightsService", 0x91932ef6));
                 dependent.push_back(AZ_CRC("DynamicDrawService", 0x023c1673));
                 dependent.push_back(AZ_CRC("CommonService", 0x6398eec4));
+                dependent.push_back(AZ_CRC_CE("HairService"));
             }
 
             void BootstrapSystemComponent::GetIncompatibleServices(ComponentDescriptor::DependencyArrayType& incompatible)

--- a/Gems/AtomTressFX/Code/Components/HairSystemComponent.cpp
+++ b/Gems/AtomTressFX/Code/Components/HairSystemComponent.cpp
@@ -87,7 +87,6 @@ namespace AZ
             void HairSystemComponent::Deactivate()
             {
                 AZ::RPI::FeatureProcessorFactory::Get()->UnregisterFeatureProcessor<Hair::HairFeatureProcessor>();
-
                 m_loadTemplatesHandler.Disconnect();
             }
         } // namespace Hair

--- a/Gems/AtomTressFX/Code/Passes/HairPPLLRasterPass.cpp
+++ b/Gems/AtomTressFX/Code/Passes/HairPPLLRasterPass.cpp
@@ -158,13 +158,13 @@ namespace AZ
                 RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
                 shaderVariant.ConfigurePipelineState(pipelineStateDescriptor);
 
-                RHI::DrawListTag drawListTag = m_shader->GetDrawListTag();
-                RPI::Scene* scene = RPI::RPISystemInterface::Get()->GetDefaultScene().get();
+                RPI::Scene* scene = GetScene();
                 if (!scene)
                 {
                     AZ_Error("Hair Gem", false, "Scene could not be acquired" );
                     return false;
                 }
+                RHI::DrawListTag drawListTag = m_shader->GetDrawListTag();
                 scene->ConfigurePipelineState(drawListTag, pipelineStateDescriptor);
 
                 pipelineStateDescriptor.m_renderAttachmentConfiguration = GetRenderAttachmentConfiguration();
@@ -312,4 +312,3 @@ namespace AZ
         } // namespace Hair
     }   // namespace Render
 }   // namespace AZ
-

--- a/Gems/AtomTressFX/Code/Passes/HairPPLLRasterPass.h
+++ b/Gems/AtomTressFX/Code/Passes/HairPPLLRasterPass.h
@@ -30,8 +30,6 @@ namespace AZ
             class HairRenderObject;
             class HairFeatureProcessor;
 
-            static const char* const HairPPLLRasterPassTemplateName = "HairPPLLRasterPassTemplate";
-
             //! A HairPPLLRasterPass is used for the hair fragments fill render after the data
             //!  went through the skinning and simulation passes.
             //! The output of this pass is the general list of fragment data that can now be

--- a/Gems/AtomTressFX/Code/Passes/HairPPLLResolvePass.h
+++ b/Gems/AtomTressFX/Code/Passes/HairPPLLResolvePass.h
@@ -24,7 +24,6 @@ namespace AZ
     {
         namespace Hair
         {
-            static const char* const HairPPLLResolvePassName = "HairPPLLResolvePass";
             class HairFeatureProcessor;
 
             //! The hair PPLL resolve pass is a full screen pass that runs over the hair fragments list

--- a/Gems/AtomTressFX/Code/Passes/HairPPLLResolvePass.h
+++ b/Gems/AtomTressFX/Code/Passes/HairPPLLResolvePass.h
@@ -24,7 +24,7 @@ namespace AZ
     {
         namespace Hair
         {
-            static const char* const HairPPLLResolvePassTemplateName = "HairPPLLResolvePassTemplate";
+            static const char* const HairPPLLResolvePassName = "HairPPLLResolvePass";
             class HairFeatureProcessor;
 
             //! The hair PPLL resolve pass is a full screen pass that runs over the hair fragments list

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -44,7 +44,6 @@ namespace AZ
     {
         namespace Hair
         {
-            const char* HairFeatureProcessor::s_featureProcessorName = "HairFeatureProcessor";
             uint32_t HairFeatureProcessor::s_instanceCount = 0;
 
             HairFeatureProcessor::HairFeatureProcessor()

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -49,12 +49,17 @@ namespace AZ
 
             HairFeatureProcessor::HairFeatureProcessor()
             {
-                GlobalShapeConstraintsPass = Name{ "HairGlobalShapeConstraintsComputePassTemplate" };
-                CalculateStrandDataPass = Name{ "HairCalculateStrandLevelDataComputePassTemplate" };
-                VelocityShockPropagationPass = Name{ "HairVelocityShockPropagationComputePassTemplate" };
-                LocalShapeConstraintsPass = Name{ "HairLocalShapeConstraintsComputePassTemplate" };
-                LengthConstriantsWindAndCollisionPass = Name{ "HairLengthConstraintsWindAndCollisionComputePassTemplate" };
-                UpdateFollowHairPass = Name{ "HairUpdateFollowHairComputePassTemplate" };
+                HairParentPassName = Name{ "HairParentPass" };
+
+                HairPPLLRasterPassName = Name{ "HairPPLLRasterPass" };
+                HairPPLLResolvePassName = Name{ "HairPPLLResolvePass" };
+
+                GlobalShapeConstraintsPassName = Name{ "HairGlobalShapeConstraintsComputePass" };
+                CalculateStrandDataPassName = Name{ "HairCalculateStrandLevelDataComputePass" };
+                VelocityShockPropagationPassName = Name{ "HairVelocityShockPropagationComputePass" };
+                LocalShapeConstraintsPassName = Name{ "HairLocalShapeConstraintsComputePass" };
+                LengthConstriantsWindAndCollisionPassName = Name{ "HairLengthConstraintsWindAndCollisionComputePass" };
+                UpdateFollowHairPassName = Name{ "HairUpdateFollowHairComputePass" };
 
                 ++s_instanceCount;
 
@@ -101,7 +106,7 @@ namespace AZ
             {
                 const float MAX_SIMULATION_TIME_STEP = 0.033f;  // Assuming minimal of 30 fps
                 m_currentDeltaTime = AZStd::min(deltaTime, MAX_SIMULATION_TIME_STEP);
-                for (auto object : m_hairRenderObjects )
+                for (auto object : m_hairRenderObjects)
                 {
                     object->SetFrameDeltaTime(m_currentDeltaTime);
                 }
@@ -116,7 +121,7 @@ namespace AZ
             {
                 if (!m_initialized)
                 {
-                    Init();
+                    Init(m_renderPipeline);
                 }
 
                 m_hairRenderObjects.push_back(renderObject);
@@ -134,7 +139,7 @@ namespace AZ
                 // to be reconnected and then loaded again.
                 return;
 
-                for (auto mapIter = m_computePasses.begin() ; mapIter != m_computePasses.end(); ++mapIter)
+                for (auto mapIter = m_computePasses.begin(); mapIter != m_computePasses.end(); ++mapIter)
                 {
                     mapIter->second->SetEnabled(enable);
                 }
@@ -144,7 +149,7 @@ namespace AZ
 
             bool HairFeatureProcessor::RemoveHairRenderObject(Data::Instance<HairRenderObject> renderObject)
             {
-                for ( auto objIter = m_hairRenderObjects.begin() ; objIter != m_hairRenderObjects.end() ; ++objIter )
+                for (auto objIter = m_hairRenderObjects.begin(); objIter != m_hairRenderObjects.end(); ++objIter)
                 {
                     if (objIter->get() == renderObject)
                     {
@@ -202,7 +207,7 @@ namespace AZ
                 AZ_ATOM_PROFILE_FUNCTION("Hair", "HairFeatureProcessor: Simulate");
                 AZ_UNUSED(packet);
 
-                if (m_hairRenderObjects.empty() || (!m_initialized && !Init()))
+                if (m_hairRenderObjects.empty())
                 {   // there might not be are no render objects yet, indicating that scene data might not be ready
                     // to initialize just yet.
                     return;
@@ -221,7 +226,7 @@ namespace AZ
                 // Prepare materials array for the per pass srg
                 std::vector<const AMD::TressFXRenderParams*> hairObjectsRenderMaterials;
                 uint32_t obj = 0;
-                for ( auto objIter = m_hairRenderObjects.begin() ; objIter != m_hairRenderObjects.end(); ++objIter, ++obj )
+                for (auto objIter = m_hairRenderObjects.begin(); objIter != m_hairRenderObjects.end(); ++objIter, ++obj)
                 {
                     HairRenderObject* renderObject = objIter->get();
                     if (!renderObject->IsEnabled())
@@ -250,11 +255,10 @@ namespace AZ
                 AZ_PROFILE_FUNCTION(Debug::ProfileCategory::Hair);
                 AZ_ATOM_PROFILE_FUNCTION("Hair", "HairFeatureProcessor: Render");
 
-                if (!m_initialized && !Init())
+                if (!m_initialized)
                 {
                     return;
                 }
-
 
                 // [To Do] - no culling scheme applied yet.
                 // Possibly setup the hair culling work group to be re-used for each view.
@@ -290,12 +294,18 @@ namespace AZ
 
                 // Mark for all passes to evacuate their render data and recreate it.
                 m_forceRebuildRenderData = true;
-                m_forceClearRenderData = true; 
+                m_forceClearRenderData = true;
             }
 
             void HairFeatureProcessor::OnRenderPipelineAdded([[maybe_unused]] RPI::RenderPipelinePtr pipeline)
             {
-                Init();
+                // Is the pass a main pipeline pass that requires a change / initialization of the pipeline.
+                if (!pipeline.get()->GetRootPass()->FindPassByNameRecursive(HairParentPassName))
+                {
+                    return;
+                }
+
+                Init(pipeline.get());
 
                 // Mark for all passes to evacuate their render data and recreate it.
                 m_forceRebuildRenderData = true;
@@ -303,17 +313,24 @@ namespace AZ
 
             void HairFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* pipeline)
             {
+                m_renderPipeline = nullptr;
                 ClearPasses();
             }
 
             void HairFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
             {
-                Init();
+                // Is the pass a main pipeline pass that requires a change / initialization of the pipeline.
+                if (!renderPipeline->GetRootPass()->FindPassByNameRecursive(HairParentPassName))
+                {
+                    return;
+                }
+
+                Init(renderPipeline);
 
                 // Mark for all passes to evacuate their render data and recreate it.
                 m_forceRebuildRenderData = true;
             }
-            
+
             void HairFeatureProcessor::OnBeginPrepareRender()
             {
                 RPI::FeatureProcessor::OnBeginPrepareRender();
@@ -324,17 +341,19 @@ namespace AZ
                 RPI::FeatureProcessor::OnEndPrepareRender();
             }
 
-            bool HairFeatureProcessor::Init()
+            bool HairFeatureProcessor::Init(RPI::RenderPipeline* renderPipeline)
             {
+                m_renderPipeline = renderPipeline;
+
                 ClearPasses();
 
                 // Compute Passes - populate the passes map
-                bool resultSuccess = InitComputePass(GlobalShapeConstraintsPass);
-                resultSuccess &= InitComputePass(CalculateStrandDataPass);
-                resultSuccess &= InitComputePass(VelocityShockPropagationPass);
-                resultSuccess &= InitComputePass(LocalShapeConstraintsPass, true);  // restore shape over several iterations
-                resultSuccess &= InitComputePass(LengthConstriantsWindAndCollisionPass);
-                resultSuccess &= InitComputePass(UpdateFollowHairPass);
+                bool resultSuccess = InitComputePass(GlobalShapeConstraintsPassName);
+                resultSuccess &= InitComputePass(CalculateStrandDataPassName);
+                resultSuccess &= InitComputePass(VelocityShockPropagationPassName);
+                resultSuccess &= InitComputePass(LocalShapeConstraintsPassName, true);  // restore shape over several iterations
+                resultSuccess &= InitComputePass(LengthConstriantsWindAndCollisionPassName);
+                resultSuccess &= InitComputePass(UpdateFollowHairPassName);
 
                 // Rendering Passes
                 resultSuccess &= InitPPLLFillPass();
@@ -380,7 +399,7 @@ namespace AZ
                     descriptor = SrgBufferDescriptor(
                         RPI::CommonBufferPoolType::ReadWrite, RHI::Format::Unknown,
                         PPLL_NODE_SIZE, RESERVED_PIXELS_FOR_OIT,
-                        Name{ "LinkedListNodesPPLL" + instanceNumber}, Name{ "m_linkedListNodes" }, 0, 0
+                        Name{ "LinkedListNodesPPLL" + instanceNumber }, Name{ "m_linkedListNodes" }, 0, 0
                     );
                     m_linkedListNodesBuffer = UtilityClass::CreateBuffer("Hair Gem", descriptor, nullptr);
                     if (!m_linkedListNodesBuffer)
@@ -412,58 +431,48 @@ namespace AZ
             bool HairFeatureProcessor::InitComputePass(const Name& passName, bool allowIterations)
             {
                 m_computePasses[passName] = nullptr;
-
-                RPI::PassSystemInterface* passSystem = RPI::PassSystemInterface::Get();
-                if (passSystem->HasPassesForTemplateName(passName))
+                if (!m_renderPipeline)
                 {
-                    auto& desiredPasses = passSystem->GetPassesForTemplateName(passName);
-                    if (!desiredPasses.empty() && desiredPasses[0])
-                    {
-                        m_computePasses[passName] = static_cast<HairSkinningComputePass*>(desiredPasses[0]);
-                        m_computePasses[passName]->SetFeatureProcessor(this);
-                        m_computePasses[passName]->SetAllowIterations(allowIterations);
-                    }
-                    else
-                    {
-                        AZ_Error("Hair Gem", false,
-                            "%s does not have any valid passes. Check your game project's .pass assets.",
-                            passName.GetCStr());
-                        return false;
-                    }
+                    AZ_Error("Hair Gem", false, "%s does NOT have renderr pipeline set yet", passName.GetCStr());
+                    return false;
+                }
+
+                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(AZ::Name{ passName });
+                if (desiredPass)
+                {
+                    m_computePasses[passName] = static_cast<HairSkinningComputePass*>(desiredPass.get());
+                    m_computePasses[passName]->SetFeatureProcessor(this);
+                    m_computePasses[passName]->SetAllowIterations(allowIterations);
                 }
                 else
                 {
                     AZ_Error("Hair Gem", false,
-                        "Failed to find passes for %s. Check your game project's .pass assets.",
+                        "%s does not have any valid passes. Check your game project's .pass assets.",
                         passName.GetCStr());
                     return false;
                 }
+
                 return true;
             }
 
             bool HairFeatureProcessor::InitPPLLFillPass()
             {
                 m_hairPPLLRasterPass = nullptr;   // reset it to null, just in case it fails to load the assets properly
-
-                RPI::PassSystemInterface* passSystem = RPI::PassSystemInterface::Get();
-                if (passSystem->HasPassesForTemplateName(AZ::Name{HairPPLLRasterPassTemplateName}))
+                if (!m_renderPipeline)
                 {
-                    auto& desiredPasses = passSystem->GetPassesForTemplateName(AZ::Name{HairPPLLRasterPassTemplateName});
+                    AZ_Error("Hair Gem", false, "Hair Fill Pass does NOT have renderr pipeline set yet");
+                    return false;
+                }
 
-                    // For now, assume one skinning pass
-                    if (!desiredPasses.empty() && desiredPasses[0])
-                    {
-                        m_hairPPLLRasterPass = static_cast<HairPPLLRasterPass*>(desiredPasses[0]);
-                        m_hairPPLLRasterPass->SetFeatureProcessor(this);                  }
-                    else
-                    {
-                        AZ_Error("Hair Gem", false, "HairPPLLRasterPassTemplate does not have any valid passes. Check your game project's .pass assets.");
-                        return false;
-                    }
+                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(AZ::Name{ HairPPLLRasterPassName });
+                if (desiredPass)
+                {
+                    m_hairPPLLRasterPass = static_cast<HairPPLLRasterPass*>(desiredPass.get());
+                    m_hairPPLLRasterPass->SetFeatureProcessor(this);
                 }
                 else
                 {
-                    AZ_Error("Hair Gem", false, "Failed to find passes for HairPPLLRasterPassTemplate. Check your game project's .pass assets.");
+                    AZ_Error("Hair Gem", false, "HairPPLLRasterPass does not have any valid passes. Check your game project's .pass assets.");
                     return false;
                 }
                 return true;
@@ -472,27 +481,22 @@ namespace AZ
             bool HairFeatureProcessor::InitPPLLResolvePass()
             {
                 m_hairPPLLResolvePass = nullptr;   // reset it to null, just in case it fails to load the assets properly
-
-                RPI::PassSystemInterface* passSystem = RPI::PassSystemInterface::Get();
-                if (passSystem->HasPassesForTemplateName(AZ::Name{HairPPLLResolvePassTemplateName}))
+                if (!m_renderPipeline)
                 {
-                    auto& desiredPasses = passSystem->GetPassesForTemplateName(AZ::Name{HairPPLLResolvePassTemplateName});
+                    AZ_Error("Hair Gem", false, "Hair Fill Pass does NOT have renderr pipeline set yet");
+                    return false;
+                }
 
-                    // For now, assume one skinning pass
-                    if (!desiredPasses.empty() && desiredPasses[0])
-                    {
-                         m_hairPPLLResolvePass = static_cast<HairPPLLResolvePass*>(desiredPasses[0]);
-                         m_hairPPLLResolvePass->SetFeatureProcessor(this);
-                    }
-                    else
-                    {
-                        AZ_Error("Hair Gem", false, "HairPPLLResolvePassTemplate does not have any valid passes. Check your game project's .pass assets.");
-                        return false;
-                    }
+                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(AZ::Name{ HairPPLLResolvePassName });
+                if (desiredPass)
+                {
+                    m_hairPPLLResolvePass = static_cast<HairPPLLResolvePass*>(desiredPass.get());
+                    m_hairPPLLResolvePass->SetFeatureProcessor(this);
                 }
                 else
                 {
-                    AZ_Error("Hair Gem", false, "Failed to find passes for HairPPLLResolvePassTemplate. Check your game project's .pass assets.");
+                    AZ_ErrorOnce("Hair Gem", false, "HairPPLLResolvePassTemplate does not have valid passes. Check your game project's .pass assets.");
+//                    AZ_Error("Hair Gem", false, "HairPPLLResolvePassTemplate does not have valid passes. Check your game project's .pass assets.");
                     return false;
                 }
                 return true;
@@ -503,17 +507,17 @@ namespace AZ
                 HairRenderObject* renderObjectPtr = renderObject.get();
 
                 // Dispatches for Compute passes
-                m_computePasses[GlobalShapeConstraintsPass]->BuildDispatchItem(
+                m_computePasses[GlobalShapeConstraintsPassName]->BuildDispatchItem(
                     renderObjectPtr, DispatchLevel::DISPATCHLEVEL_VERTEX);
-                m_computePasses[CalculateStrandDataPass]->BuildDispatchItem(
+                m_computePasses[CalculateStrandDataPassName]->BuildDispatchItem(
                     renderObjectPtr, DispatchLevel::DISPATCHLEVEL_STRAND);
-                m_computePasses[VelocityShockPropagationPass]->BuildDispatchItem(
+                m_computePasses[VelocityShockPropagationPassName]->BuildDispatchItem(
                     renderObjectPtr, DispatchLevel::DISPATCHLEVEL_VERTEX);
-                m_computePasses[LocalShapeConstraintsPass]->BuildDispatchItem(
+                m_computePasses[LocalShapeConstraintsPassName]->BuildDispatchItem(
                     renderObjectPtr, DispatchLevel::DISPATCHLEVEL_STRAND);
-                m_computePasses[LengthConstriantsWindAndCollisionPass]->BuildDispatchItem(
+                m_computePasses[LengthConstriantsWindAndCollisionPassName]->BuildDispatchItem(
                     renderObjectPtr, DispatchLevel::DISPATCHLEVEL_VERTEX);
-                m_computePasses[UpdateFollowHairPass]->BuildDispatchItem(
+                m_computePasses[UpdateFollowHairPassName]->BuildDispatchItem(
                     renderObjectPtr, DispatchLevel::DISPATCHLEVEL_VERTEX);
 
                 // Render / Raster pass - adding the object will schedule Srgs binding
@@ -523,18 +527,18 @@ namespace AZ
 
             Data::Instance<HairSkinningComputePass> HairFeatureProcessor::GetHairSkinningComputegPass()
             {
-                if (!m_computePasses[GlobalShapeConstraintsPass])
-                {   
-                    Init();
+                if (!m_computePasses[GlobalShapeConstraintsPassName])
+                {
+                    Init(m_renderPipeline);
                 }
-                return m_computePasses[GlobalShapeConstraintsPass];
+                return m_computePasses[GlobalShapeConstraintsPassName];
             }
 
             Data::Instance<HairPPLLRasterPass> HairFeatureProcessor::GetHairPPLLRasterPass()
             {
                 if (!m_hairPPLLRasterPass)
                 {
-                    Init();
+                    Init(m_renderPipeline);
                 }
                 return m_hairPPLLRasterPass;
             }

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.cpp
@@ -299,7 +299,7 @@ namespace AZ
                 m_forceClearRenderData = true;
             }
 
-            void HairFeatureProcessor::OnRenderPipelineAdded([[maybe_unused]] RPI::RenderPipelinePtr renderPipeline)
+            void HairFeatureProcessor::OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline)
             {
                 // Proceed only if this is the main pipeline that contains the parent pass
                 if (!renderPipeline.get()->GetRootPass()->FindPassByNameRecursive(HairParentPassName))
@@ -313,7 +313,7 @@ namespace AZ
                 m_forceRebuildRenderData = true;
             }
 
-            void HairFeatureProcessor::OnRenderPipelineRemoved([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
+            void HairFeatureProcessor::OnRenderPipelineRemoved(RPI::RenderPipeline* renderPipeline)
             {
                 // Proceed only if this is the main pipeline that contains the parent pass
                 if (!renderPipeline->GetRootPass()->FindPassByNameRecursive(HairParentPassName))
@@ -325,7 +325,7 @@ namespace AZ
                 ClearPasses();
             }
 
-            void HairFeatureProcessor::OnRenderPipelinePassesChanged([[maybe_unused]] RPI::RenderPipeline* renderPipeline)
+            void HairFeatureProcessor::OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline)
             {
                 // Proceed only if this is the main pipeline that contains the parent pass
                 if (!renderPipeline->GetRootPass()->FindPassByNameRecursive(HairParentPassName))
@@ -445,7 +445,7 @@ namespace AZ
                     return false;
                 }
 
-                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(AZ::Name{ passName });
+                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(passName);
                 if (desiredPass)
                 {
                     m_computePasses[passName] = static_cast<HairSkinningComputePass*>(desiredPass.get());
@@ -455,7 +455,7 @@ namespace AZ
                 else
                 {
                     AZ_Error("Hair Gem", false,
-                        "%s does not have any valid passes. Check your game project's .pass assets.",
+                        "%s does not exist in this pipeline. Check your game project's .pass assets.",
                         passName.GetCStr());
                     return false;
                 }
@@ -472,7 +472,7 @@ namespace AZ
                     return false;
                 }
 
-                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(AZ::Name{ HairPPLLRasterPassName });
+                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(HairPPLLRasterPassName);
                 if (desiredPass)
                 {
                     m_hairPPLLRasterPass = static_cast<HairPPLLRasterPass*>(desiredPass.get());
@@ -495,7 +495,7 @@ namespace AZ
                     return false;
                 }
 
-                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(AZ::Name{ HairPPLLResolvePassName });
+                RPI::Ptr<RPI::Pass> desiredPass = m_renderPipeline->GetRootPass()->FindPassByNameRecursive(HairPPLLResolvePassName);
                 if (desiredPass)
                 {
                     m_hairPPLLResolvePass = static_cast<HairPPLLResolvePass*>(desiredPass.get());

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
@@ -154,8 +154,6 @@ namespace AZ
 
                 void EnablePasses(bool enable);
 
-                static const char* s_featureProcessorName;
-
                 //! The following will serve to register the FP in the Thumbnail system
                 AZStd::vector<AZStd::string> m_hairFeatureProcessorRegistryName;
 

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
@@ -71,12 +71,17 @@ namespace AZ
                 , public HairGlobalSettingsRequestBus::Handler
                 , private AZ::TickBus::Handler
             {
-                Name GlobalShapeConstraintsPass;
-                Name CalculateStrandDataPass;
-                Name VelocityShockPropagationPass;
-                Name LocalShapeConstraintsPass;
-                Name LengthConstriantsWindAndCollisionPass;
-                Name UpdateFollowHairPass;
+                Name HairParentPassName;
+
+                Name HairPPLLRasterPassName;
+                Name HairPPLLResolvePassName;
+
+                Name GlobalShapeConstraintsPassName;
+                Name CalculateStrandDataPassName;
+                Name VelocityShockPropagationPassName;
+                Name LocalShapeConstraintsPassName;
+                Name LengthConstriantsWindAndCollisionPassName;
+                Name UpdateFollowHairPassName;
 
             public:
                 AZ_RTTI(AZ::Render::Hair::HairFeatureProcessor, "{5F9DDA81-B43F-4E30-9E56-C7C3DC517A4C}", RPI::FeatureProcessor);
@@ -90,7 +95,7 @@ namespace AZ
 
                 void UpdateHairSkinning();
 
-                bool Init();
+                bool Init(RPI::RenderPipeline* pipeline);
                 bool IsInitialized() { return m_initialized; }
 
                 // FeatureProcessor overrides ...
@@ -153,6 +158,15 @@ namespace AZ
 
                 //! The following will serve to register the FP in the Thumbnail system
                 AZStd::vector<AZStd::string> m_hairFeatureProcessorRegistryName;
+
+                //! The render pipeline is acquired and set when a pipeline is created or changed
+                //! and accordingly the passes and the feature processor are associated.
+                //! Notice that scene can contain several pipelines all using the same feature
+                //! processor.  On the pass side, it will acquire the scene and request the FP, 
+                //! but on the FP side, it will only associate to the latest pass hence such a case
+                //! might still be a problem.  If needed, it can be resolved using a map for each
+                //! pass name per pipeline.
+                RPI::RenderPipeline* m_renderPipeline = nullptr;
 
                 //! The Hair Objects in the scene (one per hair component)
                 AZStd::list<Data::Instance<HairRenderObject>> m_hairRenderObjects;

--- a/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
+++ b/Gems/AtomTressFX/Code/Rendering/HairFeatureProcessor.h
@@ -90,7 +90,7 @@ namespace AZ
                 static void Reflect(AZ::ReflectContext* context);
 
                 HairFeatureProcessor();
-                virtual ~HairFeatureProcessor() = default;
+                virtual ~HairFeatureProcessor();
 
 
                 void UpdateHairSkinning();
@@ -112,8 +112,8 @@ namespace AZ
                 bool RemoveHairRenderObject(Data::Instance<HairRenderObject> renderObject);
 
                 // RPI::SceneNotificationBus overrides ...
-                void OnRenderPipelineAdded(RPI::RenderPipelinePtr pipeline) override;
-                void OnRenderPipelineRemoved(RPI::RenderPipeline* pipeline) override;
+                void OnRenderPipelineAdded(RPI::RenderPipelinePtr renderPipeline) override;
+                void OnRenderPipelineRemoved(RPI::RenderPipeline* renderPipeline) override;
                 void OnRenderPipelinePassesChanged(RPI::RenderPipeline* renderPipeline) override;
 
                 void OnBeginPrepareRender() override;


### PR DESCRIPTION
In this addition the hair FP is handling the various pipelines and respects the match between passes and the pipeline they belong to, and by verifying this match it sets or resets the pipeline and initialize the passes.
I also tested across various pipelines and editors that can work in parallel and employ different pipelines.  Closing the MaterialEditor revealed that the bootstrap and attempting to deactivate all feature processors, however in the Hair system component was released at this point before the bootstrap system component and so there was a need to create order between them as well.