### PR TITLE
DRAFT: Add changes from PR-2167

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ComponentMode/ComponentModeCollection.cpp
@@ -9,6 +9,7 @@
 #include "ComponentModeCollection.h"
 
 #include <AzToolsFramework/Commands/ComponentModeCommand.h>
+#include <AzToolsFramework/API/ViewportEditorModeTrackerInterface.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
 
 namespace AzToolsFramework
@@ -199,6 +200,8 @@ namespace AzToolsFramework
 
         void ComponentModeCollection::BeginComponentMode()
         {
+            AZ::Interface<ViewportEditorModeTrackerInterface>::Get()->EnterMode({}, ViewportEditorMode::Component);
+
             m_selectedComponentModeIndex = 0;
             m_componentMode = true;
             m_adding = false;
@@ -262,6 +265,8 @@ namespace AzToolsFramework
 
         void ComponentModeCollection::EndComponentMode()
         {
+            AZ::Interface<ViewportEditorModeTrackerInterface>::Get()->ExitMode({}, ViewportEditorMode::Component);
+
             if (!UndoRedoOperationInProgress())
             {
                 ScopedUndoBatch undoBatch(s_leavingComponentModeUndoRedoDesc);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -885,13 +885,24 @@ namespace AzToolsFramework
 
         AZ::EntityId PrefabPublicHandler::GetInstanceContainerEntityId(AZ::EntityId entityId) const
         {
-            AZ::Entity* entity = GetEntityById(entityId);
-            if (entity)
+            InstanceOptionalReference owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(entityId);
+            if (owningInstance)
             {
-                InstanceOptionalReference owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(entity->GetId());
-                if (owningInstance)
+                return owningInstance->get().GetContainerEntityId();
+            }
+
+            return AZ::EntityId();
+        }
+
+        AZ::EntityId PrefabPublicHandler::GetParentInstanceContainerEntityId(AZ::EntityId entityId) const
+        {
+            InstanceOptionalReference owningInstance = m_instanceEntityMapperInterface->FindOwningInstance(entityId);
+            if (owningInstance)
+            {
+                InstanceOptionalReference parentInstance = owningInstance->get().GetParentInstance();
+                if (parentInstance)
                 {
-                    return owningInstance->get().GetContainerEntityId();
+                    return parentInstance->get().GetContainerEntityId();
                 }
             }
 
@@ -1792,5 +1803,10 @@ namespace AzToolsFramework
             linkPatch.Parse(previousPatchString.toUtf8().constData());
         }
 
+        AZ::EntityId PrefabPublicHandler::OverrideEntitySelectionInViewport(AZ::EntityId entityId)
+        {
+            return entityId;
+        }
+        
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -56,6 +56,7 @@ namespace AzToolsFramework
             bool IsInstanceContainerEntity(AZ::EntityId entityId) const override;
             bool IsLevelInstanceContainerEntity(AZ::EntityId entityId) const override;
             AZ::EntityId GetInstanceContainerEntityId(AZ::EntityId entityId) const override;
+            AZ::EntityId GetParentInstanceContainerEntityId(AZ::EntityId entityId) const override;
             AZ::EntityId GetLevelInstanceContainerEntityId() const override;
             AZ::IO::Path GetOwningInstancePrefabPath(AZ::EntityId entityId) const override;
             PrefabRequestResult HasUnsavedChanges(AZ::IO::Path prefabFilePath) const override;
@@ -183,6 +184,8 @@ namespace AzToolsFramework
             static Instance* GetParentInstance(Instance* instance);
             static Instance* GetAncestorOfInstanceThatIsChildOfRoot(const Instance* ancestor, Instance* descendant);
             static void GenerateContainerEntityTransform(const EntityList& topLevelEntities, AZ::Vector3& translation, AZ::Quaternion& rotation);
+
+             AZ::EntityId OverrideEntitySelectionInViewport(AZ::EntityId entityId) override;
 
             InstanceEntityMapperInterface* m_instanceEntityMapperInterface = nullptr;
             InstanceToTemplateInterface* m_instanceToTemplateInterface = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicInterface.h
@@ -123,6 +123,13 @@ namespace AzToolsFramework
             virtual AZ::EntityId GetInstanceContainerEntityId(AZ::EntityId entityId) const = 0;
             
             /**
+             * Gets the entity id for the instance container of the parent of the owning instance.
+             * @param entityId The id of the entity to query.
+             * @return The entity id of the instance container for the parent of the instance owning the queried entity.
+             */
+            virtual AZ::EntityId GetParentInstanceContainerEntityId(AZ::EntityId entityId) const = 0;
+            
+            /**
              * Gets the entity id for the instance container of the level instance.
              * @return The entity id of the instance container for the currently loaded level.
              */
@@ -174,6 +181,9 @@ namespace AzToolsFramework
               * @return An outcome object; on failure, it comes with an error message detailing the cause of the error.
               */
             virtual PrefabOperationResult DetachPrefab(const AZ::EntityId& containerEntityId) = 0;
+
+            // Test...
+            virtual AZ::EntityId OverrideEntitySelectionInViewport(AZ::EntityId entityId) = 0;
         };
 
     } // namespace Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/EditorEntityUi/EditorEntityUiHandlerBase.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/EditorEntityUi/EditorEntityUiHandlerBase.cpp
@@ -62,6 +62,16 @@ namespace AzToolsFramework
         return true;
     }
 
+    bool EditorEntityUiHandlerBase::IsOverridingExpandedState(AZ::EntityId /*entityId*/) const
+    {
+        return false;
+    }
+    
+    bool EditorEntityUiHandlerBase::GenerateOverriddenExpandedState(AZ::EntityId /*entityId*/) const
+    {
+        return false;
+    }
+
     void EditorEntityUiHandlerBase::PaintItemBackground(QPainter* /*painter*/, const QStyleOptionViewItem& /*option*/, const QModelIndex& /*index*/) const
     {
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/EditorEntityUi/EditorEntityUiHandlerBase.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/EditorEntityUi/EditorEntityUiHandlerBase.h
@@ -41,10 +41,14 @@ namespace AzToolsFramework
         virtual QString GenerateItemTooltip(AZ::EntityId entityId) const;
         //! Returns the item icon pixmap to display in the Outliner.
         virtual QPixmap GenerateItemIcon(AZ::EntityId entityId) const;
-        //! Returns whether the element's lock and visibility state should be accessible in the Outliner
+        //! Returns whether the element's lock and visibility state should be accessible in the Outliner.
         virtual bool CanToggleLockVisibility(AZ::EntityId entityId) const;
-        //! Returns whether the element's name should be editable
+        //! Returns whether the element's name should be editable.
         virtual bool CanRename(AZ::EntityId entityId) const;
+        //! Returns whether the element's expanded state should be accessible in the Outliner.
+        virtual bool IsOverridingExpandedState(AZ::EntityId entityId) const;
+        //! If the handler is overriding the expanded state, returns the overridden value for the element.
+        virtual bool GenerateOverriddenExpandedState(AZ::EntityId entityId) const;
 
         //! Paints the background of the item in the Outliner.
         virtual void PaintItemBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutliner.qss
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutliner.qss
@@ -32,6 +32,11 @@ AzToolsFramework--EntityOutlinerWidget QTreeView::branch:selected
     background: rgba(255, 255, 255, 45);
 }
 
+AzToolsFramework--EntityOutlinerWidget QTreeView::branch:open:has-children
+, AzToolsFramework--EntityOutlinerWidget QTreeView::branch:closed:has-children
+{
+    image: none;
+}
 
 /* --- VISIBILITY AND LOCK --- */
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerCacheBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerCacheBus.h
@@ -39,17 +39,17 @@ namespace AzToolsFramework
     public:
         /// The entity has changed in such a way that its outliner representation has changed and should be redrawn
         /// invalidate now is true if the item needs to be redrawn immediately.
-        virtual void EntityCacheChanged(const AZ::EntityId& /*entityId*/) {}
+        virtual void EntityCacheChanged(AZ::EntityId /*entityId*/) {}
 
         /// The outliner cache item associated with the given entity has been selected
         /// and is requesting that a notification be sent to the tree view.
         /// These requests should be handled, considered, and either acted on or queued
-        virtual void EntityCacheSelectionRequest(const AZ::EntityId&  /*entityId*/) {}
+        virtual void EntityCacheSelectionRequest(AZ::EntityId  /*entityId*/) {}
 
         /// The outliner cache item associated with the given entity has been deselected
         /// and is requesting that the a notification be sent to the tree view.
         /// These requests should be handled, considered, and either acted on or queued
-        virtual void EntityCacheDeselectionRequest(const AZ::EntityId&  /*entityId*/) {}
+        virtual void EntityCacheDeselectionRequest(AZ::EntityId  /*entityId*/) {}
     };
 
     /// \ref EditorVisibilityNotifications
@@ -64,7 +64,7 @@ namespace AzToolsFramework
         /// and is requesting that a notification be sent to the tree view.
         /// These requests should be handled, considered, and either acted on or queued
         virtual void ModelEntitySelectionChanged(const AZStd::unordered_set<AZ::EntityId>& /*selectedEntityIdList*/, const AZStd::unordered_set<AZ::EntityId>& /*deselectedEntityIdList*/) {}
-        virtual void QueueScrollToNewContent(const AZ::EntityId& /*entityId*/) {}
+        virtual void QueueScrollToNewContent(AZ::EntityId /*entityId*/) {}
     };
 
     /// \ref EditorVisibilityNotifications

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx
@@ -22,6 +22,7 @@
 #include <AzToolsFramework/Entity/EditorEntityRuntimeActivationBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorLockComponentBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorVisibilityBus.h>
+#include <AzToolsFramework/UI/Outliner/EntityOutlinerCacheBus.h>
 #include <AzToolsFramework/UI/Outliner/EntityOutlinerSearchWidget.h>
 #include <AzToolsFramework/UI/SearchWidget/SearchCriteriaWidget.hxx>
 
@@ -53,6 +54,7 @@ namespace AzToolsFramework
         , private EntityCompositionNotificationBus::Handler
         , private EditorEntityRuntimeActivationChangeNotificationBus::Handler
         , private AZ::EntitySystemBus::Handler
+        , private EntityOutlinerCacheNotificationBus::Handler
     {
         Q_OBJECT;
 
@@ -214,6 +216,9 @@ namespace AzToolsFramework
 
         // EditorEntityRuntimeActivationChangeNotificationBus::Handler
         void OnEntityRuntimeActivationChanged(AZ::EntityId entityId, bool activeOnStart) override;
+
+        // EntityOutlinerCacheNotificationBus...
+        void EntityCacheChanged(AZ::EntityId entityId) override;
 
         // Drag/Drop of components from Component Palette.
         bool dropMimeDataComponentPalette(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerTreeView.hxx
@@ -72,6 +72,8 @@ namespace AzToolsFramework
         void StartCustomDrag(const QModelIndexList& indexList, Qt::DropActions supportedActions) override;
 
         void PaintBranchBackground(QPainter* painter, const QRect& rect, const QModelIndex& index) const;
+
+        bool IsExpanderHidden(const QModelIndex& index) const;
         
         QMouseEvent* m_queuedMouseEvent;
         bool m_draggingUnselectedItem; // This is set when an item is dragged outside its bounding box.
@@ -81,6 +83,8 @@ namespace AzToolsFramework
 
         const QColor m_selectedColor = QColor(255, 255, 255, 45);
         const QColor m_hoverColor = QColor(255, 255, 255, 30);
+        const QIcon m_expandedIcon;
+        const QIcon m_collapsedIcon;
 
         EditorEntityUiInterface* m_editorEntityFrameworkInterface;
     };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.cpp
@@ -32,9 +32,11 @@
 #include <AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx>
 #include <AzToolsFramework/UI/Outliner/EntityOutlinerSortFilterProxyModel.hxx>
 
+#include <AzQtComponents/Components/Style.h>
 #include <AzQtComponents/Components/StyleManager.h>
 #include <AzQtComponents/Utilities/QtPluginPaths.h>
 #include <AzQtComponents/Utilities/QtViewPaneEffects.h>
+
 
 #include <QApplication>
 #include <QDir>
@@ -200,6 +202,8 @@ namespace AzToolsFramework
         m_proxyModel->setSourceModel(m_listModel);
         m_gui->m_objectTree->setModel(m_proxyModel);
 
+        AzQtComponents::Style::addClass(m_gui->m_objectTree, QStringLiteral("DisableArrowPainting"));
+
         // Link up signals for informing the model of tree changes using the proxy as an intermediary
         connect(m_gui->m_objectTree, &QTreeView::clicked, this, &EntityOutlinerWidget::OnTreeItemClicked);
         connect(m_gui->m_objectTree, &QTreeView::doubleClicked, this, &EntityOutlinerWidget::OnTreeItemDoubleClicked);
@@ -211,6 +215,10 @@ namespace AzToolsFramework
         connect(m_listModel, &EntityOutlinerListModel::EnableSelectionUpdates, this, &EntityOutlinerWidget::OnEnableSelectionUpdates);
         connect(m_listModel, &EntityOutlinerListModel::ResetFilter, this, &EntityOutlinerWidget::ClearFilter);
         connect(m_listModel, &EntityOutlinerListModel::ReapplyFilter, this, &EntityOutlinerWidget::InvalidateFilter);
+
+        connect(m_listModel, &EntityOutlinerListModel::modelReset, this, [this]() {
+            m_gui->m_objectTree->expandToDepth(1);
+        });
 
         QToolButton* display_options = new QToolButton(this);
         display_options->setObjectName(QStringLiteral("m_display_options"));
@@ -989,7 +997,7 @@ namespace AzToolsFramework
         m_focusInEntityOutliner = false;
     }
 
-    void EntityOutlinerWidget::QueueScrollToNewContent(const AZ::EntityId& entityId)
+    void EntityOutlinerWidget::QueueScrollToNewContent(AZ::EntityId entityId)
     {
         if (m_dropOperationInProgress)
         {
@@ -1139,7 +1147,6 @@ namespace AzToolsFramework
     {
         QTimer::singleShot(1, this, [this]() {
             m_gui->m_objectTree->setUpdatesEnabled(true);
-            m_gui->m_objectTree->expand(m_proxyModel->index(0,0));
         });
     }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Outliner/EntityOutlinerWidget.hxx
@@ -166,7 +166,7 @@ namespace AzToolsFramework
         // OutlinerModelNotificationBus::Handler
         // Receive notification from the outliner model that we should scroll
         // to a given entity
-        void QueueScrollToNewContent(const AZ::EntityId& entityId) override;
+        void QueueScrollToNewContent(AZ::EntityId entityId) override;
 
         void SetDefaultTreeViewEditTriggers();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.cpp
@@ -70,6 +70,16 @@ namespace AzToolsFramework
         return infoString;
     }
 
+    bool LevelRootUiHandler::IsOverridingExpandedState(AZ::EntityId /*entityId*/) const
+    {
+        return true;
+    }
+
+    bool LevelRootUiHandler::GenerateOverriddenExpandedState(AZ::EntityId /*entityId*/) const
+    {
+        return true;
+    }
+
     bool LevelRootUiHandler::CanToggleLockVisibility(AZ::EntityId /*entityId*/) const
     {
         return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/LevelRootUiHandler.h
@@ -31,6 +31,8 @@ namespace AzToolsFramework
         // EditorEntityUiHandler...
         QPixmap GenerateItemIcon(AZ::EntityId entityId) const override;
         QString GenerateItemInfoString(AZ::EntityId entityId) const override;
+        bool IsOverridingExpandedState(AZ::EntityId entityId) const override;
+        bool GenerateOverriddenExpandedState(AZ::EntityId entityId) const override;
         bool CanToggleLockVisibility(AZ::EntityId entityId) const override;
         bool CanRename(AZ::EntityId entityId) const override;
         void PaintItemBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditInterface.h
@@ -17,7 +17,7 @@ namespace AzToolsFramework
     {
         /*!
          * PrefabEditInterface
-         * Interface to expose the API to Edit Prefabs in the Editor.
+         * Internal interface exposing the Prefab Edit API.
          */
         class PrefabEditInterface
         {
@@ -28,14 +28,7 @@ namespace AzToolsFramework
              * Sets the prefab for the instance owning the entity provided as the prefab being edited.
              * @param entityId The entity whose owning prefab should be edited.
              */
-            virtual void EditOwningPrefab(AZ::EntityId entityId) = 0;
-            
-            /**
-             * Queries the Edit Manager to know if the provided entity is part of the prefab currently being edited.
-             * @param entityId The entity whose prefab editing state we want to query.
-             * @return True if the prefab owning this entity is being edited, false otherwise.
-             */
-            virtual bool IsOwningPrefabBeingEdited(AZ::EntityId entityId) = 0;
+            virtual void EditPrefab(AZ::EntityId entityId) = 0;
         };
 
     } // namespace Prefab

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditManager.h
@@ -13,6 +13,8 @@
 
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/UI/Prefab/PrefabEditInterface.h>
+#include <AzToolsFramework/UI/Prefab/PrefabEditPublicInterface.h>
+#include <AzToolsFramework/ViewportSelection/EditorInteractionInterface.h>
 
 namespace AzToolsFramework
 {
@@ -20,6 +22,8 @@ namespace AzToolsFramework
     {
         class PrefabEditManager final
             : private PrefabEditInterface
+            , private PrefabEditPublicInterface
+            , private EditorInteractionInterface
         {
         public:
             AZ_CLASS_ALLOCATOR(PrefabEditManager, AZ::SystemAllocator, 0);
@@ -29,10 +33,20 @@ namespace AzToolsFramework
 
         private:
             // PrefabEditInterface...
+            void EditPrefab(AZ::EntityId entityId) override;
+
+            // PrefabEditPublicInterface...
             void EditOwningPrefab(AZ::EntityId entityId) override;
             bool IsOwningPrefabBeingEdited(AZ::EntityId entityId) override;
+            bool IsOwningPrefabInEditStack(AZ::EntityId entityId) override;
 
-            AZ::EntityId m_instanceBeingEdited;
+            // EditorInteractionInterface...
+            AZ::EntityId RedirectEntitySelection(AZ::EntityId entityId) override;
+
+            // EntityId of the container for the prefab instance that is currently being edited
+            AZ::EntityId m_editedPrefabContainerId;
+            // Store the container ids for all prefab instances in the hierarchy that is being edited for quick reference
+            AZStd::set<AZ::EntityId> m_editedPrefabHierarchyCache;
 
             PrefabPublicInterface* m_prefabPublicInterface;
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditPublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditPublicInterface.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        /*!
+         * PrefabEditPublicInterface
+         * Interface to expose the Public API to Edit Prefabs in the Editor.
+         * Functions in this API support undo/redo and are meant to be called in UI and Editor Scripting.
+         */
+        class PrefabEditPublicInterface
+        {
+        public:
+            AZ_RTTI(PrefabEditInterface, "{7152D92B-4E14-450C-8190-08BDD8FB32DA}");
+
+            /**
+             * Sets the prefab for the instance owning the entity provided as the prefab being edited.
+             * @param entityId The entity whose owning prefab should be edited. An invalid id defaults to editing the level.
+             */
+            virtual void EditOwningPrefab(AZ::EntityId entityId) = 0;
+            
+            /**
+             * Queries the Edit Manager to know if the provided entity is part of the prefab currently being edited.
+             * @param entityId The entity whose prefab editing state we want to query.
+             * @return True if the prefab owning this entity is being edited, false otherwise.
+             */
+            virtual bool IsOwningPrefabBeingEdited(AZ::EntityId entityId) = 0;
+            
+            /**
+             * Queries the Edit Manager to know if the provided entity is part of a prefab that is currently in the edit stack.
+             * @param entityId The entity whose prefab editing state we want to query.
+             * @return True if the prefab owning this entity is in the edit stack, false otherwise.
+             */
+            virtual bool IsOwningPrefabInEditStack(AZ::EntityId entityId) = 0;
+        };
+
+    } // namespace Prefab
+} // namespace AzToolsFramework
+

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditUndo.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Interface/Interface.h>
+
+#include <AzToolsFramework/Prefab/Instance/Instance.h>
+#include <AzToolsFramework/UI/Prefab/PrefabEditInterface.h>
+#include <AzToolsFramework/UI/Prefab/PrefabEditUndo.h>
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        PrefabUndoEdit::PrefabUndoEdit(const AZStd::string& undoOperationName)
+            : UndoSystem::URSequencePoint(undoOperationName)
+            , m_changed(true)
+        {
+            m_prefabEditInterface = AZ::Interface<PrefabEditInterface>::Get();
+            AZ_Assert(m_prefabEditInterface, "PrefabUndoEdit - Failed to grab prefab edit interface");
+        }
+
+        void PrefabUndoEdit::Capture(AZ::EntityId oldContainerEntityId, AZ::EntityId newContainerEntityId)
+        {
+            m_oldContainerEntityId = oldContainerEntityId;
+            m_newContainerEntityId = newContainerEntityId;
+        }
+
+        void PrefabUndoEdit::Undo()
+        {
+            m_prefabEditInterface->EditPrefab(m_oldContainerEntityId);
+        }
+
+        void PrefabUndoEdit::Redo()
+        {
+            m_prefabEditInterface->EditPrefab(m_newContainerEntityId);
+        }
+
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditUndo.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabEditUndo.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzToolsFramework/Undo/UndoSystem.h>
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        class PrefabEditInterface;
+
+        class PrefabUndoEdit : public UndoSystem::URSequencePoint
+        {
+        public:
+            explicit PrefabUndoEdit(const AZStd::string& undoOperationName);
+
+            bool Changed() const override
+            {
+                return m_changed;
+            }
+            void Capture(AZ::EntityId oldContainerEntityId, AZ::EntityId newContainerEntityId);
+
+            void Undo();
+            void Redo();
+
+        protected:
+            AZ::EntityId m_oldContainerEntityId;
+            AZ::EntityId m_newContainerEntityId;
+
+            PrefabEditInterface* m_prefabEditInterface;
+            bool m_changed;
+        };
+
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabIntegrationManager.h
@@ -28,7 +28,6 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
-
         class PrefabLoaderInterface;
 
         //! Structure for saving/retrieving user settings related to prefab workflows.
@@ -93,6 +92,7 @@ namespace AzToolsFramework
             static void ContextMenu_CreatePrefab(AzToolsFramework::EntityIdList selectedEntities);
             static void ContextMenu_InstantiatePrefab();
             static void ContextMenu_EditPrefab(AZ::EntityId containerEntity);
+            static void ContextMenu_ClosePrefab();
             static void ContextMenu_SavePrefab(AZ::EntityId containerEntity);
             static void ContextMenu_DeleteSelected();
             static void ContextMenu_DetachPrefab(AZ::EntityId containerEntity);
@@ -140,7 +140,7 @@ namespace AzToolsFramework
 
             static EditorEntityUiInterface* s_editorEntityUiInterface;
             static PrefabPublicInterface* s_prefabPublicInterface;
-            static PrefabEditInterface* s_prefabEditInterface;
+            static PrefabEditPublicInterface* s_prefabEditPublicInterface;
             static PrefabLoaderInterface* s_prefabLoaderInterface;
             static PrefabSystemComponentInterface* s_prefabSystemComponentInterface;
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.cpp
@@ -8,7 +8,7 @@
 
 #include <AzToolsFramework/UI/Prefab/PrefabUiHandler.h>
 
-#include <AzToolsFramework/UI/Prefab/PrefabEditInterface.h>
+#include <AzToolsFramework/UI/Prefab/PrefabEditPublicInterface.h>
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/UI/Outliner/EntityOutlinerListModel.hxx>
 
@@ -26,11 +26,11 @@ namespace AzToolsFramework
 
     PrefabUiHandler::PrefabUiHandler()
     {
-        m_prefabEditInterface = AZ::Interface<Prefab::PrefabEditInterface>::Get();
+        m_prefabEditPublicInterface = AZ::Interface<Prefab::PrefabEditPublicInterface>::Get();
 
-        if (m_prefabEditInterface == nullptr)
+        if (m_prefabEditPublicInterface == nullptr)
         {
-            AZ_Assert(false, "PrefabUiHandler - could not get PrefabEditInterface on PrefabUiHandler construction.");
+            AZ_Assert(false, "PrefabUiHandler - could not get PrefabEditPublicInterface on PrefabUiHandler construction.");
             return;
         }
 
@@ -83,12 +83,22 @@ namespace AzToolsFramework
 
     QPixmap PrefabUiHandler::GenerateItemIcon(AZ::EntityId entityId) const
     {
-        if (m_prefabEditInterface->IsOwningPrefabBeingEdited(entityId))
+        if (m_prefabEditPublicInterface->IsOwningPrefabBeingEdited(entityId))
         {
             return QPixmap(m_prefabEditIconPath);
         }
 
         return QPixmap(m_prefabIconPath);
+    }
+
+    bool PrefabUiHandler::IsOverridingExpandedState(AZ::EntityId /*entityId*/) const
+    {
+        return true;
+    }
+
+    bool PrefabUiHandler::GenerateOverriddenExpandedState(AZ::EntityId entityId) const
+    {
+        return m_prefabEditPublicInterface->IsOwningPrefabInEditStack(entityId);
     }
 
     void PrefabUiHandler::PaintItemBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
@@ -105,7 +115,7 @@ namespace AzToolsFramework
         const bool hasVisibleChildren = index.data(EntityOutlinerListModel::ExpandedRole).value<bool>() && index.model()->hasChildren(index);
 
         QColor backgroundColor = m_prefabCapsuleColor;
-        if (m_prefabEditInterface->IsOwningPrefabBeingEdited(entityId))
+        if (m_prefabEditPublicInterface->IsOwningPrefabBeingEdited(entityId))
         {
             backgroundColor = m_prefabCapsuleEditColor;
         }
@@ -191,7 +201,7 @@ namespace AzToolsFramework
         const bool isLastColumn = descendantIndex.column() == EntityOutlinerListModel::ColumnLockToggle;
 
         QColor borderColor = m_prefabCapsuleColor;
-        if (m_prefabEditInterface->IsOwningPrefabBeingEdited(entityId))
+        if (m_prefabEditPublicInterface->IsOwningPrefabBeingEdited(entityId))
         {
             borderColor = m_prefabCapsuleEditColor;
         }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -14,7 +14,7 @@ namespace AzToolsFramework
 {
     namespace Prefab
     {
-        class PrefabEditInterface;
+        class PrefabEditPublicInterface;
         class PrefabPublicInterface;
     };
 
@@ -32,12 +32,14 @@ namespace AzToolsFramework
         QString GenerateItemInfoString(AZ::EntityId entityId) const override;
         QString GenerateItemTooltip(AZ::EntityId entityId) const override;
         QPixmap GenerateItemIcon(AZ::EntityId entityId) const override;
+        bool IsOverridingExpandedState(AZ::EntityId entityId) const override;
+        bool GenerateOverriddenExpandedState(AZ::EntityId entityId) const override;
         void PaintItemBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
         void PaintDescendantBackground(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index,
             const QModelIndex& descendantIndex) const override;
 
     private:
-        Prefab::PrefabEditInterface* m_prefabEditInterface = nullptr;
+        Prefab::PrefabEditPublicInterface* m_prefabEditPublicInterface = nullptr;
         Prefab::PrefabPublicInterface* m_prefabPublicInterface = nullptr;
 
         static bool IsLastVisibleChild(const QModelIndex& parent, const QModelIndex& child);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorDefaultSelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorDefaultSelection.cpp
@@ -12,6 +12,7 @@
 #include <AzToolsFramework/Manipulators/ManipulatorManager.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
+#include <AzToolsFramework/API/ViewportEditorModeTrackerInterface.h>
 #include <Entity/EditorEntityHelpers.h>
 #include <QGuiApplication>
 
@@ -28,10 +29,17 @@ namespace AzToolsFramework
 
         m_manipulatorManager = AZStd::make_shared<AzToolsFramework::ManipulatorManager>(AzToolsFramework::g_mainManipulatorManagerId);
         m_transformComponentSelection = AZStd::make_unique<EditorTransformComponentSelection>(entityDataCache);
+
+        AZ::Interface<ViewportEditorModeTrackerInterface>::Get()->EnterMode({}, ViewportEditorMode::Default);
     }
 
     EditorDefaultSelection::~EditorDefaultSelection()
     {
+        if (AZ::Interface<ViewportEditorModeTrackerInterface>::Get() != nullptr)
+        {
+            AZ::Interface<ViewportEditorModeTrackerInterface>::Get()->ExitMode({}, ViewportEditorMode::Default);
+        }
+
         ComponentModeFramework::ComponentModeSystemRequestBus::Handler::BusDisconnect();
         ActionOverrideRequestBus::Handler::BusDisconnect();
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorHelpers.cpp
@@ -17,6 +17,7 @@
 #include <AzToolsFramework/ToolsComponents/EditorEntityIconComponentBus.h>
 #include <AzToolsFramework/Viewport/ViewportMessages.h>
 #include <AzToolsFramework/Viewport/ViewportTypes.h>
+#include <AzToolsFramework/ViewportSelection/EditorInteractionInterface.h>
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
 #include <AzToolsFramework/ViewportSelection/EditorVisibleEntityDataCache.h>
 
@@ -171,6 +172,13 @@ namespace AzToolsFramework
                     }
                 }
             }
+        }
+
+        // Allow entity system to override the selection
+        auto editorInteractionInterface = AZ::Interface<EditorInteractionInterface>::Get();
+        if (editorInteractionInterface != nullptr)
+        {
+            entityIdUnderCursor = editorInteractionInterface->RedirectEntitySelection(entityIdUnderCursor);
         }
 
         return entityIdUnderCursor;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorInteractionInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorInteractionInterface.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project. 
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * 
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Interface/Interface.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace AzToolsFramework
+{
+        /*!
+         * EditorInteractionInterface
+         * Allows systems to alter the behavior of viewport selection.
+         */
+        class EditorInteractionInterface
+        {
+        public:
+            AZ_RTTI(EditorInteractionInterface, "{09276E3C-9AA6-40FF-A0B5-3D33A33F0E5A}");
+
+            /*!
+             * Allows the entity system to redirect the selection of an entity to another entity.
+             * It can be used to select a container when clicking on its content.
+             */
+            virtual AZ::EntityId RedirectEntitySelection(AZ::EntityId entityId) = 0;
+        };
+
+} // namespace AzToolsFramework
+

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorInteractionSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorInteractionSystemComponent.cpp
@@ -17,6 +17,7 @@ namespace AzToolsFramework
     {
         EditorInteractionSystemViewportSelectionRequestBus::Handler::BusConnect(GetEntityContextId());
         EditorEventsBus::Handler::BusConnect();
+        m_viewportEditorMode.RegisterInterface();
     }
 
     void EditorInteractionSystemComponent::Deactivate()
@@ -24,6 +25,7 @@ namespace AzToolsFramework
         // EditorVisibleEntityDataCache does BusDisconnect in the destructor, so have to reset here
         m_entityDataCache.reset();
 
+        m_viewportEditorMode.UnregisterInterface();
         AzFramework::ViewportDebugDisplayEventBus::Handler::BusDisconnect();
         EditorEventsBus::Handler::BusDisconnect();
         EditorInteractionSystemViewportSelectionRequestBus::Handler::BusDisconnect();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorInteractionSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorInteractionSystemComponent.h
@@ -11,9 +11,12 @@
 #include <AzCore/Component/Component.h>
 #include <AzToolsFramework/ViewportSelection/EditorInteractionSystemViewportSelectionRequestBus.h>
 #include <AzToolsFramework/ViewportSelection/EditorVisibleEntityDataCache.h>
+#include <AzToolsFramework/ViewportSelection/ViewportEditorModeTracker.h>
 
 namespace AzToolsFramework
 {
+    class ViewportEditorModeStateTracker;
+
     //! System Component to wrap active input handler.
     //! EditorInteractionSystemComponent is notified of viewport mouse events from RenderViewport
     //! and forwards them to a concrete implementation of ViewportSelectionRequests.
@@ -54,5 +57,6 @@ namespace AzToolsFramework
         AZStd::unique_ptr<InternalViewportSelectionRequests> m_interactionRequests; //!< Hold a concrete implementation of
                                                                                     //!< ViewportSelectionRequests to handle viewport
                                                                                     //!< input and drawing for the Editor.
+        ViewportEditorModeTracker m_viewportEditorMode;
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ViewportSelection/EditorPickEntitySelection.cpp
@@ -9,6 +9,7 @@
 #include "EditorPickEntitySelection.h"
 
 #include <AzToolsFramework/ViewportSelection/EditorSelectionUtil.h>
+#include <AzToolsFramework/API/ViewportEditorModeTrackerInterface.h>
 #include <QApplication>
 
 namespace AzToolsFramework
@@ -18,10 +19,13 @@ namespace AzToolsFramework
     EditorPickEntitySelection::EditorPickEntitySelection(const EditorVisibleEntityDataCache* entityDataCache)
         : m_editorHelpers(AZStd::make_unique<EditorHelpers>(entityDataCache))
     {
+        AZ::Interface<ViewportEditorModeTrackerInterface>::Get()->EnterMode({}, ViewportEditorMode::Pick);
     }
 
     EditorPickEntitySelection::~EditorPickEntitySelection()
     {
+        AZ::Interface<ViewportEditorModeTrackerInterface>::Get()->ExitMode({}, ViewportEditorMode::Pick);
+
         if (m_hoveredEntityId.IsValid())
         {
             ToolsApplicationRequestBus::Broadcast(&ToolsApplicationRequests::SetEntityHighlighted, m_hoveredEntityId, false);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -33,7 +33,6 @@ set(FILES
     API/EditorCameraBus.cpp
     API/EditorAnimationSystemRequestBus.h
     API/EditorEntityAPI.h
-    API/EditorLevelNotificationBus.h
     API/ViewportEditorModeTrackerNotificationBus.h
     API/EditorVegetationRequestsBus.h
     API/EditorPythonConsoleBus.h
@@ -521,6 +520,7 @@ set(FILES
     ComponentModes/BoxComponentMode.cpp
     ComponentModes/BoxViewportEdit.h
     ComponentModes/BoxViewportEdit.cpp
+    ViewportSelection/EditorInteractionInterface.h
     ViewportSelection/EditorBoxSelect.h
     ViewportSelection/EditorBoxSelect.cpp
     ViewportSelection/EditorDefaultSelection.h
@@ -722,8 +722,11 @@ set(FILES
     UI/Prefab/LevelRootUiHandler.h
     UI/Prefab/LevelRootUiHandler.cpp
     UI/Prefab/PrefabEditInterface.h
+    UI/Prefab/PrefabEditPublicInterface.h
     UI/Prefab/PrefabEditManager.h
     UI/Prefab/PrefabEditManager.cpp
+    UI/Prefab/PrefabEditUndo.h
+    UI/Prefab/PrefabEditUndo.cpp
     UI/Prefab/PrefabIntegrationBus.h
     UI/Prefab/PrefabIntegrationManager.h
     UI/Prefab/PrefabIntegrationManager.cpp


### PR DESCRIPTION
This PR is a DRAFT (not to be merged) and adds the previous draft PR-2167 (@AMZN-daimini) for discussion pertaining to the wider context of FocusMode.

Additions to this PR are the call sites for informing the ViewportEditorModeTracker of when editor modes are entered/exited.

PRs smooshed together in this PR:
https://github.com/o3de/o3de/pull/4112 (editor mode state tracker impl + tests).
https://github.com/o3de/o3de/pull/2167 (@AMZN-daimini's defunct draft of prefab UX prototype).

Signed-off-by: John <jonawals@amazon.com>