### PR TITLE
Crytimer replacement part 4

### DIFF
--- a/Code/Framework/AzCore/AzCore/Time/ITime.h
+++ b/Code/Framework/AzCore/AzCore/Time/ITime.h
@@ -104,6 +104,9 @@ namespace AZ
         virtual int32_t GetSimulationTickRate() const = 0;
 
         AZ_DISABLE_COPY_MOVE(ITime);
+
+        static const AZ::TimeMs ZeroTimeMs = AZ::TimeMs{ 0 };
+        static const AZ::TimeUs ZeroTimeUs = AZ::TimeUs{ 0 };
     };
 
     // EBus wrapper for ScriptCanvas

--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.cpp
@@ -49,11 +49,6 @@ namespace AZ
 
     AZ_CVAR(int, t_simulationTickRate, 0, cvar_t_simulationTickRate_Changed, AZ::ConsoleFunctorFlags::Null,
         "The minimum rate to force the game simulation tick to run. 0 for as fast as possible. 30 = ~33ms, 60 = ~16ms");
-    
-    namespace Constants
-    {
-        static const AZ::TimeUs ZeroTimeUs = AZ::TimeUs{ 0 };
-    }
 
     void TimeSystem::Reflect(AZ::ReflectContext* context)
     {
@@ -133,7 +128,7 @@ namespace AZ
         m_lastRealTickTimeUs = currentTimeUs;
 
         //game time
-        if (m_simulationTickDeltaOverride > Constants::ZeroTimeUs)
+        if (m_simulationTickDeltaOverride > AZ::ITime::ZeroTimeUs)
         {
             m_simulationTickDeltaTimeUs = m_simulationTickDeltaOverride;
             m_lastSimulationTickTimeUs = m_simulationTickDeltaTimeUs;
@@ -162,7 +157,7 @@ namespace AZ
         {
             const TimeUs currentTimeUs = AZ::GetRealElapsedTimeUs();
             const TimeUs timeUntilNextTick = (m_lastSimulationTickTimeUs + m_simulationTickLimitTimeUs) - currentTimeUs;
-            if (timeUntilNextTick > ZeroTimeUs)
+            if (timeUntilNextTick > AZ::ITime::ZeroTimeUs)
             {
                 AZ_TracePrintf("tick", "Sleeping for %.2f", AZ::TimeUsToSecondsDouble(timeUntilNextTick));
                 AZStd::this_thread::sleep_for(AZStd::chrono::microseconds(static_cast<int64_t>(timeUntilNextTick)));
@@ -208,7 +203,7 @@ namespace AZ
         }
         else
         {
-            m_simulationTickLimitTimeUs = Constants::ZeroTimeUs;
+            m_simulationTickLimitTimeUs = AZ::ITime::ZeroTimeUs;
         }
     }
 

--- a/Code/Framework/AzCore/AzCore/Time/TimeSystem.h
+++ b/Code/Framework/AzCore/AzCore/Time/TimeSystem.h
@@ -58,27 +58,27 @@ namespace AZ
     private:
         //! Used to calculate the delta time between calls to GetElapsedTimeMs/TimeUs().
         //! Mutable to allow GetElapsedTimeMs/TimeUs() to be a const functions.
-        mutable TimeUs m_lastInvokedTimeUs = AZ::TimeUs{ 0 };
+        mutable TimeUs m_lastInvokedTimeUs = AZ::ITime::ZeroTimeUs;
 
         //! Accumulates the delta time of GetElapsedTimeMs/TimeUs() calls.
         //! Mutable to allow GetElapsedTimeMs/TimeUs() to be a const functions.
-        mutable TimeUs m_accumulatedTimeUs = AZ::TimeUs{ 0 };
+        mutable TimeUs m_accumulatedTimeUs = AZ::ITime::ZeroTimeUs;
 
         //! The current game tick delta time.
         //! Can be affected by time system cvars.
         //! Updated in AdvanceTickDeltaTimes().
-        TimeUs m_simulationTickDeltaTimeUs = AZ::TimeUs{ 0 };
+        TimeUs m_simulationTickDeltaTimeUs = AZ::ITime::ZeroTimeUs;
 
         //! The current real tick delta time.
         //! Will not be affected by time system cvars.
         //! Updated in AdvanceTickDeltaTimes().
-        TimeUs m_realTickDeltaTimeUs = AZ::TimeUs{ 0 };
+        TimeUs m_realTickDeltaTimeUs = AZ::ITime::ZeroTimeUs;
 
-        TimeUs m_lastSimulationTickTimeUs = AZ::TimeUs{ 0 }; //!< Used to determine the game tick delta time (affected by cvars).
-        TimeUs m_lastRealTickTimeUs = AZ::TimeUs{ 0 }; //!< Used to determine the real game tick delta time (not affected by cvars).
+        TimeUs m_lastSimulationTickTimeUs = AZ::ITime::ZeroTimeUs; //!< Used to determine the game tick delta time (affected by cvars).
+        TimeUs m_lastRealTickTimeUs = AZ::ITime::ZeroTimeUs; //!< Used to determine the real game tick delta time (not affected by cvars).
 
-        TimeUs m_simulationTickDeltaOverride = AZ::TimeUs{ 0 }; //<! Stores the TimeUs value of the t_simulationTickDeltaOverride cvar.
-        TimeUs m_simulationTickLimitTimeUs = AZ::TimeUs{ 0 }; //<! Stores the TimeUs value of the t_simulationTickRate cvar.
+        TimeUs m_simulationTickDeltaOverride = AZ::ITime::ZeroTimeUs; //<! Stores the TimeUs value of the t_simulationTickDeltaOverride cvar.
+        TimeUs m_simulationTickLimitTimeUs = AZ::ITime::ZeroTimeUs; //<! Stores the TimeUs value of the t_simulationTickRate cvar.
         int32_t m_simulationTickLimitRate = 0; //<! Stores the simulation rate limit in frames per second.
     };
 }

--- a/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockITime.h
+++ b/Code/Framework/AzCore/AzCore/UnitTest/Mocks/MockITime.h
@@ -55,37 +55,37 @@ namespace AZ
 
         virtual AZ::TimeMs GetElapsedTimeMs() const override
         {
-            return AZ::TimeMs{ 0 };
+            return AZ::ITime::ZeroTimeMs;
         }
 
         virtual AZ::TimeUs GetElapsedTimeUs() const override
         {
-            return AZ::TimeUs{ 0 };
+            return AZ::ITime::ZeroTimeUs;
         }
 
         virtual AZ::TimeMs GetRealElapsedTimeMs() const override
         {
-            return AZ::TimeMs{ 0 };
+            return AZ::ITime::ZeroTimeMs;
         }
 
         virtual AZ::TimeUs GetRealElapsedTimeUs() const override
         {
-            return AZ::TimeUs{ 0 };
+            return AZ::ITime::ZeroTimeUs;
         }
 
         virtual AZ::TimeMs GetSimulationTickDeltaTimeMs() const override
         {
-            return AZ::TimeMs{ 0 };
+            return AZ::ITime::ZeroTimeMs;
         }
 
         virtual AZ::TimeMs GetRealTickDeltaTimeMs() const override
         {
-            return AZ::TimeMs{ 0 };
+            return AZ::ITime::ZeroTimeMs;
         }
 
         virtual AZ::TimeMs GetLastSimulationTickTime() const override
         {
-            return AZ::TimeMs{ 0 };
+            return AZ::ITime::ZeroTimeMs;
         }
 
         virtual void SetSimulationTickDeltaOverride([[maybe_unused]]TimeMs timeMs) override
@@ -94,7 +94,7 @@ namespace AZ
 
         virtual TimeMs GetSimulationTickDeltaOverride() const override
         {
-            return AZ::TimeMs{ 0 }; 
+            return AZ::ITime::ZeroTimeMs; 
         }
 
         virtual void SetSimulationTickScale([[maybe_unused]] float scale) override

--- a/Code/Framework/AzNetworking/AzNetworking/ConnectionLayer/ConnectionMetrics.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/ConnectionLayer/ConnectionMetrics.cpp
@@ -42,7 +42,7 @@ namespace AzNetworking
     {
         const uint32_t sampleAtom = 1 - m_activeAtom;
 
-        if (m_atoms[sampleAtom].m_timeAccumulatorMs == AZ::TimeMs{0})
+        if (m_atoms[sampleAtom].m_timeAccumulatorMs == AZ::ITime::ZeroTimeMs)
         {
             return 0.0f;
         }

--- a/Code/Framework/AzNetworking/AzNetworking/ConnectionLayer/ConnectionMetrics.h
+++ b/Code/Framework/AzNetworking/AzNetworking/ConnectionLayer/ConnectionMetrics.h
@@ -19,7 +19,7 @@ namespace AzNetworking
     {
         DatarateAtom() = default;
 
-        AZ::TimeMs m_timeAccumulatorMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_timeAccumulatorMs = AZ::ITime::ZeroTimeMs;
         uint32_t m_bytesTransmitted = 0;
         uint32_t m_packetsSent = 0;
         uint32_t m_packetsLost = 0;
@@ -78,7 +78,7 @@ namespace AzNetworking
         ConnectionPacketEntry(PacketId packetId, AZ::TimeMs sendTimeMs);
 
         PacketId m_packetId = InvalidPacketId;
-        AZ::TimeMs m_sendTimeMs = AZ::TimeMs{0};
+        AZ::TimeMs m_sendTimeMs = AZ::ITime::ZeroTimeMs;
     };
 
     //! @class ConnectionComputeRtt

--- a/Code/Framework/AzNetworking/AzNetworking/ConnectionLayer/IConnection.h
+++ b/Code/Framework/AzNetworking/AzNetworking/ConnectionLayer/IConnection.h
@@ -28,8 +28,8 @@ namespace AzNetworking
         ConnectionQuality(int32_t lossPercentage, AZ::TimeMs latencyMs, AZ::TimeMs varianceMs);
 
         int32_t m_lossPercentage = 0;
-        AZ::TimeMs m_latencyMs = AZ::TimeMs{ 0 };
-        AZ::TimeMs m_varianceMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_latencyMs = AZ::ITime::ZeroTimeMs;
+        AZ::TimeMs m_varianceMs = AZ::ITime::ZeroTimeMs;
     };
 
     enum class TrustZone

--- a/Code/Framework/AzNetworking/AzNetworking/DataStructures/TimeoutQueue.h
+++ b/Code/Framework/AzNetworking/AzNetworking/DataStructures/TimeoutQueue.h
@@ -39,8 +39,8 @@ namespace AzNetworking
             void UpdateTimeoutTime(AZ::TimeMs currentTimeMs);
 
             uint64_t m_userData = 0;
-            AZ::TimeMs m_timeoutMs = AZ::TimeMs{0};
-            AZ::TimeMs m_nextTimeoutTimeMs = AZ::TimeMs{0};
+            AZ::TimeMs m_timeoutMs = AZ::ITime::ZeroTimeMs;
+            AZ::TimeMs m_nextTimeoutTimeMs = AZ::ITime::ZeroTimeMs;
         };
 
         TimeoutQueue() = default;

--- a/Code/Framework/AzNetworking/AzNetworking/Framework/NetworkInterfaceMetrics.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Framework/NetworkInterfaceMetrics.h
@@ -15,11 +15,11 @@ namespace AzNetworking
     struct NetworkInterfaceMetrics
     {
         //! Returns the total number of milliseconds spent updating this network interface.
-        AZ::TimeMs m_updateTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_updateTimeMs = AZ::ITime::ZeroTimeMs;
         //! Returns the total number of connections bound to this network interface.
         uint64_t m_connectionCount = 0;
         //! Returns the total number of milliseconds spent sending data on this network interface.
-        AZ::TimeMs m_sendTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_sendTimeMs = AZ::ITime::ZeroTimeMs;
         //! Returns the total number of packets sent on this socket.
         uint64_t m_sendPackets = 0;
         //! Returns the total number of encrypted packets sent on this socket.
@@ -37,7 +37,7 @@ namespace AzNetworking
         //! Returns the total number of packets that had to be resent on this network interface due to packet loss.
         uint64_t m_resentPackets = 0;
         //! Returns the total number of milliseconds spent processing received data on this network interface.
-        AZ::TimeMs m_recvTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_recvTimeMs = AZ::ITime::ZeroTimeMs;
         //! Returns the total number of packets received on this socket.
         uint64_t m_recvPackets = 0;
         //! Returns the total number of bytes received on this socket after compression.

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpListenThread.h
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpListenThread.h
@@ -67,6 +67,6 @@ namespace AzNetworking
         uint32_t m_listenPortCount = 0;
         TcpSocketManager m_tcpSocketManager;
         AZ::ThreadSafeDeque<ListenPort> m_listenPorts;
-        AZ::TimeMs m_updateTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_updateTimeMs = AZ::ITime::ZeroTimeMs;
     };
 }

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.cpp
@@ -120,7 +120,7 @@ namespace AzNetworking
 
         auto readCallback = [this, startTimeMs](SocketFd socketFd) { HandleConnectionRecv(socketFd, startTimeMs); };
         auto writeCallback = [this](SocketFd socketFd) { HandleConnectionSend(socketFd); };
-        m_tcpSocketManager.ProcessEvents(AZ::TimeMs{ 0 }, readCallback, writeCallback);
+        m_tcpSocketManager.ProcessEvents(AZ::ITime::ZeroTimeMs, readCallback, writeCallback);
 
         FlushQueuedRemoves();
 
@@ -317,7 +317,7 @@ namespace AzNetworking
         {
             tcpConnection->SendReliablePacket(CorePackets::HeartbeatPacket());
         }
-        else if (net_TcpTimeoutConnections && (m_networkInterface.GetTimeoutMs() > AZ::TimeMs{ 0 }))
+        else if (net_TcpTimeoutConnections && (m_networkInterface.GetTimeoutMs() > AZ::ITime::ZeroTimeMs))
         {
             tcpConnection->Disconnect(DisconnectReason::Timeout, TerminationEndpoint::Local);
             return TimeoutResult::Delete;

--- a/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/TcpTransport/TcpNetworkInterface.h
@@ -156,7 +156,7 @@ namespace AzNetworking
         AZ::Name m_name;
         TrustZone m_trustZone;
         uint16_t m_port = 0;
-        AZ::TimeMs m_timeoutMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_timeoutMs = AZ::ITime::ZeroTimeMs;
         IConnectionListener& m_connectionListener;
         TcpConnectionSet m_connectionSet;
         TcpSocketManager m_tcpSocketManager;

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.cpp
@@ -746,7 +746,7 @@ namespace AzNetworking
         {
             udpConnection->SendUnreliablePacket(CorePackets::HeartbeatPacket());
         }
-        else if (net_UdpTimeoutConnections && (m_networkInterface.GetTimeoutMs() > AZ::TimeMs{ 0 }))
+        else if (net_UdpTimeoutConnections && (m_networkInterface.GetTimeoutMs() > AZ::ITime::ZeroTimeMs))
         {
             udpConnection->Disconnect(DisconnectReason::Timeout, TerminationEndpoint::Local);
             return TimeoutResult::Delete;

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpNetworkInterface.h
@@ -181,7 +181,7 @@ namespace AzNetworking
         TrustZone m_trustZone;
         uint16_t m_port = 0;
         bool m_allowIncomingConnections = false;
-        AZ::TimeMs m_timeoutMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_timeoutMs = AZ::ITime::ZeroTimeMs;
         IConnectionListener& m_connectionListener;
         UdpConnectionSet m_connectionSet;
         TimeoutQueue m_connectionTimeoutQueue;

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpReaderThread.h
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpReaderThread.h
@@ -94,6 +94,6 @@ namespace AzNetworking
         int32_t m_backIndex = 0;
         AZStd::array<ReaderBuffer, 2> m_readerBuffers;
         AZStd::vector<UdpSocket*> m_pendingAdds;
-        AZ::TimeMs m_updateTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_updateTimeMs = AZ::ITime::ZeroTimeMs;
     };
 }

--- a/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpSocket.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/UdpTransport/UdpSocket.cpp
@@ -135,7 +135,7 @@ namespace AzNetworking
         int32_t sentBytes = size;
 
 #ifdef ENABLE_LATENCY_DEBUG
-        if (connectionQuality.m_latencyMs <= AZ::TimeMs{ 0 })
+        if (connectionQuality.m_latencyMs <= AZ::ITime::ZeroTimeMs)
 #endif
         {
             sentBytes = SendInternal(address, data, size, encrypt, dtlsEndpoint);
@@ -153,9 +153,9 @@ namespace AzNetworking
             }
         }
 #ifdef ENABLE_LATENCY_DEBUG
-        else if ((connectionQuality.m_latencyMs > AZ::TimeMs{ 0 }) || (connectionQuality.m_varianceMs > AZ::TimeMs{ 0 }))
+        else if ((connectionQuality.m_latencyMs > AZ::ITime::ZeroTimeMs) || (connectionQuality.m_varianceMs > AZ::ITime::ZeroTimeMs))
         {
-            const AZ::TimeMs jitterMs = aznumeric_cast<AZ::TimeMs>(m_random.GetRandom()) % (connectionQuality.m_varianceMs > AZ::TimeMs{ 0 }
+            const AZ::TimeMs jitterMs = aznumeric_cast<AZ::TimeMs>(m_random.GetRandom()) % (connectionQuality.m_varianceMs > AZ::ITime::ZeroTimeMs
                                       ? connectionQuality.m_varianceMs
                                       : AZ::TimeMs{ 1 });
             const AZ::TimeMs deferTimeMs = (connectionQuality.m_latencyMs) + jitterMs;

--- a/Code/Framework/AzNetworking/AzNetworking/Utilities/EncryptionCommon.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Utilities/EncryptionCommon.cpp
@@ -94,7 +94,7 @@ namespace AzNetworking
     static const uint32_t MaxCookieHistory = 8;
     static bool g_encryptionInitialized = false;
     static int32_t g_azNetworkingTrustDataIndex = 0;
-    static AZ::TimeMs g_lastCookieTimestamp = AZ::TimeMs{0};
+    static AZ::TimeMs g_lastCookieTimestamp = AZ::ITime::ZeroTimeMs;
     static uint64_t g_validCookieArray[MaxCookieHistory];
     static uint32_t g_cookieReplaceIndex = 0;
 

--- a/Code/Framework/AzNetworking/Tests/Serialization/DeltaSerializerTests.cpp
+++ b/Code/Framework/AzNetworking/Tests/Serialization/DeltaSerializerTests.cpp
@@ -15,7 +15,7 @@ namespace UnitTest
     {
         AzNetworking::PacketId m_packetId = AzNetworking::InvalidPacketId;
         uint32_t m_id = 0;
-        AZ::TimeMs m_timeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_timeMs = AZ::ITime::ZeroTimeMs;
         float m_blendFactor = 0.f;
         AZStd::vector<int> m_growVector, m_shrinkVector;
 

--- a/Code/Legacy/CrySystem/Log.cpp
+++ b/Code/Legacy/CrySystem/Log.cpp
@@ -935,9 +935,9 @@ void CLog::LogStringToFile(const char* szString, ELogType logType, bool bAdd, [[
         }
         else if (dwCVarState == 2)     // Log_IncludeTime
         {
-            static AZ::TimeMs lasttime = AZ::TimeMs{ 0 };
+            static AZ::TimeMs lasttime = AZ::ITime::ZeroTimeMs;
             const AZ::TimeMs currenttime = AZ::GetRealElapsedTimeMs();
-            if (lasttime != AZ::TimeMs{ 0 })
+            if (lasttime != AZ::ITime::ZeroTimeMs)
             {
                 timeStr.clear();
                 uint32 dwMs = aznumeric_cast<uint32>(currenttime - lasttime);
@@ -962,9 +962,9 @@ void CLog::LogStringToFile(const char* szString, ELogType logType, bool bAdd, [[
 #endif
             tempString = LogStringType(sTime) + tempString;
 
-            static AZ::TimeMs lasttime = AZ::TimeMs{ 0 };
+            static AZ::TimeMs lasttime = AZ::ITime::ZeroTimeMs;
             const AZ::TimeMs currenttime = AZ::GetRealElapsedTimeMs();
-            if (lasttime != AZ::TimeMs{ 0 })
+            if (lasttime != AZ::ITime::ZeroTimeMs)
             {
                 timeStr.clear();
                 uint32 dwMs = (uint32)(currenttime - lasttime);
@@ -977,9 +977,9 @@ void CLog::LogStringToFile(const char* szString, ELogType logType, bool bAdd, [[
         {
             static bool bFirst = true;
 
-            static AZ::TimeMs lasttime = AZ::TimeMs{ 0 };
+            static AZ::TimeMs lasttime = AZ::ITime::ZeroTimeMs;
             const AZ::TimeMs currenttime = AZ::GetRealElapsedTimeMs();
-            if (lasttime != AZ::TimeMs{ 0 })
+            if (lasttime != AZ::ITime::ZeroTimeMs)
             {
                 timeStr.clear();
                 uint32 dwMs = (uint32)(currenttime - lasttime);

--- a/Code/Legacy/CrySystem/System.cpp
+++ b/Code/Legacy/CrySystem/System.cpp
@@ -1394,7 +1394,7 @@ const char* CSystem::GetSystemGlobalStateName(const ESystemGlobalState systemGlo
 
 void CSystem::SetSystemGlobalState(const ESystemGlobalState systemGlobalState)
 {
-    static AZ::TimeMs s_startTime = AZ::TimeMs{ 0 };
+    static AZ::TimeMs s_startTime = AZ::ITime::ZeroTimeMs;
     if (systemGlobalState != m_systemGlobalState)
     {
         const AZ::TimeMs endTime = AZ::GetRealElapsedTimeMs();

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerClickOrTap.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerClickOrTap.inl
@@ -56,7 +56,7 @@ inline void Gestures::RecognizerClickOrTap::Config::Reflect(AZ::ReflectContext* 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline Gestures::RecognizerClickOrTap::RecognizerClickOrTap(const Config& config)
     : m_config(config)
-    , m_timeOfLastEvent(AZ::TimeMs{ 0 })
+    , m_timeOfLastEvent(AZ::ITime::ZeroTimeMs)
     , m_positionOfFirstEvent()
     , m_positionOfLastEvent()
     , m_currentCount(0)

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDrag.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerDrag.inl
@@ -44,7 +44,7 @@ inline void Gestures::RecognizerDrag::Config::Reflect(AZ::ReflectContext* contex
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline Gestures::RecognizerDrag::RecognizerDrag(const Config& config)
     : m_config(config)
-    , m_startTime(AZ::TimeMs{ 0 })
+    , m_startTime(AZ::ITime::ZeroTimeMs)
     , m_startPosition()
     , m_currentPosition()
     , m_currentState(State::Idle)

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerHold.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerHold.inl
@@ -44,7 +44,7 @@ inline void Gestures::RecognizerHold::Config::Reflect(AZ::ReflectContext* contex
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 inline Gestures::RecognizerHold::RecognizerHold(const Config& config)
     : m_config(config)
-    , m_startTime(AZ::TimeMs{ 0 })
+    , m_startTime(AZ::ITime::ZeroTimeMs)
     , m_startPosition()
     , m_currentPosition()
     , m_currentState(State::Idle)

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerPinch.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerPinch.inl
@@ -42,8 +42,8 @@ inline Gestures::RecognizerPinch::RecognizerPinch(const Config& config)
     : m_config(config)
     , m_currentState(State::Idle)
 {
-    m_lastUpdateTimes[0] = AZ::TimeMs{ 0 };
-    m_lastUpdateTimes[1] = AZ::TimeMs{ 0 };
+    m_lastUpdateTimes[0] = AZ::ITime::ZeroTimeMs;
+    m_lastUpdateTimes[1] = AZ::ITime::ZeroTimeMs;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerRotate.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerRotate.inl
@@ -42,8 +42,8 @@ inline Gestures::RecognizerRotate::RecognizerRotate(const Config& config)
     : m_config(config)
     , m_currentState(State::Idle)
 {
-    m_lastUpdateTimes[0] = AZ::TimeMs{ 0 };
-    m_lastUpdateTimes[1] = AZ::TimeMs{ 0 };
+    m_lastUpdateTimes[0] = AZ::ITime::ZeroTimeMs;
+    m_lastUpdateTimes[1] = AZ::ITime::ZeroTimeMs;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Gems/Gestures/Code/Include/Gestures/GestureRecognizerSwipe.inl
+++ b/Gems/Gestures/Code/Include/Gestures/GestureRecognizerSwipe.inl
@@ -45,8 +45,8 @@ inline Gestures::RecognizerSwipe::RecognizerSwipe(const Config& config)
     : m_config(config)
     , m_startPosition()
     , m_endPosition()
-    , m_startTime(AZ::TimeMs{ 0 })
-    , m_endTime(AZ::TimeMs{ 0 })
+    , m_startTime(AZ::ITime::ZeroTimeMs)
+    , m_endTime(AZ::ITime::ZeroTimeMs)
     , m_currentState(State::Idle)
 {
 }

--- a/Gems/Gestures/Code/Tests/BaseGestureTest.h
+++ b/Gems/Gestures/Code/Tests/BaseGestureTest.h
@@ -20,7 +20,7 @@ namespace GesturesTests
             return m_realElapsedTime;
         }
 
-        AZ::TimeMs m_realElapsedTime = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_realElapsedTime = AZ::ITime::ZeroTimeMs;
     };
 } // namespace GesturesTests
 

--- a/Gems/LyShine/Code/Source/Animation/UiAnimationSystem.cpp
+++ b/Gems/LyShine/Code/Source/Animation/UiAnimationSystem.cpp
@@ -98,7 +98,7 @@ UiAnimationSystem::UiAnimationSystem()
     m_pCallback = NULL;
     m_bPaused = false;
     m_sequenceStopBehavior = eSSB_GotoEndTime;
-    m_lastUpdateTime = AZ::TimeMs{ 0 };
+    m_lastUpdateTime = AZ::ITime::ZeroTimeMs;
 
     m_nextSequenceId = 1;
 }

--- a/Gems/LyShine/Code/Tests/AnimationTest.cpp
+++ b/Gems/LyShine/Code/Tests/AnimationTest.cpp
@@ -32,7 +32,7 @@ namespace UnitTest
             m_timeMs += AZ::SecondsToTimeMs(sec);
         }
 
-        AZ::TimeMs m_timeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_timeMs = AZ::ITime::ZeroTimeMs;
     };
 
     class TrackEventHandler

--- a/Gems/LyShine/Code/Tests/UiTooltipComponentTest.cpp
+++ b/Gems/LyShine/Code/Tests/UiTooltipComponentTest.cpp
@@ -35,7 +35,7 @@ namespace UnitTest
             m_time += AZ::TimeMs{ 1000 };
             return m_time;
         }
-        mutable AZ::TimeMs m_time = AZ::TimeMs{ 0 };
+        mutable AZ::TimeMs m_time = AZ::ITime::ZeroTimeMs;
     };
 
     class UiTooltipTestApplication

--- a/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/Movie.cpp
@@ -215,7 +215,7 @@ namespace Internal
         if (auto* timeSystem = AZ::Interface<AZ::ITime>::Get())
         {
             const AZ::TimeMs deltatimeOverride = timeSystem->GetSimulationTickDeltaOverride();
-            if (deltatimeOverride != AZ::TimeMs{ 0 })
+            if (deltatimeOverride != AZ::ITime::ZeroTimeMs)
             {
                 deltaTime = AZ::TimeMsToSeconds(deltatimeOverride);
             }
@@ -235,11 +235,11 @@ CMovieSystem::CMovieSystem(ISystem* pSystem)
     m_bEnableCameraShake = true;
     m_bCutscenesPausedInEditor = true;
     m_sequenceStopBehavior = eSSB_GotoEndTime;
-    m_lastUpdateTime = AZ::TimeMs{ 0 };
+    m_lastUpdateTime = AZ::ITime::ZeroTimeMs;
     m_bStartCapture = false;
     m_captureFrame = -1;
     m_bEndCapture = false;
-    m_fixedTimeStepBackUp = AZ::TimeMs{ 0 };
+    m_fixedTimeStepBackUp = AZ::ITime::ZeroTimeMs;
     m_cvar_capture_frame_once = nullptr;
     m_cvar_capture_folder = nullptr;
     m_cvar_sys_maxTimeStepForMovieSystem = nullptr;

--- a/Gems/Maestro/Code/Source/Cinematics/SceneNode.cpp
+++ b/Gems/Maestro/Code/Source/Cinematics/SceneNode.cpp
@@ -418,7 +418,7 @@ void CAnimSceneNode::Animate(SAnimContext& ec)
             {
                 m_simulationTickOverrideBackup = timeSystem->GetSimulationTickDeltaOverride();
                 // if set, disable fixed time step cvar so timewarping will have an affect.
-                timeSystem->SetSimulationTickDeltaOverride(AZ::ZeroTimeMs);
+                timeSystem->SetSimulationTickDeltaOverride(AZ::ITime::ZeroTimeMs);
 
                 m_timeScaleBackup = timeSystem->GetSimulationTickScale();
                 timeSystem->SetSimulationTickScale(timeScale);

--- a/Gems/Maestro/Code/Source/Cinematics/SceneNode.h
+++ b/Gems/Maestro/Code/Source/Cinematics/SceneNode.h
@@ -150,7 +150,7 @@ private:
 
     std::vector<SSoundInfo> m_SoundInfo;
 
-    AZ::TimeMs m_simulationTickOverrideBackup = AZ::TimeMs{ 0 };
+    AZ::TimeMs m_simulationTickOverrideBackup = AZ::ITime::ZeroTimeMs;
     float m_timeScaleBackup = 1.0f;
 };
 

--- a/Gems/Multiplayer/Code/Include/Multiplayer/Components/LocalPredictionPlayerInputComponent.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/Components/LocalPredictionPlayerInputComponent.h
@@ -99,8 +99,8 @@ namespace Multiplayer
         double m_moveAccumulator = 0.0;
         double m_clientBankedTime = 0.0;
 
-        AZ::TimeMs m_lastInputReceivedTimeMs = AZ::TimeMs{ 0 };
-        AZ::TimeMs m_lastCorrectionSentTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_lastInputReceivedTimeMs = AZ::ITime::ZeroTimeMs;
+        AZ::TimeMs m_lastCorrectionSentTimeMs = AZ::ITime::ZeroTimeMs;
 
         ClientInputId m_clientInputId = ClientInputId{ 0 }; // Clients incrementing inputId
         ClientInputId m_lastClientInputId = ClientInputId{ 0 }; // Last inputId processed by the server

--- a/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/IMultiplayer.h
@@ -265,7 +265,7 @@ namespace Multiplayer
         }
     private:
         HostFrameId m_previousHostFrameId = InvalidHostFrameId;
-        AZ::TimeMs m_previousHostTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_previousHostTimeMs = AZ::ITime::ZeroTimeMs;
         AzNetworking::ConnectionId m_previousRewindConnectionId = AzNetworking::InvalidConnectionId;
         float m_previousBlendFactor = DefaultBlendFactor;
     };

--- a/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerStats.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/MultiplayerStats.h
@@ -27,7 +27,7 @@ namespace Multiplayer
         uint64_t m_serverConnectionCount = 0;
 
         uint64_t m_recordMetricIndex = 0;
-        AZ::TimeMs m_totalHistoryTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_totalHistoryTimeMs = AZ::ITime::ZeroTimeMs;
 
         static const uint32_t RingbufferSamples = 32;
         using MetricRingbuffer = AZStd::array<uint64_t, RingbufferSamples>;

--- a/Gems/Multiplayer/Code/Include/Multiplayer/NetworkEntity/EntityReplication/EntityReplicationManager.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/NetworkEntity/EntityReplication/EntityReplicationManager.h
@@ -203,9 +203,9 @@ namespace Multiplayer
         AZStd::unique_ptr<IReplicationWindow> m_replicationWindow;
         AZStd::unique_ptr<IEntityDomain> m_remoteEntityDomain;
 
-        AZ::TimeMs m_entityActivationTimeSliceMs = AZ::TimeMs{ 0 };
-        AZ::TimeMs m_entityPendingRemovalMs = AZ::TimeMs{ 0 };
-        AZ::TimeMs m_frameTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_entityActivationTimeSliceMs = AZ::ITime::ZeroTimeMs;
+        AZ::TimeMs m_entityPendingRemovalMs = AZ::ITime::ZeroTimeMs;
+        AZ::TimeMs m_frameTimeMs = AZ::ITime::ZeroTimeMs;
         HostId m_remoteHostId = InvalidHostId;
         uint32_t m_maxRemoteEntitiesPendingCreationCount = AZStd::numeric_limits<uint32_t>::max();
         uint32_t m_maxPayloadSize = 0;

--- a/Gems/Multiplayer/Code/Include/Multiplayer/NetworkInput/NetworkInput.h
+++ b/Gems/Multiplayer/Code/Include/Multiplayer/NetworkInput/NetworkInput.h
@@ -75,7 +75,7 @@ namespace Multiplayer
         MultiplayerComponentInputVector m_componentInputs;
         ClientInputId m_inputId = ClientInputId{ 0 };
         HostFrameId m_hostFrameId = InvalidHostFrameId;
-        AZ::TimeMs m_hostTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_hostTimeMs = AZ::ITime::ZeroTimeMs;
         float m_hostBlendFactor = 0.f;
         ConstNetworkEntityHandle m_owner;
         bool m_wasAttached = false;

--- a/Gems/Multiplayer/Code/Source/ConnectionData/ClientToServerConnectionData.cpp
+++ b/Gems/Multiplayer/Code/Source/ConnectionData/ClientToServerConnectionData.cpp
@@ -13,7 +13,7 @@ namespace Multiplayer
     // This can be used to help mitigate client side performance when large numbers of entities are created off the network
     AZ_CVAR(uint32_t, cl_ClientMaxRemoteEntitiesPendingCreationCount, AZStd::numeric_limits<uint32_t>::max(), nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Maximum number of entities that we have sent to the client, but have not had a confirmation back from the client");
     AZ_CVAR(AZ::TimeMs, cl_ClientEntityReplicatorPendingRemovalTimeMs, AZ::TimeMs{ 10000 }, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "How long should wait prior to removing an entity for the client through a change in the replication window, entity deletes are still immediate");
-    AZ_CVAR(AZ::TimeMs, cl_DefaultNetworkEntityActivationTimeSliceMs, AZ::TimeMs{ 0 }, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Max Ms to use to activate entities coming from the network, 0 means instantiate everything");
+    AZ_CVAR(AZ::TimeMs, cl_DefaultNetworkEntityActivationTimeSliceMs, AZ::ITime::ZeroTimeMs, nullptr, AZ::ConsoleFunctorFlags::DontReplicate, "Max Ms to use to activate entities coming from the network, 0 means instantiate everything");
 
     ClientToServerConnectionData::ClientToServerConnectionData
     (

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugHierarchyReporter.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugHierarchyReporter.cpp
@@ -27,7 +27,7 @@ namespace Multiplayer
         CollectHierarchyRoots();
 
         AZ::EntitySystemBus::Handler::BusConnect();
-        m_updateDebugOverlay.Enqueue(AZ::TimeMs{ 0 }, true);
+        m_updateDebugOverlay.Enqueue(AZ::ITime::ZeroTimeMs, true);
     }
 
     MultiplayerDebugHierarchyReporter::~MultiplayerDebugHierarchyReporter()

--- a/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugPerEntityReporter.cpp
+++ b/Gems/Multiplayer/Code/Source/Debug/MultiplayerDebugPerEntityReporter.cpp
@@ -127,7 +127,7 @@ namespace Multiplayer
     MultiplayerDebugPerEntityReporter::MultiplayerDebugPerEntityReporter()
         : m_updateDebugOverlay([this]() { UpdateDebugOverlay(); }, AZ::Name("UpdateDebugPerEntityOverlay"))
     {
-        m_updateDebugOverlay.Enqueue(AZ::TimeMs{ 0 }, true);
+        m_updateDebugOverlay.Enqueue(AZ::ITime::ZeroTimeMs, true);
 
         m_eventHandlers.m_entitySerializeStart = decltype(m_eventHandlers.m_entitySerializeStart)([this](AzNetworking::SerializerMode mode, AZ::EntityId entityId, const char* entityName)
             {

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorConnection.cpp
@@ -33,7 +33,7 @@ namespace Multiplayer
     {
         m_networkEditorInterface = AZ::Interface<INetworking>::Get()->CreateNetworkInterface(
             AZ::Name(MpEditorInterfaceName), ProtocolType::Tcp, TrustZone::ExternalClientToServer, *this);
-        m_networkEditorInterface->SetTimeoutMs(AZ::TimeMs{ 0 }); // Disable timeouts on this network interface
+        m_networkEditorInterface->SetTimeoutMs(AZ::ITime::ZeroTimeMs); // Disable timeouts on this network interface
         ActivateDedicatedEditorServer();
     }
 

--- a/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/MultiplayerSystemComponent.h
@@ -179,7 +179,7 @@ namespace Multiplayer
         AZStd::queue<AZStd::string> m_pendingConnectionTickets;
         AZStd::unordered_map<uint64_t, NetEntityId> m_playerRejoinData;
 
-        AZ::TimeMs m_lastReplicatedHostTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_lastReplicatedHostTimeMs = AZ::ITime::ZeroTimeMs;
         HostFrameId m_lastReplicatedHostFrameId = HostFrameId(0);
 
         uint64_t m_temporaryUserIdentifier = 0; // Used in the event of a migration or rejoin

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicationManager.cpp
@@ -54,10 +54,10 @@ namespace Multiplayer
         m_maxPayloadSize = connection.GetConnectionMtu() - UdpPacketHeaderSerializeSize - ReplicationManagerPacketOverhead;
 
         // Schedule ClearRemovedReplicators()
-        m_clearRemovedReplicators.Enqueue(AZ::TimeMs{ 0 }, true);
+        m_clearRemovedReplicators.Enqueue(AZ::ITime::ZeroTimeMs, true);
 
         // Start window update events
-        m_updateWindow.Enqueue(AZ::TimeMs{ 0 }, true);
+        m_updateWindow.Enqueue(AZ::ITime::ZeroTimeMs, true);
 
         INetworkEntityManager* networkEntityManager = GetNetworkEntityManager();
         if (networkEntityManager != nullptr)
@@ -97,7 +97,7 @@ namespace Multiplayer
                     notReadyEntities.push_back(entityId);
                 }
             }
-            if (m_entityActivationTimeSliceMs > AZ::TimeMs{ 0 } && AZ::GetElapsedTimeMs() > endTimeMs)
+            if (m_entityActivationTimeSliceMs > AZ::ITime::ZeroTimeMs && AZ::GetElapsedTimeMs() > endTimeMs)
             {
                 // If we go over our timeslice, break out the loop
                 break;

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicator.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/EntityReplicator.cpp
@@ -344,7 +344,7 @@ namespace Multiplayer
     void EntityReplicator::SetPendingRemoval(AZ::TimeMs pendingRemovalTimeMs)
     {
         AZ_Assert(m_propertyPublisher, "Only valid if we are publishing updates");
-        if (pendingRemovalTimeMs > AZ::TimeMs{ 0 })
+        if (pendingRemovalTimeMs > AZ::ITime::ZeroTimeMs)
         {
             if (!IsPendingRemoval())
             {

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/PropertySubscriber.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/PropertySubscriber.cpp
@@ -26,7 +26,7 @@ namespace Multiplayer
 
     bool PropertySubscriber::IsDeleting() const
     {
-        return m_markForRemovalTimeMs > AZ::TimeMs{ 0 };
+        return m_markForRemovalTimeMs > AZ::ITime::ZeroTimeMs;
     }
 
     bool PropertySubscriber::IsDeleted() const

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/PropertySubscriber.h
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/EntityReplication/PropertySubscriber.h
@@ -40,6 +40,6 @@ namespace Multiplayer
 
         // The last packet to have been received about this entity
         AzNetworking::PacketId m_lastReceivedPacketId = AzNetworking::InvalidPacketId;
-        AZ::TimeMs m_markForRemovalTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_markForRemovalTimeMs = AZ::ITime::ZeroTimeMs;
     };
 }

--- a/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
+++ b/Gems/Multiplayer/Code/Source/NetworkEntity/NetworkEntityManager.cpp
@@ -127,7 +127,7 @@ namespace Multiplayer
                 AZ_Assert(entityHandle.GetNetBindComponent(), "No NetBindComponent found on networked entity");
             }
             m_removeList.push_back(entityHandle.GetNetEntityId());
-            m_removeEntitiesEvent.Enqueue(AZ::TimeMs{ 0 });
+            m_removeEntitiesEvent.Enqueue(AZ::ITime::ZeroTimeMs);
         }
     }
 

--- a/Gems/Multiplayer/Code/Source/NetworkTime/NetworkTime.h
+++ b/Gems/Multiplayer/Code/Source/NetworkTime/NetworkTime.h
@@ -44,7 +44,7 @@ namespace Multiplayer
 
         HostFrameId m_hostFrameId = HostFrameId{ 0 };
         HostFrameId m_unalteredFrameId = HostFrameId{ 0 };
-        AZ::TimeMs m_hostTimeMs = AZ::TimeMs{ 0 };
+        AZ::TimeMs m_hostTimeMs = AZ::ITime::ZeroTimeMs;
         float m_hostBlendFactor = DefaultBlendFactor;
         AzNetworking::ConnectionId m_rewindingConnectionId = AzNetworking::InvalidConnectionId;
     };

--- a/Gems/Multiplayer/Code/Tests/RewindableContainerTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/RewindableContainerTests.cpp
@@ -43,7 +43,7 @@ namespace UnitTest
         // Test rewind for all pushed values and overall size
         for (uint32_t idx = 0; idx < RewindableContainerSize; ++idx)
         {
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(idx), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(idx), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             EXPECT_EQ(idx + 1, test.size());
             EXPECT_EQ(idx, test.back());
         }
@@ -70,9 +70,9 @@ namespace UnitTest
         EXPECT_TRUE(test.empty());
 
         // Test rewind for pop_back and clear
-        Multiplayer::ScopedAlterTime pop_time(static_cast<Multiplayer::HostFrameId>(RewindableContainerSize), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+        Multiplayer::ScopedAlterTime pop_time(static_cast<Multiplayer::HostFrameId>(RewindableContainerSize), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
         EXPECT_EQ(RewindableContainerSize - 1, test.size());
-        Multiplayer::ScopedAlterTime clear_time(static_cast<Multiplayer::HostFrameId>(RewindableContainerSize + 1), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+        Multiplayer::ScopedAlterTime clear_time(static_cast<Multiplayer::HostFrameId>(RewindableContainerSize + 1), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
         EXPECT_EQ(0, test.size());
 
         // Test copy_values and resize_no_construct
@@ -100,7 +100,7 @@ namespace UnitTest
         // Test rewind for all values and overall size
         for (uint32_t idx = 1; idx <= RewindableContainerSize; ++idx)
         {
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(idx), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(idx), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             for (uint32_t testIdx = 0; testIdx < RewindableContainerSize; ++testIdx)
             {
                 if (testIdx < idx)

--- a/Gems/Multiplayer/Code/Tests/RewindableObjectTests.cpp
+++ b/Gems/Multiplayer/Code/Tests/RewindableObjectTests.cpp
@@ -39,7 +39,7 @@ namespace UnitTest
 
         for (uint32_t i = 0; i < 16; ++i)
         {
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(i), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(i), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             EXPECT_EQ(i, test);
         }
 
@@ -52,7 +52,7 @@ namespace UnitTest
 
         for (uint32_t i = 16; i < 48; ++i)
         {
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(i), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(i), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             EXPECT_EQ(i, test);
         }
     }
@@ -70,15 +70,15 @@ namespace UnitTest
 
         {
             // Test that Get/GetPrevious return different value when not on the owning connection
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(RewindableBufferFrames - 1), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(RewindableBufferFrames - 1), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             EXPECT_EQ(RewindableBufferFrames - 1, test.Get());
             EXPECT_EQ(RewindableBufferFrames - 2, test.GetPrevious());
         }
 
         // Test that Get/GetPrevious return the unaltered frame on the owning conection
-        Multiplayer::GetNetworkTime()->AlterTime(static_cast<Multiplayer::HostFrameId>(RewindableBufferFrames - 1), AZ::TimeMs{ 0 }, 1.f, AzNetworking::ConnectionId(0));
+        Multiplayer::GetNetworkTime()->AlterTime(static_cast<Multiplayer::HostFrameId>(RewindableBufferFrames - 1), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::ConnectionId(0));
         {
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(RewindableBufferFrames - 1), AZ::TimeMs{ 0 }, 1.f, AzNetworking::ConnectionId(0));
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(RewindableBufferFrames - 1), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::ConnectionId(0));
             test.SetOwningConnectionId(AzNetworking::ConnectionId(0));
             EXPECT_EQ(RewindableBufferFrames - 1, test.Get());
             EXPECT_EQ(RewindableBufferFrames - 1, test.GetPrevious());
@@ -99,7 +99,7 @@ namespace UnitTest
 
         {
             // Note that we didn't actually set any value for time rewindableBufferFrames, so we're testing fetching a value past the last time set
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(RewindableBufferFrames), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(RewindableBufferFrames), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             EXPECT_EQ(RewindableBufferFrames - 1, test);
         }
     }
@@ -122,7 +122,7 @@ namespace UnitTest
 
         for (uint32_t i = 0; i < RewindableBufferFrames; ++i)
         {
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(i), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(i), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             const Object& value = test;
             EXPECT_EQ(value.value, i);
         }
@@ -131,19 +131,19 @@ namespace UnitTest
     TEST_F(RewindableObjectTests, TestBackfillOnLargeTimestep)
     {
         Multiplayer::RewindableObject<uint32_t, RewindableBufferFrames> test(0);
-        Multiplayer::ScopedAlterTime time1(static_cast<Multiplayer::HostFrameId>(0), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+        Multiplayer::ScopedAlterTime time1(static_cast<Multiplayer::HostFrameId>(0), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
         test = 1;
 
-        Multiplayer::ScopedAlterTime time2(static_cast<Multiplayer::HostFrameId>(31), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+        Multiplayer::ScopedAlterTime time2(static_cast<Multiplayer::HostFrameId>(31), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
         test = 2;
 
         for (uint32_t i = 0; i < 31; ++i)
         {
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(i), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(i), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             EXPECT_EQ(1, test);
         }
 
-        Multiplayer::ScopedAlterTime time3(static_cast<Multiplayer::HostFrameId>(31), AZ::TimeMs{ 0 }, 1.f,  AzNetworking::InvalidConnectionId);
+        Multiplayer::ScopedAlterTime time3(static_cast<Multiplayer::HostFrameId>(31), AZ::ITime::ZeroTimeMs, 1.f,  AzNetworking::InvalidConnectionId);
         EXPECT_EQ(2, test);
     }
 
@@ -159,7 +159,7 @@ namespace UnitTest
 
         for (uint32_t i = 0; i < 1000; ++i)
         {
-            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(1000 - i), AZ::TimeMs{ 0 }, 1.f, AzNetworking::InvalidConnectionId);
+            Multiplayer::ScopedAlterTime time(static_cast<Multiplayer::HostFrameId>(1000 - i), AZ::ITime::ZeroTimeMs, 1.f, AzNetworking::InvalidConnectionId);
             EXPECT_EQ(1000, test);
         }
     }


### PR DESCRIPTION
Next PR contains the following:
- Updating usages of AZ::TimeMs{ 0 } and AZ::TimeUs{ 0 } to AZ::ITime::ZeroTimeMs and AZ::ITime::ZeroTimeUs

This builds off the changes from these PRs.
[Part 1](https://github.com/aws-lumberyard-dev/o3de/pull/274)
[Part 2](https://github.com/aws-lumberyard-dev/o3de/pull/275)
[Part 3](https://github.com/aws-lumberyard-dev/o3de/pull/276)

This PR is into a staging branch, not development