### PR TITLE
Crytimer replacement Part 2

### DIFF
--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
@@ -101,7 +101,7 @@ namespace AZ
 
     TimeMs TimeSystem::GetRealElapsedTimeMs() const
     {
-        return static_cast<TimeMs>(AZStd::GetTimeNowMicroSecond() / 1000);
+        return AZ::TimeUsToMs(GetRealElapsedTimeUs());
     }
 
     TimeUs TimeSystem::GetRealElapsedTimeUs() const
@@ -144,7 +144,7 @@ namespace AZ
 
         if (!AZ::IsClose(t_simulationTickScale, 1.0f))
         {
-            const float floatDelta = AZStd::GetMax(static_cast<float>(m_simulationTickDeltaTimeUs) * t_simulationTickScale, 1.0f);
+            const double floatDelta = AZStd::GetMax(static_cast<double>(m_simulationTickDeltaTimeUs) * static_cast<double>(t_simulationTickScale), 1.0);
             m_simulationTickDeltaTimeUs = static_cast<TimeUs>(static_cast<int64_t>(floatDelta));
         }
         m_lastSimulationTickTimeUs = currentTimeUs;
@@ -160,7 +160,7 @@ namespace AZ
         // sleeping if there's still time remaining.
         if (t_simulationTickRate > 0)
         {
-            const TimeUs currentTimeUs = static_cast<TimeUs>(AZStd::GetTimeNowMicroSecond());
+            const TimeUs currentTimeUs = AZ::GetRealElapsedTimeUs();
             const TimeUs timeUntilNextTick = (m_lastSimulationTickTimeUs + m_simulationTickLimitTimeUs) - currentTimeUs;
             if (timeUntilNextTick > ZeroTimeUs)
             {

--- a/Code/Legacy/CrySystem/Timer.cpp
+++ b/Code/Legacy/CrySystem/Timer.cpp
@@ -76,22 +76,6 @@ bool CTimer::Init()
 {
     // if game code was accessing them by name there was something wrong anyway
 
-    REGISTER_CVAR2("t_Smoothing", &m_TimeSmoothing, DEFAULT_FRAME_SMOOTHING, 0,
-        "time smoothing\n"
-        "0=off, 1=on");
-
-    REGISTER_CVAR2("t_FixedStep", &m_fixed_time_step, 0, VF_NET_SYNCED | VF_DEV_ONLY,
-        "Game updated with this fixed frame time\n"
-        "0=off, number specifies the frame time in seconds\n"
-        "e.g. 0.033333(30 fps), 0.1(10 fps), 0.01(100 fps)");
-
-    REGISTER_CVAR2("t_MaxStep", &m_max_time_step, 0.25f, 0,
-        "Game systems clamped to this frame time");
-
-    // todo: reconsider exposing that as cvar (negative time, same value is used by Trackview, better would be another value multipled with the internal one)
-    REGISTER_CVAR2("t_Scale", &m_cvar_time_scale, 1.0f, VF_NET_SYNCED | VF_DEV_ONLY,
-        "Game time scaled by this - for variable slow motion");
-
     REGISTER_CVAR2("t_Debug", &m_TimeDebug, 0, 0, "Timer debug: 0 = off, 1 = events, 2 = verbose");
 
     // -----------------

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-
 #include <AzCore/Component/Entity.h>
 #include <AzCore/std/allocator_stateless.h>
 #include <AzCore/std/containers/map.h>
@@ -208,6 +207,22 @@ namespace
     }
 }
 
+namespace Internal
+{
+    float ApplyDeltaTimeOverrideIfEnabled(float deltaTime)
+    {
+        if (auto* timeSystem = AZ::Interface<AZ::ITime>::Get())
+        {
+            const AZ::TimeMs deltatimeOverride = timeSystem->GetSimulationTickDeltaOverride();
+            if (deltatimeOverride != AZ::TimeMs{ 0 })
+            {
+                deltaTime = AZ::TimeMsToSeconds(deltatimeOverride);
+            }
+        }
+        return deltaTime;
+    }
+} // namespace Internal
+
 //////////////////////////////////////////////////////////////////////////
 CMovieSystem::CMovieSystem(ISystem* pSystem)
 {
@@ -219,18 +234,13 @@ CMovieSystem::CMovieSystem(ISystem* pSystem)
     m_bEnableCameraShake = true;
     m_bCutscenesPausedInEditor = true;
     m_sequenceStopBehavior = eSSB_GotoEndTime;
-    m_lastUpdateTime.SetValue(0);
+    m_lastUpdateTime = AZ::TimeMs{ 0 };
     m_bStartCapture = false;
     m_captureFrame = -1;
     m_bEndCapture = false;
-    m_fixedTimeStepBackUp = 0;
-    m_maxStepBackUp = 0;
-    m_smoothingBackUp = 0;
+    m_fixedTimeStepBackUp = AZ::TimeMs{ 0 };
     m_cvar_capture_frame_once = nullptr;
     m_cvar_capture_folder = nullptr;
-    m_cvar_t_FixedStep = nullptr;
-    m_cvar_t_MaxStep = nullptr;
-    m_cvar_t_Smoothing = nullptr;
     m_cvar_sys_maxTimeStepForMovieSystem = nullptr;
     m_cvar_capture_frames = nullptr;
     m_cvar_capture_file_prefix = nullptr;
@@ -1041,13 +1051,13 @@ void CMovieSystem::PreUpdate(float deltaTime)
     }
     m_newlyActivatedSequences.clear();
 
-    UpdateInternal(m_cvar_t_FixedStep ? m_cvar_t_FixedStep->GetFVal() : deltaTime, true);
+    UpdateInternal(Internal::ApplyDeltaTimeOverrideIfEnabled(deltaTime), true);
 }
 
 //////////////////////////////////////////////////////////////////////////
 void CMovieSystem::PostUpdate(float deltaTime)
 {
-    UpdateInternal(m_cvar_t_FixedStep ? m_cvar_t_FixedStep->GetFVal() : deltaTime, false);
+    UpdateInternal(Internal::ApplyDeltaTimeOverrideIfEnabled(deltaTime), false);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -1061,7 +1071,7 @@ void CMovieSystem::UpdateInternal(const float deltaTime, const bool bPreUpdate)
     }
 
     // don't update more than once if dt==0.0
-    CTimeValue curTime = gEnv->pTimer->GetFrameStartTime();
+    const AZ::TimeMs curTime = AZ::GetLastSimulationTickTime();
     if (deltaTime == 0.0f && curTime == m_lastUpdateTime && !gEnv->IsEditor())
     {
         return;
@@ -1513,34 +1523,11 @@ void CMovieSystem::GoToFrame(const char* seqName, float targetFrame)
 
 void CMovieSystem::EnableFixedStepForCapture(float step)
 {
-    if (nullptr == m_cvar_t_FixedStep)
+    if (auto* timeSystem = AZ::Interface<AZ::ITime>::Get())
     {
-        m_cvar_t_FixedStep = gEnv->pConsole->GetCVar("t_FixedStep");
+        m_fixedTimeStepBackUp = timeSystem->GetSimulationTickDeltaOverride();
+        timeSystem->SetSimulationTickDeltaOverride(AZ::SecondsToTimeMs(step));
     }
-
-    m_fixedTimeStepBackUp = m_cvar_t_FixedStep->GetFVal();
-    m_cvar_t_FixedStep->Set(step);
-
-    if (nullptr == m_cvar_t_MaxStep)
-    {
-        m_cvar_t_MaxStep = gEnv->pConsole->GetCVar("t_MaxStep");
-    }
-
-    // Make sure to make the max step large enough
-    m_maxStepBackUp = m_cvar_t_MaxStep->GetFVal();
-    if (step > m_maxStepBackUp)
-    {
-        m_cvar_t_MaxStep->Set(step);
-    }
-
-    if (nullptr == m_cvar_t_Smoothing)
-    {
-        m_cvar_t_Smoothing = gEnv->pConsole->GetCVar("t_Smoothing");
-    }
-
-    // Turn off framerate smoothing
-    m_smoothingBackUp = m_cvar_t_Smoothing->GetFVal();
-    m_cvar_t_Smoothing->Set(0);
 
     if (nullptr == m_cvar_sys_maxTimeStepForMovieSystem)
     {
@@ -1557,9 +1544,10 @@ void CMovieSystem::EnableFixedStepForCapture(float step)
 
 void CMovieSystem::DisableFixedStepForCapture()
 {
-    m_cvar_t_FixedStep->Set(m_fixedTimeStepBackUp);
-    m_cvar_t_MaxStep->Set(m_maxStepBackUp);
-    m_cvar_t_Smoothing->Set(m_smoothingBackUp);
+    if (auto* timeSystem = AZ::Interface<AZ::ITime>::Get())
+    {
+        timeSystem->SetSimulationTickDeltaOverride(m_fixedTimeStepBackUp);
+    }
     m_cvar_sys_maxTimeStepForMovieSystem->Set(m_maxTimeStepForMovieSystemBackUp);
 }
 

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.h
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.h
@@ -268,15 +268,10 @@ private:
     int m_captureFrame;
     bool m_bEndCapture;
     ICaptureKey m_captureKey;
-    float m_fixedTimeStepBackUp;
-    float m_maxStepBackUp;
-    float m_smoothingBackUp;
+    AZ::TimeMs m_fixedTimeStepBackUp;
     float m_maxTimeStepForMovieSystemBackUp;
     ICVar* m_cvar_capture_frame_once;
     ICVar* m_cvar_capture_folder;
-    ICVar* m_cvar_t_FixedStep;
-    ICVar* m_cvar_t_MaxStep;
-    ICVar* m_cvar_t_Smoothing;
     ICVar* m_cvar_sys_maxTimeStepForMovieSystem;
     ICVar* m_cvar_capture_frames;
     ICVar* m_cvar_capture_file_prefix;

--- a/Gems/Maestro/Code/Source/Cinematics/SceneNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/SceneNode.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <AzCore/std/containers/map.h>
+#include <AzCore/Time/ITime.h>
 
 #include "AnimNode.h"
 #include "SoundTrack.h"
@@ -149,7 +150,8 @@ private:
 
     std::vector<SSoundInfo> m_SoundInfo;
 
-    ICVar* m_cvar_t_FixedStep;
+    AZ::TimeMs m_simulationTickOverrideBackup = AZ::TimeMs{ 0 };
+    float m_timeScaleBackup = 1.0f;
 };
 
 #endif // CRYINCLUDE_CRYMOVIE_SCENENODE_H


### PR DESCRIPTION
Next PR contains the following:

- removal of the cry timer cvars (these were replaced in the [first PR](https://github.com/aws-lumberyard-dev/o3de/pull/274))
- small improvements to the time system from the [previous pr](https://github.com/aws-lumberyard-dev/o3de/pull/274)

This PR is into a staging branch, not development