### PR TITLE
fix for "warning C4100: 'message': unreferenced formal"

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EntityUtilityComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EntityUtilityComponent.cpp
@@ -181,7 +181,7 @@ namespace AzToolsFramework
         using namespace AZ::JsonSerializationResult;
 
         AZ::JsonDeserializerSettings settings = AZ::JsonDeserializerSettings{};
-        settings.m_reporting = [](AZStd::string_view message, ResultCode result, AZStd::string_view) -> auto
+        settings.m_reporting = []([[maybe_unused]] AZStd::string_view message, ResultCode result, AZStd::string_view) -> auto
         {
             if (result.GetProcessing() == Processing::Halted)
             {


### PR DESCRIPTION
fix for "warning C4100: 'message': unreferenced formal"

Signed-off-by: jackalbe <23512001+jackalbe@users.noreply.github.com>