### PR TITLE
Hair - first iteration of ShortCut shaders using Atom

### DIFF
--- a/Gems/AtomTressFX/Assets/Shaders/HairComputeSrgs.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairComputeSrgs.azsli
@@ -29,7 +29,7 @@
 // THE SOFTWARE.
 //
 //------------------------------------------------------------------------------
-// File: HairSRGs.azsli
+// File: HairComputeSrgs.azsli
 //
 // Declarations of SRGs used by the hair shaders.
 //------------------------------------------------------------------------------

--- a/Gems/AtomTressFX/Assets/Shaders/HairFullScreenUtils.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairFullScreenUtils.azsli
@@ -1,0 +1,59 @@
+/*
+* Modifications Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: (Apache-2.0 OR MIT) AND MIT
+*
+*/
+
+#include <Atom/Features/PostProcessing/FullscreenVertexInfo.azsli>
+#include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
+
+//==============================================================================
+// Generate a fullscreen triangle from pipeline provided vertex id 
+VSOutput FullScreenVS(VSInput input)
+{
+    VSOutput OUT;
+
+    float4 posTex = GetVertexPositionAndTexCoords(input.m_vertexID);
+
+    OUT.m_texCoord = float2(posTex.z, posTex.w);    // [To Do] - test sign of Y based on original code
+    OUT.m_position = float4(posTex.xy, 0.0, 1.0);
+
+    return OUT;
+}
+
+//==============================================================================
+// Given the depth buffer depth of the current pixel and the fragment XY position, 
+// reconstruct the NDC.
+// screenCoords - from 0.. dimension of the screen of the current pixel
+// screenTexture - screen buffer texture representing the same resolution we work in
+// sDepth - the depth buffer depth at the fragment location
+// NDC - Normalized Device Coordinates = warped screen space ( -1.1, -1..1, 0..1 )
+float3 ScreenPosToNDC( Texture2D<float> screenTexture, float2 screenCoords, float depth )
+{ 
+    uint2 dimensions;
+    screenTexture.GetDimensions(dimensions.x, dimensions.y);
+    float2 UV = saturate(screenCoords / dimensions.xy);
+
+    float x = UV.x * 2.0f - 1.0f;
+    float y = (1.0f - UV.y) * 2.0f - 1.0f;
+    float3 NDC = float3(x, y, depth);
+
+    return NDC;
+}
+
+// Given the depth buffer depth of the current pixel and the fragment XY position, 
+// reconstruct the world space position
+float3 ScreenPosToWorldPos( 
+    Texture2D<float> screenTexture, float2 screenCoords, float depth, 
+    inout float3 screenPosNDC )
+{ 
+    screenPosNDC = ScreenPosToNDC(PassSrg::m_linearDepth, screenCoords, depth);
+    float4 projectedPos = float4(screenPosNDC, 1.0f);    // warped projected space [0..1]
+    float4 positionVS = mul(ViewSrg::m_projectionMatrixInverse, projectedPos);
+    positionVS /= positionVS.w; // notice the normalization factor - crucial! 
+    float4 positionWS = mul(ViewSrg::m_viewMatrixInverse, positionVS);
+
+    return positionWS.xyz;
+}

--- a/Gems/AtomTressFX/Assets/Shaders/HairLighting.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairLighting.azsli
@@ -230,7 +230,7 @@ float3 CalculateLighting(
     return lightingData.diffuseLighting + lightingData.specularLighting;
 }
 
-float3 TressFXShading(float2 pixelCoord, float depth, float3 vTangentCoverage, float3 baseColor, float thickness, int shaderParamIndex)
+float3 TressFXShading(float2 pixelCoord, float depth, float3 tangent, float3 baseColor, float thickness, int shaderParamIndex)
 {
     float3 vNDC;    // normalized device / screen coordinates: [-1..1, -1..1, 0..1]
     float3 vPositionWS = ScreenPosToWorldPos(PassSrg::m_linearDepth, pixelCoord, depth, vNDC);
@@ -240,9 +240,6 @@ float3 TressFXShading(float2 pixelCoord, float depth, float3 vTangentCoverage, f
     float4 screenCoords = float4( _BIG_HACK_FOR_TESTING_ * pixelCoord, depth, depth);   // screen space position - XY in pixels - ZW are depth 0..1
 
     float3 vViewDirWS = g_vEye - vPositionWS;
-
-    // Need to expand the tangent that was compressed to store in the buffer
-    float3 vTangent = normalize(vTangentCoverage.xyz * 2.f - 1.f);
 
     //---- TressFX original lighting params setting ----
     HairShadeParams params;
@@ -266,11 +263,19 @@ float3 TressFXShading(float2 pixelCoord, float depth, float3 vTangentCoverage, f
     if (o_hairLightingModel == HairLightingModel::Kajiya)
     {   // This option should be removed and the Kajiya-Kay model should be operated from within 
         // the Atom lighting loop.
-        accumulatedLight = SimplifiedHairLighting(vTangent, vPositionWS, vViewDirWS, params, vNDC);    
+        accumulatedLight = SimplifiedHairLighting(tangent, vPositionWS, vViewDirWS, params, vNDC);    
     }
     else
     {
-        accumulatedLight = CalculateLighting(screenCoords, vPositionWS, vViewDirWS, vTangent, thickness, params);
+        accumulatedLight = CalculateLighting(screenCoords, vPositionWS, vViewDirWS, tangent, thickness, params);
     }
     return accumulatedLight;
+}
+
+float3 TressFXShadingFullScreen(float2 pixelCoord, float depth, float3 compressedTangent, float3 baseColor, float thickness, int shaderParamIndex)
+{
+    // The tangent that was compressed to store in the PPLL structure
+    float3 tangent = normalize(compressedTangent.xyz * 2.f - 1.f);
+
+    return TressFXShading(pixelCoord, depth, tangent, baseColor, thickness, shaderParamIndex);
 }

--- a/Gems/AtomTressFX/Assets/Shaders/HairLightingEquations.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairLightingEquations.azsli
@@ -66,7 +66,7 @@ option bool o_enableAzimuthCoeff = true;
 float M_R(Surface surface, float Lh, float sinLiPlusSinLr)
 {
     float a = 1.0f * surface.cuticleTilt;   // Tilt is translate as the mean offset
-    float b = 0.5 * surface.roughnessA2;    // Roughness is used as the standard deviation
+    float b = 0.5f * surface.roughnessA2;    // Roughness is used as the standard deviation
 
 //    return GaussianNormalized(sinLiPlusSinLr, a, b);  // reference
     return GaussianNormalized(Lh, a, b);
@@ -74,8 +74,8 @@ float M_R(Surface surface, float Lh, float sinLiPlusSinLr)
 
 float M_TT(Surface surface, float Lh, float sinLiPlusSinLr)
 {
-    float a = 1.0 * surface.cuticleTilt;
-    float b = 0.5 * surface.roughnessA2;
+    float a = 1.0f * surface.cuticleTilt;
+    float b = 0.5f * surface.roughnessA2;
 
 //    return GaussianNormalized(sinLiPlusSinLr, a, b);  // reference
     return GaussianNormalized(Lh, a, b);
@@ -83,8 +83,8 @@ float M_TT(Surface surface, float Lh, float sinLiPlusSinLr)
 
 float M_TRT(Surface surface, float Lh, float sinLiPlusSinLr)
 {
-    float a = 1.5 * surface.cuticleTilt;
-    float b = 1.0 * surface.roughnessA2;
+    float a = 1.5f * surface.cuticleTilt;
+    float b = 1.0f * surface.roughnessA2;
 
 //    return GaussianNormalized(sinLiPlusSinLr, a, b);  // reference
     return GaussianNormalized(Lh, a, b);    

--- a/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairRenderingFillPPLL.azsl
@@ -40,7 +40,8 @@
 //!  that can change between passes due to the application of skinning, simulation 
 //!  and physics affect and is then read by the rendering shaders.  
 ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback 
-{   //! This shared buffer needs to match the SharedBuffer structure  
+{   
+    //! This shared buffer needs to match the SharedBuffer structure  
     //! shared between all draw calls / dispatches for the hair skinning
     StructuredBuffer<int>           m_skinnedHairSharedBuffer;
 
@@ -101,39 +102,8 @@ ShaderResourceGroup HairDynamicDataSrg : SRG_PerObject // space 1 - per instance
 #define g_GuideHairVertexTangents   HairDynamicDataSrg::m_hairVertexTangents
 
 //==============================================================================
-#include <HairStrands.azsli>
+#include <HairStrands.azsli>        // VS resides here
 //==============================================================================
-//! Hair input structure to Pixel shaders
-struct PS_INPUT_HAIR
-{
-    float4 Position    : SV_POSITION;
-    float4 Tangent     : Tangent;
-    float4 p0p1        : TEXCOORD0;
-    float4 StrandColor : TEXCOORD1;
-};
-
-//! Hair Render VS 
-PS_INPUT_HAIR RenderHairVS(uint vertexId : SV_VertexID)
-{
-//    uint2  scrSize;
-//    PassSrg::m_linearDepth.GetDimensions(scrSize.x, scrSize.y);
-//    TressFXVertex tressfxVert = GetExpandedTressFXVert(vertexId, g_vEye.xyz, float2(scrSize), g_mVP);
-
-    // [To Do] Hair: the above code should replace the existing but requires modifications to 
-    // the function GetExpandedTressFXVert. 
-    // Note that in Atom g_vViewport is aspect ratio and NOT size.
-    TressFXVertex tressfxVert = GetExpandedTressFXVert(vertexId, g_vEye.xyz, g_vViewport.zw, g_mVP);
-
-
-    PS_INPUT_HAIR Output;
-
-    Output.Position = tressfxVert.Position;
-    Output.Tangent = tressfxVert.Tangent;
-    Output.p0p1 = tressfxVert.p0p1;
-    Output.StrandColor = tressfxVert.StrandColor;
-
-    return Output;
-}
 
 // Allocate a new fragment location in fragment color, depth, and link buffers
 int AllocateFragment(int2 vScreenAddress)
@@ -202,9 +172,9 @@ void PPLLFillPS(PS_INPUT_HAIR input)
 
     //////////////////////////////////////////////////////////////////////
     // [To Do] Hair: anti aliasing via coverage requires work and is disabled for now
-    float3 vNDC = ScreenPosToNDC(PassSrg::m_linearDepth, input.Position.xy, input.Position.z);
-    uint2  dimensions;
-    PassSrg::m_linearDepth.GetDimensions(dimensions.x, dimensions.y);
+//    float3 vNDC = ScreenPosToNDC(PassSrg::m_linearDepth, input.Position.xy, input.Position.z);
+//    uint2  dimensions;
+//    PassSrg::m_linearDepth.GetDimensions(dimensions.x, dimensions.y);
 //    float coverage = ComputeCoverage(input.p0p1.xy, input.p0p1.zw, vNDC.xy, float2(dimensions.x, dimensions.y));
     float coverage = 1.0;  
     /////////////////////////////////////////////////////////////////////

--- a/Gems/AtomTressFX/Assets/Shaders/HairRenderingResolvePPLL.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairRenderingResolvePPLL.azsl
@@ -93,26 +93,11 @@ ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
 #define HairParams          PassSrg::m_hairParams
 //==============================================================================
 
+#include <HairFullScreenUtils.azsli>    // provides the Vertex Shader
 #include <HairLighting.azsli>
-#include <Atom/Features/PostProcessing/FullscreenVertexInfo.azsli>
-#include <Atom/Features/PostProcessing/FullscreenVertexUtil.azsli>
-
-// Generates a fullscreen triangle from pipeline provided vertex id 
-VSOutput FullScreenVS(VSInput input)
-{
-    VSOutput OUT;
-
-    float4 posTex = GetVertexPositionAndTexCoords(input.m_vertexID);
-
-    OUT.m_texCoord = float2(posTex.z, posTex.w);  
-    OUT.m_position = float4(posTex.x, posTex.y, 0.0, 1.0);
-
-    return OUT;
-}
 
 //////////////////////////////////////////////////////////////
 // Bind data for PPLLResolvePS
-
 #define NODE_DATA(x) LinkedListNodes[x].data
 #define NODE_NEXT(x) LinkedListNodes[x].uNext
 #define NODE_DEPTH(x) LinkedListNodes[x].depth
@@ -298,7 +283,7 @@ float4 GatherLinkedList(float2 vfScreenAddress, float2 screenUV, inout float out
         uint shadeParamIndex;	// So we know what settings to shade with
 
         float3 vColor = UnpackUintIntoFloat3Byte(color, shadeParamIndex);
-        float3 fragmentColor = TressFXShading(vfScreenAddress, fDepth, vTangent, vColor, fcolor.w, shadeParamIndex);
+        float3 fragmentColor = TressFXShadingFullScreen(vfScreenAddress, fDepth, vTangent, vColor, fcolor.w, shadeParamIndex);
 
         // Blend in the fragment color
         fcolor.xyz = fcolor.xyz * (1.f - alpha) + fragmentColor * alpha;
@@ -355,7 +340,7 @@ float4 GetClosestFragment(float2 vfScreenAddress, float2 screenUV, inout float c
     float alpha = 1.0;
     uint shadeParamIndex;	// the material index
     float3 vColor = UnpackUintIntoFloat3Byte(curColor, shadeParamIndex);
-    float3 fragmentColor = TressFXShading(vfScreenAddress, curDepth, vTangent, vColor, fcolor.w, shadeParamIndex);
+    float3 fragmentColor = TressFXShadingFullScreen(vfScreenAddress, curDepth, vTangent, vColor, fcolor.w, shadeParamIndex);
 
     // Blend in the fragment color
     fcolor.xyz = fcolor.xyz * (1.f - alpha) + (fragmentColor * alpha);

--- a/Gems/AtomTressFX/Assets/Shaders/HairShortCutGeometryDepthAlpha.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairShortCutGeometryDepthAlpha.azsl
@@ -1,0 +1,126 @@
+/*
+* Modifications Copyright (c) Contributors to the Open 3D Engine Project. 
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+* 
+* SPDX-License-Identifier: (Apache-2.0 OR MIT) AND MIT
+*
+*/
+
+//
+// Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include <Atom/Features/SrgSemantics.azsli>
+#include <HairRenderingSrgs.azsli>
+#include <HairStrands.azsli>        // VS resides here
+#include <HairLighting.azsli>
+
+//!------------------------------ SRG Structure --------------------------------
+//! Per pass SRG that holds the dynamic shared read-write buffer shared 
+//! across all dispatches and draw calls. It is used for all the dynamic buffers
+//! that can change between passes due to the application of skinning, simulation 
+//! and physics affect. 
+//! Once the compute pases are done, it is read by the rendering shaders.  
+ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    //! This shared buffer needs to match the SharedBuffer structure  
+    //! shared between all draw calls / dispatches for the hair skinning
+    StructuredBuffer<int>   m_skinnedHairSharedBuffer;
+
+    //! Based on [[vk::binding(0, 3)]] RWTexture2DArray<uint> RWFragmentDepthsTexture : register(u0, space3);
+    RWTexture2DArray<uint>  m_RWFragmentDepthsTexture;
+}
+//==============================================================================
+
+//!------------------------------ SRG Structure --------------------------------
+//! Per instance/draw SRG representing dynamic read-write set of buffers
+//!  that are unique per instance and are shared and changed between passes due 
+//!  to the application of skinning, simulation and physics affect.
+//! It is then also read by the rendering shaders. 
+//! This Srg is NOT shared by the passes since it requires having barriers between
+//!  both passes and draw calls, instead, all buffers are allocated from a single 
+//!  shared buffer (through BufferViews) and that buffer is then shared between 
+//!  the passes via the PerPass Srg frequency. 
+ShaderResourceGroup HairDynamicDataSrg : SRG_PerObject // space 1 - per instance / object
+{
+    Buffer<float4>      m_hairVertexPositions;
+    Buffer<float4>      m_hairVertexTangents;
+
+    //! Per hair object offset to the start location of each buffer within 
+    //! 'm_skinnedHairSharedBuffer'. The offset is in bytes!
+    uint m_positionBufferOffset;
+    uint m_tangentBufferOffset;
+};
+//------------------------------------------------------------------------------
+// Allow for the code to run with minimal changes - skinning / simulation compute passes
+
+// Usage of per-instance buffer
+#define g_GuideHairVertexPositions  HairDynamicDataSrg::m_hairVertexPositions
+#define g_GuideHairVertexTangents   HairDynamicDataSrg::m_hairVertexTangents
+
+//!=============================================================================
+//! This is the first pass of the ShortCut rendering method.
+//! Depth Alpha PS
+//! It is a Geometry pass that stores the K=3 front fragment depths, and accumulates 
+//! product of 1-alpha values in the render target.
+//!=============================================================================
+[earlydepthstencil]
+float DepthsAlphaPS(PS_INPUT_HAIR input) : SV_Target
+{
+    //////////////////////////////////////////////////////////////////////
+    // [To Do] Hair: anti aliasing via coverage requires work and is disabled for now
+//    float3 vNDC = ScreenPosToNDC(PassSrg::m_linearDepth, input.Position.xy, input.Position.z);
+//    uint2  dimensions;
+//    PassSrg::m_linearDepth.GetDimensions(dimensions.x, dimensions.y);
+//    float coverage = ComputeCoverage(input.p0p1.xy, input.p0p1.zw, vNDC.xy, float2(dimensions.x, dimensions.y));
+    float coverage = 1.0;  
+    /////////////////////////////////////////////////////////////////////
+
+    float alpha = coverage * MatBaseColor.a;
+
+    if (alpha < SHORTCUT_MIN_ALPHA)
+        return 1.0;
+
+    int2 vScreenAddress = int2(input.Position.xy);
+
+    uint uDepth = asuint(input.Position.z);
+    uint uDepth0Prev, uDepth1Prev;
+
+    // Min of depth 0 and input depth
+    // Original value is uDepth0Prev
+    InterlockedMin(PassSrg::m_RWFragmentDepthsTexture[uint3(vScreenAddress, 0)], uDepth, uDepth0Prev);
+
+    // Min of depth 1 and greater of the last compare
+    // If fragment opaque, always use input depth (don't need greater depths)
+    uDepth = (alpha > 0.98) ? uDepth : max(uDepth, uDepth0Prev);
+
+    InterlockedMin(PassSrg::m_RWFragmentDepthsTexture[uint3(vScreenAddress, 1)], uDepth, uDepth1Prev);
+
+    uint uDepth2Prev;
+
+    // Min of depth 2 and greater of the last compare
+    // If fragment opaque, always use input depth (don't need greater depths)
+    uDepth = (alpha > 0.98) ? uDepth : max(uDepth, uDepth1Prev);
+
+    InterlockedMin(PassSrg::m_RWFragmentDepthsTexture[uint3(vScreenAddress, 2)], uDepth, uDepth2Prev);
+
+    return 1.0 - alpha;
+}

--- a/Gems/AtomTressFX/Assets/Shaders/HairShortCutGeometryShading.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairShortCutGeometryShading.azsl
@@ -1,0 +1,164 @@
+/*
+* Modifications Copyright (c) Contributors to the Open 3D Engine Project. 
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+* 
+* SPDX-License-Identifier: (Apache-2.0 OR MIT) AND MIT
+*
+*/
+
+//------------------------------------------------------------------------------
+// Shader code related to lighting and shadowing for TressFX
+//------------------------------------------------------------------------------
+//
+// Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include <Atom/Features/SrgSemantics.azsli>
+#include <HairRenderingSrgs.azsli>
+#include <HairStrands.azsli>            // VS resides here
+#include <HairFullScreenUtils.azsli>    // Required for world coordinates calculation
+#include <HairLighting.azsli>
+
+#define AMD_TRESSFX_MAX_HAIR_GROUP_RENDER 16
+
+//!------------------------------ SRG Structure --------------------------------
+//! Per pass SRG that holds the dynamic shared read-write buffer shared 
+//! across all dispatches and draw calls. It is used for all the dynamic buffers
+//! that can change between passes due to the application of skinning, simulation 
+//! and physics affect. 
+//! Once the compute pases are done, it is read by the rendering shaders.  
+ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    //! Per hair object material array used by the PPLL resolve pass
+    //! Originally in TressFXRendering.hlsl this is space 0 
+    HairObjectShadeParams   m_hairParams[AMD_TRESSFX_MAX_HAIR_GROUP_RENDER];
+
+    // Linear depth is used for getting the screen to world transform
+    Texture2D<float>        m_linearDepth;
+
+    //------------------------------
+    //        Lighting Data
+    //------------------------------
+    Sampler LinearSampler
+    {   // Required by LightingData.azsli
+        MinFilter = Linear;
+        MagFilter = Linear;
+        MipFilter = Linear;
+        AddressU = Clamp;
+        AddressV = Clamp;
+        AddressW = Clamp;
+    };
+
+    Texture2DArray<float>   m_directionalLightShadowmap;
+    Texture2DArray<float>   m_directionalLightExponentialShadowmap;
+    Texture2DArray<float>   m_projectedShadowmaps;
+    Texture2DArray<float>   m_projectedExponentialShadowmap;
+    Texture2D               m_brdfMap;   
+    Texture2D<uint4>        m_tileLightData;
+    StructuredBuffer<uint>  m_lightListRemapped;
+}
+
+//------------------------------------------------------------------------------
+//! The hair objects' material array buffer used by the rendering resolve pass
+#define HairParams          PassSrg::m_hairParams
+//==============================================================================
+
+//!------------------------------ SRG Structure --------------------------------
+//! Per instance/draw SRG representing dynamic read-write set of buffers
+//!  that are unique per instance and are shared and changed between passes due 
+//!  to the application of skinning, simulation and physics affect.
+//! It is then also read by the rendering shaders. 
+//! This Srg is NOT shared by the passes since it requires having barriers between
+//!  both passes and draw calls, instead, all buffers are allocated from a single 
+//!  shared buffer (through BufferViews) and that buffer is then shared between 
+//!  the passes via the PerPass Srg frequency. 
+ShaderResourceGroup HairDynamicDataSrg : SRG_PerObject // space 1 - per instance / object
+{
+    Buffer<float4>      m_hairVertexPositions;
+    Buffer<float4>      m_hairVertexTangents;
+
+    //! Per hair object offset to the start location of each buffer within 
+    //! 'm_skinnedHairSharedBuffer'. The offset is in bytes!
+    uint m_positionBufferOffset;
+    uint m_tangentBufferOffset;
+};
+//------------------------------------------------------------------------------
+// Allow for the code to run with minimal changes - skinning / simulation compute passes
+
+// Usage of per-instance buffer
+#define g_GuideHairVertexPositions  HairDynamicDataSrg::m_hairVertexPositions
+#define g_GuideHairVertexTangents   HairDynamicDataSrg::m_hairVertexTangents
+
+
+//!=============================================================================
+//! This is the third pass of ShortCut.
+//! It is a Geometry pass that shades pixels passing early depth test. It is limited 
+//! to near fragments due to previous depth write pass that will early cull all others.
+//! Colors are accumulated in render target for a weighted average in final pass.
+//!=============================================================================
+[earlydepthstencil]
+float4 HairColorPS(PS_INPUT_HAIR input) : SV_Target
+{
+    // Strand Color read in is either the BaseMatColor, or BaseMatColor modulated with a color read from texture 
+    // on vertex shader for base color along with modulation by the tip color  
+    float4 strandColor = float4(input.StrandColor.rgb, MatBaseColor.a);
+
+    // If we are supporting strand UV texturing, further blend in the texture color/alpha
+    // Do this while computing NDC and coverage to hide latency from texture lookup
+    if (EnableStrandUV)
+    {
+        // Grab the uv in case we need it
+        float2 uv = float2(input.Tangent.w, input.StrandColor.w);
+
+        // Apply StrandUVTiling
+        float2 strandUV = float2(uv.x, (uv.y * StrandUVTilingFactor) - floor(uv.y * StrandUVTilingFactor));
+
+        strandColor.rgb *= StrandAlbedoTexture.Sample(LinearWrapSampler, strandUV).rgb;
+    }
+
+    //////////////////////////////////////////////////////////////////////
+    // [To Do] Hair: anti aliasing via coverage requires work and is disabled for now
+//    float3 vNDC = ScreenPosToNDC(PassSrg::m_linearDepth, input.Position.xy, input.Position.z);
+//    uint2  dimensions;
+//    PassSrg::m_linearDepth.GetDimensions(dimensions.x, dimensions.y);
+//    float coverage = ComputeCoverage(input.p0p1.xy, input.p0p1.zw, vNDC.xy, float2(dimensions.x, dimensions.y));
+// original:    float coverage = ComputeCoverage(input.p0p1.xy, input.p0p1.zw, vNDC.xy, g_vViewport.zw - g_vViewport.xy);
+    float coverage = 1.0;  
+    /////////////////////////////////////////////////////////////////////
+    
+    float alpha = coverage;
+
+    // Update the alpha to have proper value (accounting for coverage, base alpha, and strand alpha)
+    alpha *= strandColor.w;
+
+    // Early out
+    if (alpha < SHORTCUT_MIN_ALPHA)
+    {
+        return float4(0, 0, 0, 0);
+    }
+
+    float2 pixelCoord = input.Position.xy;
+    float depth = input.Position.z;
+    float thickess = 0.5f;  // [To Do] - this will need to be corrected somehow since this technique doesn't quite support it
+    float3 TressFXShading(pixelCoord, depth, input.Tangent.xyz, strandColor.rgb, thickness, RenderParamsIndex);
+
+    return float4(color * alpha, alpha);
+}

--- a/Gems/AtomTressFX/Assets/Shaders/HairShortCutResolveColor.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairShortCutResolveColor.azsl
@@ -1,0 +1,48 @@
+/*
+* Modifications Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: (Apache-2.0 OR MIT) AND MIT
+*
+*/
+
+#include <Atom/Features/SrgSemantics.azsli>
+#include <HairUtilities.azsli> 
+#include <HairFullScreenUtils.azsli>    // provides the Vertex Shader
+
+//!------------------------------ SRG Structure --------------------------------
+//! Per pass SRG that holds the dynamic shared read-write buffer shared 
+//! across all dispatches and draw calls. It is used for all the dynamic buffers
+//! that can change between passes due to the application of skinning, simulation 
+//! and physics affect. 
+//! Once the compute pases are done, it is read by the rendering shaders.  
+ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    // oiriginally: [[vk::binding(0, 0)]] Texture2D<float4> HaiColorTexture : register(t0, space0);
+    // oiriginally: [[vk::binding(1, 0)]] Texture2D<float>  AccumInvAlpha : register(t1, space0);
+    Texture2D<float4> m_hairColorTexture;
+    Texture2D<float>  m_accumInvAlpha;
+}
+
+//////////////////////////////////////////////////////////////
+//! HairColorPS - the fourth pass of ShortCut.
+//! Full-screen pass that finalizes the weighted average, and blends using the accumulated 1-alpha product.
+[earlydepthstencil]
+float4 ResolveHairPS(VSOutput input) : SV_Target
+{
+    int2 vScreenAddress = int2(input.vPosition.xy);
+
+    float fInvAlpha = PassSrg::m_accumInvAlpha[vScreenAddress];
+    float fAlpha = 1.0 - fInvAlpha;
+
+    if (fAlpha < SHORTCUT_MIN_ALPHA)
+        return float4(0, 0, 0, 1);
+
+    float4 finalColor;
+    float weightSum = PassSrg::m_hairColorTexture[vScreenAddress].w;
+
+    finalColor.xyz = PassSrg::m_hairColorTexture[vScreenAddress] * fAlpha / weightSum;
+    finalColor.w = fInvAlpha;
+
+    return fcolor;
+}

--- a/Gems/AtomTressFX/Assets/Shaders/HairShortCutResolveDepth.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairShortCutResolveDepth.azsl
@@ -1,0 +1,63 @@
+/*
+* Modifications Copyright (c) Contributors to the Open 3D Engine Project.
+* For complete copyright and license terms please see the LICENSE at the root of this distribution.
+*
+* SPDX-License-Identifier: (Apache-2.0 OR MIT) AND MIT
+*
+*/
+
+//------------------------------------------------------------------------------
+// Shader code related to lighting and shadowing for TressFX
+//------------------------------------------------------------------------------
+//
+// Copyright (c) 2019 Advanced Micro Devices, Inc. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+#include <Atom/Features/SrgSemantics.azsli>
+#include <HairFullScreenUtils.azsli>    // provides the Vertex Shader
+
+//!------------------------------ SRG Structure --------------------------------
+//! Per pass SRG that holds the dynamic shared read-write buffer shared 
+//! across all dispatches and draw calls. It is used for all the dynamic buffers
+//! that can change between passes due to the application of skinning, simulation 
+//! and physics affect. 
+//! Once the compute pases are done, it is read by the rendering shaders.  
+ShaderResourceGroup PassSrg : SRG_PerPass_WithFallback
+{
+    // Originally: [[vk::binding(0, 0)]] Texture2DArray<uint> FragmentDepthsTexture : register(t0, space0);
+    Texture2DArray<uint> m_fragmentDepthsTexture; 
+}
+
+//////////////////////////////////////////////////////////////
+//! Resolve Depth PS - second pass of ShortCut.
+//! Full-screen pass that writes the farthest of the near depths for depth culling.
+float ResolveDepthPS(VSOutput input) : SV_Depth
+{
+    // Blend the layers of fragments from back to front
+    int2 vScreenAddress = int2(input.m_position.xy);
+
+    // Write farthest depth value for culling in the next pass.
+    // It may be the initial value of 1.0 if there were not enough fragments to write all depths, but then culling not important.
+    const int farthestDepthIndex = 2;
+    uint uDepth = PassSrg::m_fragmentDepthsTexture[uint3(vScreenAddress, farthestDepthIndex)];
+
+    return asfloat(uDepth);
+}

--- a/Gems/AtomTressFX/Assets/Shaders/HairSimulationCompute.azsl
+++ b/Gems/AtomTressFX/Assets/Shaders/HairSimulationCompute.azsl
@@ -31,7 +31,7 @@
 // THE SOFTWARE.
 //
 //--------------------------------------------------------------------------------------
-#include <HairSimulationSrgs.azsli>
+#include <HairSimulationComputeSrgs.azsli>
 #include <HairSimulationCommon.azsli>
 
 //--------------------------------------------------------------------------------------

--- a/Gems/AtomTressFX/Assets/Shaders/HairSimulationComputeSrgs.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairSimulationComputeSrgs.azsli
@@ -29,13 +29,13 @@
 // THE SOFTWARE.
 //
 //------------------------------------------------------------------------------
-// File: HairSRGs.azsli
+// File: HairSimulationComputeSrgs.azsli
 //
 // Declarations of SRGs used by the hair shaders.
 //------------------------------------------------------------------------------
 #pragma once
 
-#include <HairSrgs.azsli>
+#include <HairComputeSrgs.azsli>
 
 //!-----------------------------------------------------------------------------
 //! 

--- a/Gems/AtomTressFX/Assets/Shaders/HairStrands.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairStrands.azsli
@@ -66,12 +66,22 @@ float3 GetSharedTangent(int tangentIndex)
     );
 }
 
+//! Hair vertex geometry output - input structure for the Pixel shaders
 struct TressFXVertex
 {
     float4 Position;
-    float4 Tangent;
+    float4 Tangent;         // xyz = Tangent, w = Strand U 
     float4 p0p1;
-    float4 StrandColor;
+    float4 StrandColor;     // xyz = Strand Color, w = Strand V
+};
+
+//! Matching structure to carry out as VS output / PS input
+struct PS_INPUT_HAIR
+{
+    float4 Position    : SV_POSITION;
+    float4 Tangent     : Tangent;
+    float4 p0p1        : TEXCOORD0;
+    float4 StrandColor : TEXCOORD1;
 };
 
 float3 GetStrandColor(int index, float fractionOfStrand)
@@ -178,5 +188,26 @@ TressFXVertex GetExpandedTressFXShadowVert(uint vertexId, float3 eye, float2 win
     return Output;
 }
 
-// EndHLSL
+//!=============================================================================
+//!             Hair Render VS - Used by all geometry hair shaders 
+//!=============================================================================
+PS_INPUT_HAIR RenderHairVS(uint vertexId : SV_VertexID)
+{
+    PS_INPUT_HAIR vsOutput;
 
+    //    uint2  scrSize;
+    //    PassSrg::m_linearDepth.GetDimensions(scrSize.x, scrSize.y);
+    //    TressFXVertex tressfxVert = GetExpandedTressFXVert(vertexId, g_vEye.xyz, float2(scrSize), g_mVP);
+
+    // [To Do] Hair: the above code should replace the existing but requires modifications to 
+    // the function GetExpandedTressFXVert. 
+    // Note that in Atom g_vViewport is aspect ratio and NOT size.
+    TressFXVertex tressfxVert = GetExpandedTressFXVert(vertexId, g_vEye.xyz, g_vViewport.zw, g_mVP);
+
+    vsOutput.Position = tressfxVert.Position;
+    vsOutput.Tangent = tressfxVert.Tangent;
+    vsOutput.p0p1 = tressfxVert.p0p1;
+    vsOutput.StrandColor = tressfxVert.StrandColor;
+
+    return vsOutput;
+}

--- a/Gems/AtomTressFX/Assets/Shaders/HairUtilities.azsli
+++ b/Gems/AtomTressFX/Assets/Shaders/HairUtilities.azsli
@@ -52,40 +52,6 @@ float4 MatrixMult(float4x4 m, float4 v)
     return mul(m, v);
 }
 
-// Given the depth buffer depth of the current pixel and the fragment XY position, 
-// reconstruct the NDC.
-// screenCoords - from 0.. dimension of the screen of the current pixel
-// screenTexture - screen buffer texture representing the same resolution we work in
-// sDepth - the depth buffer depth at the fragment location
-// NDC - Normalized Device Coordinates = warped screen space ( -1.1, -1..1, 0..1 )
-float3 ScreenPosToNDC( Texture2D<float> screenTexture, float2 screenCoords, float depth )
-{ 
-    uint2 dimensions;
-    screenTexture.GetDimensions(dimensions.x, dimensions.y);
-    float2 UV = saturate(screenCoords / dimensions.xy);
-
-    float x = UV.x * 2.0f - 1.0f;
-    float y = (1.0f - UV.y) * 2.0f - 1.0f;
-    float3 NDC = float3(x, y, depth);
-
-    return NDC;
-}
-
-// Given the depth buffer depth of the current pixel and the fragment XY position, 
-// reconstruct the world space position
-float3 ScreenPosToWorldPos( 
-    Texture2D<float> screenTexture, float2 screenCoords, float depth, 
-    inout float3 screenPosNDC )
-{ 
-    screenPosNDC = ScreenPosToNDC(PassSrg::m_linearDepth, screenCoords, depth);
-    float4 projectedPos = float4(screenPosNDC, 1.0f);    // warped projected space [0..1]
-    float4 positionVS = mul(ViewSrg::m_projectionMatrixInverse, projectedPos);
-    positionVS /= positionVS.w; // notice the normalization factor - crucial! 
-    float4 positionWS = mul(ViewSrg::m_viewMatrixInverse, positionVS);
-
-    return positionWS.xyz;
-}
-
 // Pack a float4 into an uint
 uint PackFloat4IntoUint(float4 vValue)
 {

--- a/Gems/AtomTressFX/Code/Passes/HairGeometryRasterPass.h
+++ b/Gems/AtomTressFX/Code/Passes/HairGeometryRasterPass.h
@@ -76,7 +76,6 @@ namespace AZ
 
                 // Pass behavior overrides
                 void InitializeInternal() override;
-//                void BuildInternal() override;
                 void FrameBeginInternal(FramePrepareParams params) override;
 
                 // Scope producer functions...

--- a/Gems/AtomTressFX/Hair_files.cmake
+++ b/Gems/AtomTressFX/Hair_files.cmake
@@ -84,28 +84,35 @@ set(FILES
     Code/Assets/HairAsset.cpp
 #)
 #set(shaders_sources
-    # Srgs and Utility files
-    Assets/Shaders/HairSrgs.azsli
-    Assets/Shaders/HairSimulationSrgs.azsli
+    # Geometry and Full Screen azsl utility files
     Assets/Shaders/HairRenderingSrgs.azsli
-    Assets/Shaders/HairSimulationCommon.azsli
     Assets/Shaders/HairStrands.azsli
     Assets/Shaders/HairUtilities.azsli
+    Assets/Shaders/HairFullScreenUtils.azsli
     Assets/Shaders/HairLighting.azsli    
     Assets/Shaders/HairLightingEquations.azsli    
     Assets/Shaders/HairLightTypes.azsli
     Assets/Shaders/HairSurface.azsli
 
-    # Simulation Compute shaders
-    Assets/Shaders/HairSimulationCompute.azsl   
-    
-    # Collision shaders - to be included soon
-#    Assets/Shaders/HairCollisionPrepareSDF.azsl
-#    Assets/Shaders/HairCollisionWithSDF.azsl
+    # ShortCut technique shaders (using multiple RTs instead of PPLL for GPU memory reduction) 
+    Assets/Shaders/HairShortCutGeometryDepthAlpha.azsl
+    Assets/Shaders/HairShortCutResolveDepth.azsl
+    Assets/Shaders/HairShortCutGeometryShading.azsl
+    Assets/Shaders/HairShortCutResolveColor.azsl
 
-    # Rendering shaders
+    # Rendering azsl files
     Assets/Shaders/HairRenderingFillPPLL.azsl
     Assets/Shaders/HairRenderingResolvePPLL.azsl  
+
+    # Simulation Compute azsl files
+    Assets/Shaders/HairComputeSrgs.azsli
+    Assets/Shaders/HairSimulationComputeSrgs.azsli
+    Assets/Shaders/HairSimulationCommon.azsli
+    Assets/Shaders/HairSimulationCompute.azsl   
+    
+    # Collision azsl files - to be included soon
+#    Assets/Shaders/HairCollisionPrepareSDF.azsl
+#    Assets/Shaders/HairCollisionWithSDF.azsl
 
     # Simulation .shader files
     Assets/Shaders/HairGlobalShapeConstraintsCompute.shader  


### PR DESCRIPTION
Signed-off-by: Adi-Amazon <barlev@amazon.com>

This is the first version of the ShortCut shader files ala Atom. It is not a final version but a first compile version that would allow to create the .shader and .pass files to create their functionality.
The CR is presented here to reduce load of review of the entire technique in a single CR, and as such, future CRs will address some of the [To Do] and comments appearing here.