### PR TITLE
[LYN-5324]  Add log archiving via Kinesis to S3 Data Ingestion

### DIFF
--- a/Gems/AWSLogExplorer/cdk/aws_logexplorer/aws_logexplorer_stack.py
+++ b/Gems/AWSLogExplorer/cdk/aws_logexplorer/aws_logexplorer_stack.py
@@ -8,6 +8,8 @@ from aws_cdk import (
     core,
 )
 
+from .data_ingestion import DataIngestion
+
 class AWSLogExplorerStack(core.Stack):
 
     def __init__(self, 
@@ -17,3 +19,5 @@ class AWSLogExplorerStack(core.Stack):
                  feature_name: str, 
                  **kwargs) -> None:
         super().__init__(scope, id_, **kwargs)
+
+        self._data_ingestion = DataIngestion(self)

--- a/Gems/AWSLogExplorer/cdk/aws_logexplorer/aws_logexplorer_stack.py
+++ b/Gems/AWSLogExplorer/cdk/aws_logexplorer/aws_logexplorer_stack.py
@@ -20,4 +20,4 @@ class AWSLogExplorerStack(core.Stack):
                  **kwargs) -> None:
         super().__init__(scope, id_, **kwargs)
 
-        self._data_ingestion = DataIngestion(self)
+        self._data_ingestion = DataIngestion(self, project_name, feature_name)

--- a/Gems/AWSLogExplorer/cdk/aws_logexplorer/data_ingestion.py
+++ b/Gems/AWSLogExplorer/cdk/aws_logexplorer/data_ingestion.py
@@ -17,13 +17,21 @@ class DataIngestion:
     Create the S3 bucket and KinesisFirehose data stream to ingest metrics events.
     """
     
-    def __init__(self, stack: core.Construct) -> None:
+    def __init__(self, stack: core.Construct, project_name: str, feature_name: str) -> None:
         self._stack = stack
-        bucket = s3.Bucket(stack, "Bucket")
+        self._bucket_name = f'{project_name}-{feature_name}-S3bucket'
+  
+        bucket = s3.Bucket(
+            stack,
+            f'{project_name}-{feature_name}-S3bucket',
+            block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
+            encryption=s3.BucketEncryption.S3_MANAGED
+        )
+
+        
         self._input_stream = kinesisFirehose.DeliveryStream(
             self._stack,
             id='InputStream',
             destinations=[destinations.S3Bucket(bucket)],
             delivery_stream_name=f'{self._stack.stack_name}-InputStream'
         )
-

--- a/Gems/AWSLogExplorer/cdk/aws_logexplorer/data_ingestion.py
+++ b/Gems/AWSLogExplorer/cdk/aws_logexplorer/data_ingestion.py
@@ -1,0 +1,29 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+from aws_cdk import (
+    core,
+    aws_s3 as s3,
+    aws_kinesisfirehose as kinesisFirehose,
+    aws_kinesisfirehose_destinations as destinations
+)
+
+class DataIngestion:
+    """
+    Create the S3 bucket and KinesisFirehose data stream to ingest metrics events.
+    """
+    
+    def __init__(self, stack: core.Construct) -> None:
+        self._stack = stack
+        bucket = s3.Bucket(stack, "Bucket")
+        self._input_stream = kinesisFirehose.DeliveryStream(
+            self._stack,
+            id='InputStream',
+            destinations=[destinations.S3Bucket(bucket)],
+            delivery_stream_name=f'{self._stack.stack_name}-InputStream'
+        )
+


### PR DESCRIPTION
The code for just the data ingestion from Kinesis Firehose stream to the S3 bucket, for the purpose of log archiving. Was not able to add server access logging in latest commit, can be added in a future PR.

Tested using boto3 client code to simulate the insertion of log entries into the named delivery stream, data was taken from sample log files from o3de build. The resulting s3 buckets contents are attached
[O3DE-AWS-PROJECT-AWSLogExplorer-us-west-2-InputStream-2-2021-09-16-21-14-11-bee8c3ef-0bb2-4605-935b-7a9d74349b7d-1.pdf](https://github.com/aws-lumberyard-dev/o3de/files/7181062/O3DE-AWS-PROJECT-AWSLogExplorer-us-west-2-InputStream-2-2021-09-16-21-14-11-bee8c3ef-0bb2-4605-935b-7a9d74349b7d-1.pdf)
. 