### PR TITLE
{ly5384} script processing rule behavior more stateless

### DIFF
--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.cpp
@@ -98,6 +98,7 @@ namespace AZ::SceneAPI::Behaviors
         {
             AZStd::string result;
             CallResult(result, FN_OnUpdateManifest, scene);
+            ScriptBuildingNotificationBusHandler::BusDisconnect();
             return result;
         }
 
@@ -109,6 +110,7 @@ namespace AZ::SceneAPI::Behaviors
         {
             ExportProductList result;
             CallResult(result, FN_OnPrepareForExport, scene, outputDirectory, platformIdentifier, productList);
+            ScriptBuildingNotificationBusHandler::BusDisconnect();
             return result;
         }
 
@@ -167,21 +169,9 @@ namespace AZ::SceneAPI::Behaviors
         UnloadPython();
     }
 
-    bool ScriptProcessorRuleBehavior::LoadPython(const AZ::SceneAPI::Containers::Scene& scene)
+    bool ScriptProcessorRuleBehavior::LoadPython(const AZ::SceneAPI::Containers::Scene& scene, AZStd::string& scriptPath)
     {
-        if (m_editorPythonEventsInterface && !m_scriptFilename.empty())
-        {
-            return true;
-        }
-
-        // get project folder
-        auto settingsRegistry = AZ::SettingsRegistry::Get();
-        AZ::IO::FixedMaxPath projectPath;
-        if (!settingsRegistry->Get(projectPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath))
-        {
-            return false;
-        }
-
+        int scriptDiscoveryAttempts = 0;
         const AZ::SceneAPI::Containers::SceneManifest& manifest = scene.GetManifest();
         auto view = Containers::MakeDerivedFilterView<DataTypes::IScriptProcessorRule>(manifest.GetValueStorage());
         for (const auto& scriptItem : view)
@@ -193,9 +183,21 @@ namespace AZ::SceneAPI::Behaviors
                 continue;
             }
 
+            ++scriptDiscoveryAttempts;
+
             // check for file exist via absolute path
             if (!IO::FileIOBase::GetInstance()->Exists(scriptFilename.c_str()))
             {
+                // get project folder
+                auto settingsRegistry = AZ::SettingsRegistry::Get();
+                AZ::IO::FixedMaxPath projectPath;
+                if (!settingsRegistry->Get(projectPath.Native(), AZ::SettingsRegistryMergeUtils::FilePathKey_ProjectPath))
+                {
+                    AZ_Error("scene", false, "With (%s) could not find Project Path during script discovery.",
+                        scene.GetManifestFilename().c_str());
+                    return false;
+                }
+
                 // check for script in the project folder
                 AZ::IO::FixedMaxPath projectScriptPath = projectPath / scriptFilename;
                 if (!IO::FileIOBase::GetInstance()->Exists(projectScriptPath.c_str()))
@@ -208,32 +210,47 @@ namespace AZ::SceneAPI::Behaviors
                 scriptFilename = AZStd::move(projectScriptPath);
             }
 
-            // lazy load the Python interface
-            auto editorPythonEventsInterface = AZ::Interface<AzToolsFramework::EditorPythonEventsInterface>::Get();
-            if (editorPythonEventsInterface->IsPythonActive() == false)
-            {
-                const bool silenceWarnings = false;
-                if (editorPythonEventsInterface->StartPython(silenceWarnings) == false)
-                {
-                    editorPythonEventsInterface = nullptr;
-                }
-            }
+            scriptPath = scriptFilename.c_str();
+            break;
+        }
 
-            // both Python and the script need to be ready
-            if (editorPythonEventsInterface == nullptr || scriptFilename.empty())
-            {
-                AZ_Warning("scene", false,"The scene manifest (%s) attempted to use script(%s) but Python is not enabled;"
-                    "please add the EditorPythonBinding gem & PythonAssetBuilder gem to your project.",
-                    scene.GetManifestFilename().c_str(), scriptFilename.c_str());
+        if (scriptPath.empty())
+        {
+            AZ_Warning("scene", scriptDiscoveryAttempts == 0,
+                "The scene manifest (%s) attempted to use script rule, but no script file path could be found.",
+                scene.GetManifestFilename().c_str());
+            return false;
+        }
 
-                return false;
-            }
-
-            m_editorPythonEventsInterface = editorPythonEventsInterface;
-            m_scriptFilename = scriptFilename.c_str();
+        // already prepared the Python VM?
+        if (m_editorPythonEventsInterface)
+        {
             return true;
         }
-        return false;
+
+        // lazy load the Python interface
+        auto editorPythonEventsInterface = AZ::Interface<AzToolsFramework::EditorPythonEventsInterface>::Get();
+        if (editorPythonEventsInterface->IsPythonActive() == false)
+        {
+            const bool silenceWarnings = false;
+            if (editorPythonEventsInterface->StartPython(silenceWarnings) == false)
+            {
+                editorPythonEventsInterface = nullptr;
+            }
+        }
+
+        // both Python and the script need to be ready
+        if (editorPythonEventsInterface == nullptr)
+        {
+            AZ_Warning("scene", false,
+                "The scene manifest (%s) attempted to prepare Python but Python can not start",
+                scene.GetManifestFilename().c_str());
+
+            return false;
+        }
+
+        m_editorPythonEventsInterface = editorPythonEventsInterface;
+        return true;
     }
 
     void ScriptProcessorRuleBehavior::UnloadPython()
@@ -250,11 +267,13 @@ namespace AZ::SceneAPI::Behaviors
     {
         using namespace AzToolsFramework;
 
-        auto executeCallback = [this, &context]()
+        AZStd::string scriptPath;
+
+        auto executeCallback = [&context, &scriptPath]()
         {
             // set up script's hook callback
             EditorPythonRunnerRequestBus::Broadcast(&EditorPythonRunnerRequestBus::Events::ExecuteByFilename,
-                m_scriptFilename.c_str());
+                scriptPath.c_str());
 
             // call script's callback to allow extra products
             ExportProductList extraProducts;
@@ -278,7 +297,7 @@ namespace AZ::SceneAPI::Behaviors
             }
         };
 
-        if (LoadPython(context.GetScene()))
+        if (LoadPython(context.GetScene(), scriptPath))
         {
             EditorPythonConsoleNotificationHandler logger;
             m_editorPythonEventsInterface->ExecuteWithLock(executeCallback);
@@ -305,23 +324,19 @@ namespace AZ::SceneAPI::Behaviors
     {
         using namespace AzToolsFramework;
 
-        // This behavior persists on the same AssetBuilder. Clear the script file name so that if
-        // this builder processes a scene file with a script file name, and then later processes
-        // a scene without a script file name, it won't run the old script on the new scene.
-        m_scriptFilename.clear();
-
         if (action != ManifestAction::Update)
         {
             return Events::ProcessingResult::Ignored;
         }
 
-        if (LoadPython(scene))
+        AZStd::string scriptPath;
+        if (LoadPython(scene, scriptPath))
         {
             AZStd::string manifestUpdate;
-            auto executeCallback = [this, &scene, &manifestUpdate]()
+            auto executeCallback = [&scene, &manifestUpdate, &scriptPath]()
             {
                 EditorPythonRunnerRequestBus::Broadcast(&EditorPythonRunnerRequestBus::Events::ExecuteByFilename,
-                    m_scriptFilename.c_str());
+                    scriptPath.c_str());
 
                 ScriptBuildingNotificationBus::BroadcastResult(manifestUpdate, &ScriptBuildingNotificationBus::Events::OnUpdateManifest,
                     scene);

--- a/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h
+++ b/Code/Tools/SceneAPI/SceneData/Behaviors/ScriptProcessorRuleBehavior.h
@@ -51,15 +51,13 @@ namespace AZ::SceneAPI::Behaviors
             ManifestAction action,
             RequestingApplication requester) override;
 
-
     protected:
-        bool LoadPython(const AZ::SceneAPI::Containers::Scene& scene);
+        bool LoadPython(const AZ::SceneAPI::Containers::Scene& scene, AZStd::string& scriptPath);
         void UnloadPython();
         bool DoPrepareForExport(Events::PreExportEventContext& context);
 
     private:
         AzToolsFramework::EditorPythonEventsInterface* m_editorPythonEventsInterface = nullptr;
-        AZStd::string m_scriptFilename;
 
         struct ExportEventHandler;
         AZStd::shared_ptr<ExportEventHandler> m_exportEventHandler;


### PR DESCRIPTION
Made the script processing rule behavior more stateless so that the
script name needs to be discovered each time.

Disconnect from the bus after each scene script builder usage.

Before it would be possible that the same script can be run more than
once for each asset.