### PR TITLE
PhysX heightfield fixes

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/HeightfieldProviderBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/HeightfieldProviderBus.h
@@ -45,10 +45,20 @@ namespace Physics
         //! @param numColumns contains the size of the grid in the x direction.
         //! @param numRows contains the size of the grid in the y direction.
         virtual void GetHeightfieldGridSize(int32_t& numColumns, int32_t& numRows) const = 0;
-      
+
+        //! Returns the AABB of the heightfield.
+        //! This is provided separately from the shape AABB because the heightfield might choose to modify the AABB bounds.
+        //! @return AABB of the heightfield.
+        virtual AZ::Aabb GetHeightfieldAabb() const = 0;
+
+        //! Returns the Transform for the heightfield.
+        //! This is provided separately from the entity transform because the heightfield might want to clear out the rotation or scale.
+        //! @return transform that should be used with the heightfield data.
+        virtual AZ::Transform GetHeightfieldTransform() const = 0;
+
         //! Returns the list of materials used by the height field.
         //! @return returns a vector of all materials.
-        virtual AZStd::vector<MaterialId>GetMaterialList() const = 0;
+        virtual AZStd::vector<MaterialId> GetMaterialList() const = 0;
 
         //! Returns the list of heights used by the height field.
         //! @return the rows*columns vector of the heights.
@@ -78,11 +88,17 @@ namespace Physics
     public:
         static const AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
 
-        virtual void OnHeightfieldDataChanged([[maybe_unused]] const AZ::Aabb& dirtyRegion)
+        //! Called whenever the heightfield has a transform change.
+        //! This is a level of abstration beyond the Transform's notification, because the heightfield might have specialized logic
+        //! to modify the transform (for example to remove rotation) or to treat it as a full data change instead of a transform change.
+        //! @param the new transform
+        virtual void OnHeightfieldTransformChanged([[maybe_unused]] const AZ::Transform& transform)
         {
         }
 
-        virtual void RefreshHeightfield()
+        //! Called whenever the heightfield data changes.
+        //! @param the AABB of the area of data that changed.
+        virtual void OnHeightfieldDataChanged([[maybe_unused]] const AZ::Aabb& dirtyRegion)
         {
         }
 

--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AzCore/Component/TransformBus.h>
 #include <AzCore/Component/NonUniformScaleBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
@@ -17,7 +16,6 @@
 #include <AzFramework/Physics/Shape.h>
 #include <Editor/DebugDraw.h>
 #include <PhysX/ColliderShapeBus.h>
-#include <LmbrCentral/Shape/ShapeComponentBus.h>
 #include <AzFramework/Physics/HeightfieldProviderBus.h>
 
 namespace PhysX
@@ -27,9 +25,7 @@ namespace PhysX
         : public AzToolsFramework::Components::EditorComponentBase
         , protected AzToolsFramework::EntitySelectionEvents::Bus::Handler
         , protected AzPhysics::SimulatedBodyComponentRequestsBus::Handler
-        , private AZ::TransformNotificationBus::Handler
         , private PhysX::ColliderShapeRequestBus::Handler
-        , protected LmbrCentral::ShapeComponentNotificationsBus::Handler
         , protected DebugDraw::DisplayCallback
         , protected Physics::HeightfieldProviderNotificationBus::Handler
     {
@@ -61,12 +57,6 @@ namespace PhysX
         void OnSelected() override;
         void OnDeselected() override;
 
-        // TransformBus
-        void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
-
-        // handling for non-uniform scale
-        void OnNonUniformScaleChanged(const AZ::Vector3& scale);
-
         // AzPhysics::SimulatedBodyComponentRequestsBus::Handler overrides ...
         void EnablePhysics() override;
         void DisablePhysics() override;
@@ -76,9 +66,6 @@ namespace PhysX
         AzPhysics::SimulatedBodyHandle GetSimulatedBodyHandle() const override;
         AzPhysics::SceneQueryHit RayCast(const AzPhysics::RayCastRequest& request) override;
 
-        // LmbrCentral::ShapeComponentNotificationBus
-        void OnShapeChanged(LmbrCentral::ShapeComponentNotifications::ShapeChangeReasons changeReason) override;
-
         // DisplayCallback
         void Display(AzFramework::DebugDisplayRequests& debugDisplay) const;
 
@@ -87,8 +74,9 @@ namespace PhysX
         bool IsTrigger() override;
 
         // Physics::HeightfieldProviderNotificationBus
+        void OnHeightfieldTransformChanged(const AZ::Transform& transform) override;
         void OnHeightfieldDataChanged([[maybe_unused]] const AZ::Aabb& dirtyRegion) override;
-        void RefreshHeightfield() override;
+        void RefreshHeightfield();
 
         Physics::ColliderConfiguration m_colliderConfig; //!< Stores collision layers, whether the collider is a trigger, etc.
         DebugDraw::Collider m_colliderDebugDraw; //!< Handles drawing the collider based on global and local
@@ -100,9 +88,6 @@ namespace PhysX
 
         AzPhysics::SystemEvents::OnConfigurationChangedEvent::Handler m_physXConfigChangedHandler;
         AzPhysics::SystemEvents::OnMaterialLibraryChangedEvent::Handler m_onMaterialLibraryChangedEventHandler;
-        AZ::Transform m_cachedWorldTransform;
-        AZ::NonUniformScaleChangedEvent::Handler m_nonUniformScaleChangedHandler; //!< Responds to changes in non-uniform scale.
-        AZ::Vector3 m_currentNonUniformScale = AZ::Vector3::CreateOne(); //!< Caches the current non-uniform scale.
     };
 
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/HeightfieldColliderComponent.h
+++ b/Gems/PhysX/Code/Source/HeightfieldColliderComponent.h
@@ -39,6 +39,6 @@ namespace PhysX
 
     private:
         void OnHeightfieldDataChanged([[maybe_unused]] const AZ::Aabb& dirtyRegion) override;
-        void RefreshHeightfield() override;
+        void RefreshHeightfield();
     };
 } // namespace PhysX

--- a/Gems/Terrain/Code/Source/Components/TerrainLayerSpawnerComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainLayerSpawnerComponent.cpp
@@ -102,7 +102,6 @@ namespace Terrain
 
     void TerrainLayerSpawnerComponent::Activate()
     {
-        AZ::TransformNotificationBus::Handler::BusConnect(GetEntityId());
         LmbrCentral::ShapeComponentNotificationsBus::Handler::BusConnect(GetEntityId());
         TerrainSpawnerRequestBus::Handler::BusConnect(GetEntityId());
 
@@ -114,8 +113,6 @@ namespace Terrain
         TerrainSystemServiceRequestBus::Broadcast(&TerrainSystemServiceRequestBus::Events::UnregisterArea, GetEntityId());
         TerrainSpawnerRequestBus::Handler::BusDisconnect();
         LmbrCentral::ShapeComponentNotificationsBus::Handler::BusDisconnect();
-        AZ::TransformNotificationBus::Handler::BusDisconnect();
-        
     }
 
     bool TerrainLayerSpawnerComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
@@ -138,13 +135,12 @@ namespace Terrain
         return false;
     }
 
-    void TerrainLayerSpawnerComponent::OnTransformChanged([[maybe_unused]] const AZ::Transform& local, [[maybe_unused]] const AZ::Transform& world)
-    {
-        RefreshArea();
-    }
-
     void TerrainLayerSpawnerComponent::OnShapeChanged([[maybe_unused]] ShapeChangeReasons changeReason)
     {
+        // This will notify us of both shape changes and transform changes.
+        // It's important to use this event for transform changes instead of listening to OnTransformChanged, because we need to guarantee
+        // the shape has received the transform change message and updated its internal state before passing it along to us.
+
         RefreshArea();
     }
     

--- a/Gems/Terrain/Code/Source/Components/TerrainLayerSpawnerComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainLayerSpawnerComponent.h
@@ -18,7 +18,6 @@
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <TerrainSystem/TerrainSystemBus.h>
 
-#include <AzCore/Component/TransformBus.h>
 #include <LmbrCentral/Shape/ShapeComponentBus.h>
 #include <AzCore/Math/Aabb.h>
 
@@ -56,7 +55,6 @@ namespace Terrain
 
     class TerrainLayerSpawnerComponent
         : public AZ::Component
-        , private AZ::TransformNotificationBus::Handler
         , private LmbrCentral::ShapeComponentNotificationsBus::Handler
         , private Terrain::TerrainSpawnerRequestBus::Handler
     {
@@ -81,10 +79,6 @@ namespace Terrain
         bool WriteOutConfig(AZ::ComponentConfig* outBaseConfig) const override;
 
     protected:
-        //////////////////////////////////////////////////////////////////////////
-        // AZ::TransformNotificationBus::Handler
-        void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
-
         // ShapeComponentNotificationsBus
         void OnShapeChanged(ShapeChangeReasons changeReason) override;
 

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Component/Entity.h>
+#include <AzCore/Component/TransformBus.h>
 #include <AzCore/Casting/lossy_cast.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
@@ -80,18 +81,18 @@ namespace Terrain
     void TerrainPhysicsColliderComponent::Activate()
     {
         const auto entityId = GetEntityId();
-        AZ::TransformNotificationBus::Handler::BusConnect(entityId);
         LmbrCentral::ShapeComponentNotificationsBus::Handler::BusConnect(entityId);
         Physics::HeightfieldProviderRequestsBus::Handler::BusConnect(entityId);
+        AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusConnect();
 
         NotifyListenersOfHeightfieldDataChange();
     }
 
     void TerrainPhysicsColliderComponent::Deactivate()
     {
+        AzFramework::Terrain::TerrainDataNotificationBus::Handler::BusDisconnect();
         Physics::HeightfieldProviderRequestsBus::Handler ::BusDisconnect();
         LmbrCentral::ShapeComponentNotificationsBus::Handler::BusDisconnect();
-        AZ::TransformNotificationBus::Handler::BusDisconnect();
     }
 
     bool TerrainPhysicsColliderComponent::ReadInConfig(const AZ::ComponentConfig* baseConfig)
@@ -125,25 +126,38 @@ namespace Terrain
             &Physics::HeightfieldProviderNotificationBus::Events::OnHeightfieldDataChanged, worldSize);
     }
 
-    void TerrainPhysicsColliderComponent::OnTransformChanged(
-        [[maybe_unused]] const AZ::Transform& local, [[maybe_unused]] const AZ::Transform& world)
-    {
-        NotifyListenersOfHeightfieldDataChange();
-    }
-
     void TerrainPhysicsColliderComponent::OnShapeChanged([[maybe_unused]] ShapeChangeReasons changeReason)
     {
-        if (changeReason == ShapeChangeReasons::TransformChanged)
-        {
-            // This will be handled by the OnTransformChanged handler.
-            return;
-        }
+        // This will notify us of both shape changes and transform changes.
+        // It's important to use this event for transform changes instead of listening to OnTransformChanged, because we need to guarantee
+        // the shape has received the transform change message and updated its internal state before passing it along to us.
 
         NotifyListenersOfHeightfieldDataChange();
     }
 
-    void TerrainPhysicsColliderComponent::GetHeightfieldBounds(const AZ::Aabb& bounds, AZ::Vector3& minBounds, AZ::Vector3& maxBounds) const
+    void TerrainPhysicsColliderComponent::OnTerrainDataCreateEnd()
     {
+        NotifyListenersOfHeightfieldDataChange();
+    }
+
+    void TerrainPhysicsColliderComponent::OnTerrainDataDestroyBegin()
+    {
+        NotifyListenersOfHeightfieldDataChange();
+    }
+
+    void TerrainPhysicsColliderComponent::OnTerrainDataChanged(
+        [[maybe_unused]] const AZ::Aabb& dirtyRegion, [[maybe_unused]] TerrainDataChangedMask dataChangedMask)
+    {
+        NotifyListenersOfHeightfieldDataChange();
+    }
+
+    AZ::Aabb TerrainPhysicsColliderComponent::GetHeightfieldAabb() const
+    {
+        AZ::Aabb worldSize = AZ::Aabb::CreateNull();
+
+        LmbrCentral::ShapeComponentRequestsBus::EventResult(
+            worldSize, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
+
         auto vector2Floor = [](const AZ::Vector2& in)
         {
             return AZ::Vector2(floor(in.GetX()), floor(in.GetY()));
@@ -154,53 +168,54 @@ namespace Terrain
         };
 
         const AZ::Vector2 gridResolution = GetHeightfieldGridSpacing();
-        const AZ::Vector3 boundsMin = bounds.GetMin();
-        const AZ::Vector3 boundsMax = bounds.GetMax();
+        const AZ::Vector3 boundsMin = worldSize.GetMin();
+        const AZ::Vector3 boundsMax = worldSize.GetMax();
 
         const AZ::Vector2 gridMinBoundLower = vector2Floor(AZ::Vector2(boundsMin) / gridResolution) * gridResolution;
         const AZ::Vector2 gridMaxBoundUpper = vector2Ceil(AZ::Vector2(boundsMax) / gridResolution) * gridResolution;
 
-        minBounds = AZ::Vector3(gridMinBoundLower.GetX(), gridMinBoundLower.GetY(), boundsMin.GetZ());
-        maxBounds = AZ::Vector3(gridMaxBoundUpper.GetX(), gridMaxBoundUpper.GetY(), boundsMax.GetZ());
+        return AZ::Aabb::CreateFromMinMaxValues(
+            gridMinBoundLower.GetX(), gridMinBoundLower.GetY(), boundsMin.GetZ(),
+            gridMaxBoundUpper.GetX(), gridMaxBoundUpper.GetY(), boundsMax.GetZ()
+        );
     }
 
-    void TerrainPhysicsColliderComponent::GetHeightfieldGridSizeInBounds(const AZ::Aabb& bounds, int32_t& numColumns, int32_t& numRows) const
+    AZ::Transform TerrainPhysicsColliderComponent::GetHeightfieldTransform() const
+    {
+        AZ::Transform transform = AZ::Transform::CreateIdentity();
+        AZ::TransformBus::EventResult(transform, GetEntityId(), &AZ::TransformBus::Events::GetWorldTM);
+
+        // We currently don't support rotation of terrain heightfields.
+        transform.SetRotation(AZ::Quaternion::CreateIdentity());
+
+        // Scale is already handled via the underlying shape component that we use to set our heightfield bounds, so we'll reset it
+        // back to 1.0 here to prevent double-scaling the data.
+        transform.SetUniformScale(1.0f);
+
+        return transform;
+    }
+
+
+    void TerrainPhysicsColliderComponent::GenerateHeightsInBounds(AZStd::vector<float>& heights) const
     {
         const AZ::Vector2 gridResolution = GetHeightfieldGridSpacing();
 
-        AZ::Vector3 minBounds, maxBounds;
-        GetHeightfieldBounds(bounds, minBounds, maxBounds);
-
-        numColumns = aznumeric_cast<int32_t>((maxBounds.GetX() - minBounds.GetX()) / gridResolution.GetX());
-        numRows = aznumeric_cast<int32_t>((maxBounds.GetY() - minBounds.GetY()) / gridResolution.GetY());
-    }
-
-    void TerrainPhysicsColliderComponent::GenerateHeightsInBounds(const AZ::Aabb& bounds, AZStd::vector<float>& heights) const
-    {
-        const AZ::Vector2 gridResolution = GetHeightfieldGridSpacing();
-
-        AZ::Aabb worldSize = AZ::Aabb::CreateNull();
-
-        LmbrCentral::ShapeComponentRequestsBus::EventResult(
-            worldSize, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
+        AZ::Aabb worldSize = GetHeightfieldAabb();
 
         const float worldCenterZ = worldSize.GetCenter().GetZ();
 
-        AZ::Vector3 minBounds, maxBounds;
-        GetHeightfieldBounds(bounds, minBounds, maxBounds);
-
         int32_t gridWidth, gridHeight;
-        GetHeightfieldGridSizeInBounds(bounds, gridWidth, gridHeight);
+        GetHeightfieldGridSize(gridWidth, gridHeight);
 
         heights.clear();
         heights.reserve(gridWidth * gridHeight);
 
         for (int32_t row = 0; row < gridHeight; row++)
         {
-            const float y = row * gridResolution.GetY() + minBounds.GetY();
+            const float y = row * gridResolution.GetY() + worldSize.GetMin().GetY();
             for (int32_t col = 0; col < gridWidth; col++)
             {
-                const float x = col * gridResolution.GetX() + minBounds.GetX();
+                const float x = col * gridResolution.GetX() + worldSize.GetMin().GetX();
                 float height = 0.0f;
 
                 AzFramework::Terrain::TerrainDataRequestBus::BroadcastResult(
@@ -213,19 +228,13 @@ namespace Terrain
     }
 
     void TerrainPhysicsColliderComponent::GenerateHeightsAndMaterialsInBounds(
-        const AZ::Aabb& bounds, AZStd::vector<Physics::HeightMaterialPoint>& heightMaterials) const
+        AZStd::vector<Physics::HeightMaterialPoint>& heightMaterials) const
     {
         const AZ::Vector2 gridResolution = GetHeightfieldGridSpacing();
 
-        AZ::Aabb worldSize = AZ::Aabb::CreateNull();
-
-        LmbrCentral::ShapeComponentRequestsBus::EventResult(
-            worldSize, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
+        AZ::Aabb worldSize = GetHeightfieldAabb();
 
         const float worldCenterZ = worldSize.GetCenter().GetZ();
-
-        AZ::Vector3 minBounds, maxBounds;
-        GetHeightfieldBounds(bounds, minBounds, maxBounds);
 
         int32_t gridWidth, gridHeight;
         GetHeightfieldGridSize(gridWidth, gridHeight);
@@ -235,10 +244,10 @@ namespace Terrain
 
         for (int32_t row = 0; row < gridHeight; row++)
         {
-            const float y = row * gridResolution.GetY() + minBounds.GetY();
+            const float y = row * gridResolution.GetY() + worldSize.GetMin().GetY();
             for (int32_t col = 0; col < gridWidth; col++)
             {
-                const float x = col * gridResolution.GetX() + minBounds.GetX();
+                const float x = col * gridResolution.GetX() + worldSize.GetMin().GetX();
                 float height = 0.0f;
 
                 bool terrainExists = true;
@@ -247,7 +256,9 @@ namespace Terrain
                     AzFramework::Terrain::TerrainDataRequests::Sampler::DEFAULT, &terrainExists);
 
                 Physics::HeightMaterialPoint point;
-                point.m_height = height - worldCenterZ;
+                // TODO: Remove the clamp, the underlying code should handle heights outside the bounds.
+                point.m_height = AZ::GetClamp(height - worldCenterZ, -256.0f, 256.0f);
+                point.m_quadMeshType = terrainExists ? Physics::QuadMeshType::SubdivideUpperLeftToBottomRight : Physics::QuadMeshType::Hole;
                 heightMaterials.emplace_back(point);
             }
         }
@@ -265,13 +276,10 @@ namespace Terrain
     void TerrainPhysicsColliderComponent::GetHeightfieldGridSize(int32_t& numColumns, int32_t& numRows) const
     {
         const AZ::Vector2 gridResolution = GetHeightfieldGridSpacing();
+        const AZ::Aabb bounds = GetHeightfieldAabb();
 
-        AZ::Aabb worldSize = AZ::Aabb::CreateNull();
-
-        LmbrCentral::ShapeComponentRequestsBus::EventResult(
-            worldSize, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
-
-        GetHeightfieldGridSizeInBounds(worldSize, numColumns, numRows);
+        numColumns = aznumeric_cast<int32_t>((bounds.GetMax().GetX() - bounds.GetMin().GetX()) / gridResolution.GetX());
+        numRows = aznumeric_cast<int32_t>((bounds.GetMax().GetY() - bounds.GetMin().GetY()) / gridResolution.GetY());
     }
 
     AZStd::vector<Physics::MaterialId> TerrainPhysicsColliderComponent::GetMaterialList() const
@@ -281,43 +289,34 @@ namespace Terrain
 
     AZStd::vector<float> TerrainPhysicsColliderComponent::GetHeights() const
     {
-        AZ::Aabb worldSize = AZ::Aabb::CreateNull();
-
-        LmbrCentral::ShapeComponentRequestsBus::EventResult(
-            worldSize, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
-
         AZStd::vector<float> heights; 
-        GenerateHeightsInBounds(worldSize, heights);
+        GenerateHeightsInBounds(heights);
 
         return heights;
     }
 
     AZStd::vector<Physics::HeightMaterialPoint> TerrainPhysicsColliderComponent::GetHeightsAndMaterials() const
     {
-        AZ::Aabb worldSize = AZ::Aabb::CreateNull();
-
-        LmbrCentral::ShapeComponentRequestsBus::EventResult(
-            worldSize, GetEntityId(), &LmbrCentral::ShapeComponentRequestsBus::Events::GetEncompassingAabb);
-
         AZStd::vector<Physics::HeightMaterialPoint> heightMaterials;
-        GenerateHeightsAndMaterialsInBounds(worldSize, heightMaterials);
+        GenerateHeightsAndMaterialsInBounds(heightMaterials);
 
         return heightMaterials;
     }
 
-    AZStd::vector<float> TerrainPhysicsColliderComponent::UpdateHeights(const AZ::Aabb& dirtyRegion) const
+    AZStd::vector<float> TerrainPhysicsColliderComponent::UpdateHeights([[maybe_unused]] const AZ::Aabb& dirtyRegion) const
     {
         AZStd::vector<float> heights;
-        GenerateHeightsInBounds(dirtyRegion, heights);
+        GenerateHeightsInBounds(heights);
 
         return heights;
     }
 
-    AZStd::vector<Physics::HeightMaterialPoint> TerrainPhysicsColliderComponent::UpdateHeightsAndMaterials(const AZ::Aabb& dirtyRegion) const
+    AZStd::vector<Physics::HeightMaterialPoint> TerrainPhysicsColliderComponent::UpdateHeightsAndMaterials([[maybe_unused]] const AZ::Aabb& dirtyRegion) const
     {
         AZStd::vector<Physics::HeightMaterialPoint> heightMaterials;
-        GenerateHeightsAndMaterialsInBounds(dirtyRegion, heightMaterials);
+        GenerateHeightsAndMaterialsInBounds(heightMaterials);
 
         return heightMaterials;
     }
+
 }

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <AzCore/Component/Component.h>
-#include <AzCore/Component/TransformBus.h>
 
 #include <AzFramework/Physics/HeightfieldProviderBus.h>
 #include <AzFramework/Physics/Material.h>
@@ -39,9 +38,9 @@ namespace Terrain
 
     class TerrainPhysicsColliderComponent
         : public AZ::Component
-        , protected AZ::TransformNotificationBus::Handler
+        , public Physics::HeightfieldProviderRequestsBus::Handler
         , protected LmbrCentral::ShapeComponentNotificationsBus::Handler
-        , protected Physics::HeightfieldProviderRequestsBus::Handler
+        , protected AzFramework::Terrain::TerrainDataNotificationBus::Handler
     {
     public:
         template<typename, typename>
@@ -57,6 +56,17 @@ namespace Terrain
         TerrainPhysicsColliderComponent();
         ~TerrainPhysicsColliderComponent() = default;
 
+        // HeightfieldProviderRequestsBus
+        AZ::Vector2 GetHeightfieldGridSpacing() const override;
+        void GetHeightfieldGridSize(int32_t& numColumns, int32_t& numRows) const override;
+        AZ::Aabb GetHeightfieldAabb() const override;
+        AZ::Transform GetHeightfieldTransform() const override;
+        AZStd::vector<Physics::MaterialId> GetMaterialList() const override;
+        AZStd::vector<float> GetHeights() const override;
+        AZStd::vector<Physics::HeightMaterialPoint> GetHeightsAndMaterials() const override;
+        AZStd::vector<float> UpdateHeights(const AZ::Aabb& dirtyRegion) const override;
+        AZStd::vector<Physics::HeightMaterialPoint> UpdateHeightsAndMaterials(const AZ::Aabb& dirtyRegion) const override;
+
     protected:
         //////////////////////////////////////////////////////////////////////////
         // AZ::Component interface implementation
@@ -65,28 +75,18 @@ namespace Terrain
         bool ReadInConfig(const AZ::ComponentConfig* baseConfig) override;
         bool WriteOutConfig(AZ::ComponentConfig* outBaseConfig) const override;
 
-        void GetHeightfieldBounds(const AZ::Aabb& bounds, AZ::Vector3& minBounds, AZ::Vector3& maxBounds) const;
-        void GetHeightfieldGridSizeInBounds(const AZ::Aabb& bounds, int32_t& numColumns, int32_t& numRows) const;
-        void GenerateHeightsInBounds(const AZ::Aabb& bounds, AZStd::vector<float>& heights) const;
-        void GenerateHeightsAndMaterialsInBounds(const AZ::Aabb& bounds, AZStd::vector<Physics::HeightMaterialPoint>& heightMaterials) const;
+        void GenerateHeightsInBounds(AZStd::vector<float>& heights) const;
+        void GenerateHeightsAndMaterialsInBounds(AZStd::vector<Physics::HeightMaterialPoint>& heightMaterials) const;
 
         void NotifyListenersOfHeightfieldDataChange();
-
-        //////////////////////////////////////////////////////////////////////////
-        // AZ::TransformNotificationBus::Handler
-        void OnTransformChanged(const AZ::Transform& local, const AZ::Transform& world) override;
 
         // ShapeComponentNotificationsBus
         void OnShapeChanged(ShapeChangeReasons changeReason) override;
 
-        // HeightfieldProviderRequestsBus
-        AZ::Vector2 GetHeightfieldGridSpacing() const override;
-        void GetHeightfieldGridSize(int32_t& numColumns, int32_t& numRows) const override;
-        AZStd::vector<Physics::MaterialId> GetMaterialList() const override;
-        AZStd::vector<float> GetHeights() const override;
-        AZStd::vector<Physics::HeightMaterialPoint> GetHeightsAndMaterials() const override;
-        AZStd::vector<float> UpdateHeights(const AZ::Aabb& dirtyRegion) const override;
-        AZStd::vector<Physics::HeightMaterialPoint> UpdateHeightsAndMaterials(const AZ::Aabb& dirtyRegion) const override;
+        void OnTerrainDataCreateEnd() override;
+        void OnTerrainDataDestroyBegin() override;
+        void OnTerrainDataChanged(const AZ::Aabb& dirtyRegion, TerrainDataChangedMask dataChangedMask) override;
+
     private:
         TerrainPhysicsColliderConfig m_configuration;
     };


### PR DESCRIPTION
Several terrain physics bugfixes.
* Removed transform listener from a few places.  This message will get sent through OnShapeChanged as well, which is the safer place to receive it from.  If we listen for OnTransformChanged ourselves, we could receieve it before the shape does, which means that if we call any shape bus methods during the processing, they could return out-of-date shape data.  If we get it through OnShapeChanged, the shape cache will be refreshed.
* Added GetHeightfieldAabb / GetHeightfieldTransform ebus calls so that the heightfield provider has the ability to affect these values.  For the aabb, the provider might extend the bounds past the shape.  For transform, the provider might not support rotation or scale.
* Removed all transform/shape/scale notifications from the EditorHeightfieldColliderComponent.  The heightfield data provider already handles these, so we don't want to listen to them here as well.
* Fixed EditorHeightfieldColliderComponent to use the entity-specific ebus for heightfield providers, instead of broadcasting to all entities.
* Hooked up terrain data notifications to the TerrainPhysicsColliderComponent so that it refreshes correctly.