### PR TITLE
Added property handler for SourceHandle type

### DIFF
--- a/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
+++ b/Code/Framework/AzCore/AzCore/Serialization/EditContextConstants.inl
@@ -133,6 +133,8 @@ namespace AZ
             const static AZ::Crc32 AllowClearAsset = AZ_CRC("AllowClearAsset", 0x24827182);
             // Show the name of the asset that was produced from the source asset
             const static AZ::Crc32 ShowProductAssetFileName = AZ_CRC("ShowProductAssetFileName");
+            //! Regular expression pattern filter for source files
+            const static AZ::Crc32 SourceAssetFilterPattern = AZ_CRC_CE("SourceAssetFilterPattern");
 
             //! Component icon attributes
             const static AZ::Crc32 Icon = AZ_CRC("Icon", 0x659429db);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetPicker/AssetPickerDialog.cpp
@@ -96,6 +96,18 @@ namespace AzToolsFramework
                 }
             }
 
+            if (selection.GetSelectedAssetIds().empty())
+            {
+                for (auto& filePath : selection.GetSelectedFilePaths())
+                {
+                    if (!filePath.empty())
+                    {
+                        selectedAsset = true;
+                        m_ui->m_assetBrowserTreeViewWidget->SelectFileAtPath(filePath);
+                    }
+                }
+            }
+
             if (!selectedAsset)
             {
                 m_ui->m_assetBrowserTreeViewWidget->SelectFolder(selection.GetDefaultDirectory());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.cpp
@@ -10,18 +10,24 @@
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/EBusFindAssetTypeByName.h>
 
+#if !defined(Q_MOC_RUN)
+AZ_PUSH_DISABLE_WARNING(4251 4800, "-Wunknown-warning-option")
+#include <QRegExp>
+AZ_POP_DISABLE_WARNING
+#endif
+
 namespace AzToolsFramework
 {
     namespace AssetBrowser
     {
         namespace
         {
-            FilterConstType ProductsNoFoldersFilter()
+            FilterConstType EntryTypeNoFoldersFilter(AssetBrowserEntry::AssetEntryType entryType = AssetBrowserEntry::AssetEntryType::Product)
             {
-                EntryTypeFilter* productFilter = new EntryTypeFilter();
-                productFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Product);
+                EntryTypeFilter* entryTypeFilter = new EntryTypeFilter();
+                entryTypeFilter->SetEntryType(entryType);
                 // in case entry is a source or folder, it may still contain relevant product
-                productFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+                entryTypeFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
 
                 EntryTypeFilter* foldersFilter = new EntryTypeFilter();
                 foldersFilter->SetEntryType(AssetBrowserEntry::AssetEntryType::Folder);
@@ -30,7 +36,7 @@ namespace AzToolsFramework
                 noFoldersFilter->SetFilter(FilterConstType(foldersFilter));
 
                 CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
-                compFilter->AddFilter(FilterConstType(productFilter));
+                compFilter->AddFilter(FilterConstType(entryTypeFilter));
                 compFilter->AddFilter(FilterConstType(noFoldersFilter));
 
                 return FilterConstType(compFilter);
@@ -79,13 +85,37 @@ namespace AzToolsFramework
 
         void AssetSelectionModel::SetSelectedAssetIds(const AZStd::vector<AZ::Data::AssetId>& selectedAssetIds)
         {
+            m_selectedFilePaths.clear();
+
             m_selectedAssetIds = selectedAssetIds;
         }
 
         void AssetSelectionModel::SetSelectedAssetId(const AZ::Data::AssetId& selectedAssetId)
         {
+            m_selectedFilePaths.clear();
+
             m_selectedAssetIds.clear();
             m_selectedAssetIds.push_back(selectedAssetId);
+        }
+
+        const AZStd::vector<AZStd::string>& AssetSelectionModel::GetSelectedFilePaths() const
+        {
+            return m_selectedFilePaths;
+        }
+
+        void AssetSelectionModel::SetSelectedFilePaths(const AZStd::vector<AZStd::string>& selectedFilePaths)
+        {
+            m_selectedAssetIds.clear();
+
+            m_selectedFilePaths = selectedFilePaths;
+        }
+
+        void AssetSelectionModel::SetSelectedFilePath(const AZStd::string& selectedFilePath)
+        {
+            m_selectedAssetIds.clear();
+
+            m_selectedFilePaths.clear();
+            m_selectedFilePaths.push_back(selectedFilePath);
         }
 
         void AssetSelectionModel::SetDefaultDirectory(AZStd::string_view defaultDirectory)
@@ -136,7 +166,7 @@ namespace AzToolsFramework
 
             CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
             compFilter->AddFilter(assetTypeFilterPtr);
-            compFilter->AddFilter(ProductsNoFoldersFilter());
+            compFilter->AddFilter(EntryTypeNoFoldersFilter());
 
             selection.SetSelectionFilter(FilterConstType(compFilter));
             selection.SetMultiselect(multiselect);
@@ -169,7 +199,7 @@ namespace AzToolsFramework
 
             CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
             compFilter->AddFilter(anyAssetTypeFilterPtr);
-            compFilter->AddFilter(ProductsNoFoldersFilter());
+            compFilter->AddFilter(EntryTypeNoFoldersFilter());
 
             selection.SetSelectionFilter(FilterConstType(compFilter));
             selection.SetMultiselect(multiselect);
@@ -190,7 +220,28 @@ namespace AzToolsFramework
 
             CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
             compFilter->AddFilter(assetGroupFilterPtr);
-            compFilter->AddFilter(ProductsNoFoldersFilter());
+            compFilter->AddFilter(EntryTypeNoFoldersFilter());
+
+            selection.SetSelectionFilter(FilterConstType(compFilter));
+            selection.SetMultiselect(multiselect);
+
+            return selection;
+        }
+
+        AssetSelectionModel AssetSelectionModel::SourceAssetTypeSelection(const QString& pattern, bool multiselect)
+        {
+            AssetSelectionModel selection;
+
+            RegExpFilter* patternFilter = new RegExpFilter();
+            patternFilter->SetFilterPattern(pattern);
+            patternFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
+            auto patternFilterPtr = FilterConstType(patternFilter);
+
+            selection.SetDisplayFilter(patternFilterPtr);
+
+            CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::AND);
+            compFilter->AddFilter(patternFilterPtr);
+            compFilter->AddFilter(EntryTypeNoFoldersFilter(AssetBrowserEntry::AssetEntryType::Source));
 
             selection.SetSelectionFilter(FilterConstType(compFilter));
             selection.SetMultiselect(multiselect);
@@ -204,7 +255,7 @@ namespace AzToolsFramework
          
             CompositeFilter* compFilter = new CompositeFilter(CompositeFilter::LogicOperatorType::OR);
             selection.SetDisplayFilter(FilterConstType(compFilter));
-            selection.SetSelectionFilter(ProductsNoFoldersFilter());
+            selection.SetSelectionFilter(EntryTypeNoFoldersFilter());
             selection.SetMultiselect(multiselect);
 
             return selection;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetSelectionModel.h
@@ -44,6 +44,10 @@ namespace AzToolsFramework
             void SetSelectedAssetIds(const AZStd::vector<AZ::Data::AssetId>& selectedAssetIds);
             void SetSelectedAssetId(const AZ::Data::AssetId& selectedAssetId);
 
+            const AZStd::vector<AZStd::string>& GetSelectedFilePaths() const;
+            void SetSelectedFilePaths(const AZStd::vector<AZStd::string>& selectedFilePaths);
+            void SetSelectedFilePath(const AZStd::string& selectedFilePath);
+
             void SetDefaultDirectory(AZStd::string_view defaultDirectory);
             AZStd::string_view GetDefaultDirectory() const;
             
@@ -60,6 +64,7 @@ namespace AzToolsFramework
             static AssetSelectionModel AssetTypeSelection(const char* assetTypeName, bool multiselect = false);
             static AssetSelectionModel AssetTypesSelection(const AZStd::vector<AZ::Data::AssetType>& assetTypes, bool multiselect = false);
             static AssetSelectionModel AssetGroupSelection(const char* group, bool multiselect = false);
+            static AssetSelectionModel SourceAssetTypeSelection(const QString& pattern, bool multiselect = false);
             static AssetSelectionModel EverythingSelection(bool multiselect = false);
 
         private:
@@ -68,8 +73,12 @@ namespace AzToolsFramework
             // some entries like folder should always be displayed, but not always selectable, thus 2 separate filters
             FilterConstType m_selectionFilter;
             FilterConstType m_displayFilter;
-            
+
+            //! Selection can be based on asset ids (for products), or file paths (for sources)
+            //! These are mututally exclusive
             AZStd::vector<AZ::Data::AssetId> m_selectedAssetIds;
+            AZStd::vector<AZStd::string> m_selectedFilePaths;
+
             AZStd::vector<const AssetBrowserEntry*> m_results;
             AZStd::string m_defaultDirectory;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.cpp
@@ -252,6 +252,40 @@ namespace AzToolsFramework
         }
 
         //////////////////////////////////////////////////////////////////////////
+        // RegExpFilter
+        //////////////////////////////////////////////////////////////////////////
+        RegExpFilter::RegExpFilter()
+            : m_filterPattern("")
+        {
+        }
+
+        void RegExpFilter::SetFilterPattern(const QString& filterPattern)
+        {
+            m_filterPattern = filterPattern;
+            Q_EMIT updatedSignal();
+        }
+
+        QString RegExpFilter::GetNameInternal() const
+        {
+            return m_filterPattern;
+        }
+
+        bool RegExpFilter::MatchInternal(const AssetBrowserEntry* entry) const
+        {
+            // no filter pattern matches any asset
+            if (m_filterPattern.isEmpty())
+            {
+                return true;
+            }
+
+            // entry's name matches regular expression pattern
+            QRegExp regExp(m_filterPattern);
+            regExp.setPatternSyntax(QRegExp::Wildcard);
+
+            return regExp.exactMatch(entry->GetDisplayName());
+        }
+
+        //////////////////////////////////////////////////////////////////////////
         // AssetTypeFilter
         //////////////////////////////////////////////////////////////////////////
         AssetTypeFilter::AssetTypeFilter()

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Search/Filter.h
@@ -116,6 +116,28 @@ namespace AzToolsFramework
         };
 
         //////////////////////////////////////////////////////////////////////////
+        // RegExpFilter
+        //////////////////////////////////////////////////////////////////////////
+        //! RegExpFilter filters assets based on a regular expression pattern
+        class RegExpFilter
+            : public AssetBrowserEntryFilter
+        {
+            Q_OBJECT
+        public:
+            RegExpFilter();
+            ~RegExpFilter() override = default;
+
+            void SetFilterPattern(const QString& filterPattern);
+
+        protected:
+            QString GetNameInternal() const override;
+            bool MatchInternal(const AssetBrowserEntry* entry) const override;
+
+        private:
+            QString m_filterPattern;
+        };
+
+        //////////////////////////////////////////////////////////////////////////
         // AssetTypeFilter
         //////////////////////////////////////////////////////////////////////////
         //! AssetTypeFilter filters products based on their asset id

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.cpp
@@ -39,7 +39,12 @@ namespace AzToolsFramework
         typeFilter->SetAssetType(filterType);
         typeFilter->SetFilterPropagation(AssetBrowserEntryFilter::PropagateDirection::Down);
 
-        m_assetBrowserFilterModel->SetFilter(FilterConstType(typeFilter));
+        SetFilter(FilterConstType(typeFilter));
+    }
+
+    void AssetCompleterModel::SetFilter(FilterConstType filter)
+    {
+        m_assetBrowserFilterModel->SetFilter(filter);
 
         RefreshAssetList();
     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.h
@@ -32,6 +32,7 @@ namespace AzToolsFramework
         QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
         void SetFilter(AZ::Data::AssetType filterType);
+        void SetFilter(FilterConstType filter);
         void RefreshAssetList();
         void SearchStringHighlight(QString searchString);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.cpp
@@ -1265,7 +1265,7 @@ namespace AzToolsFramework
         return newCtrl;
     }
 
-    void AssetPropertyHandlerDefault::ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
+    void AssetPropertyHandlerDefault::ConsumeAttributeInternal(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
     {
         (void)debugName;
 
@@ -1464,6 +1464,11 @@ namespace AzToolsFramework
         }
     }
 
+    void AssetPropertyHandlerDefault::ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName)
+    {
+        ConsumeAttributeInternal(GUI, attrib, attrValue, debugName);
+    }
+
     void AssetPropertyHandlerDefault::WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node)
     {
         (void)index;
@@ -1606,8 +1611,8 @@ namespace AzToolsFramework
 
     void RegisterAssetPropertyHandler()
     {
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew AssetPropertyHandlerDefault());
-        EBUS_EVENT(PropertyTypeRegistrationMessages::Bus, RegisterPropertyType, aznew SimpleAssetPropertyHandlerDefault());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(&PropertyTypeRegistrationMessages::RegisterPropertyType, aznew AssetPropertyHandlerDefault());
+        PropertyTypeRegistrationMessages::Bus::Broadcast(&PropertyTypeRegistrationMessages::RegisterPropertyType, aznew SimpleAssetPropertyHandlerDefault());
     }
 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -233,7 +233,7 @@ namespace AzToolsFramework
         void SetSelectedAssetID(const AZ::Data::AssetId& newID, const AZ::Data::AssetType& newType);
         void SetCurrentAssetHint(const AZStd::string& hint);
         void SetDefaultAssetID(const AZ::Data::AssetId& defaultID);
-        void PopupAssetPicker();
+        virtual void PopupAssetPicker();
         void OnClearButtonClicked();
         void UpdateAssetDisplay();
         void OnLineEditFocus(bool focus);
@@ -268,7 +268,8 @@ namespace AzToolsFramework
         virtual void UpdateWidgetInternalTabbing(PropertyAssetCtrl* widget) override { widget->UpdateTabOrder(); }
 
         virtual QWidget* CreateGUI(QWidget* pParent) override;
-        virtual void ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
+        static void ConsumeAttributeInternal(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName);
+        void ConsumeAttribute(PropertyAssetCtrl* GUI, AZ::u32 attrib, PropertyAttributeReader* attrValue, const char* debugName) override;
         virtual void WriteGUIValuesIntoProperty(size_t index, PropertyAssetCtrl* GUI, property_t& instance, InstanceDataNode* node) override;
         virtual bool ReadValuesIntoGUI(size_t index, PropertyAssetCtrl* GUI, const property_t& instance, InstanceDataNode* node)  override;
     };

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorScriptCanvasComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorScriptCanvasComponent.cpp
@@ -193,7 +193,12 @@ namespace ScriptCanvasEditor
                     ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC("Level", 0x9aeacc13))
                     ->Attribute(AZ::Edit::Attributes::HelpPageURL, "https://o3de.org/docs/user-guide/components/reference/scripting/script-canvas/")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &EditorScriptCanvasComponent::m_sourceHandle, "Script Canvas Source File", "Script Canvas source file associated with this component")
-                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->Attribute("BrowseIcon", ":/stylesheet/img/UI20/browse-edit-select-files.svg")
+                    ->Attribute("EditButton", "")
+                    ->Attribute("EditDescription", "Open in Script Canvas Editor")
+                    ->Attribute("EditCallback", &EditorScriptCanvasComponent::OpenEditor)
+                    ->Attribute(AZ::Edit::Attributes::AssetPickerTitle, "Script Canvas")
+                    ->Attribute(AZ::Edit::Attributes::SourceAssetFilterPattern, "*.scriptcanvas")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &EditorScriptCanvasComponent::m_variableOverrides, "Properties", "Script Canvas Graph Properties")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ;
@@ -227,7 +232,7 @@ namespace ScriptCanvasEditor
         SetName(m_sourceHandle.Path().Filename().Native());
     }
 
-    void EditorScriptCanvasComponent::OpenEditor()
+    void EditorScriptCanvasComponent::OpenEditor(const AZ::Data::AssetId&, const AZ::Data::AssetType&)
     {
         AzToolsFramework::OpenViewPane(LyViewPane::ScriptCanvas);
          

--- a/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorScriptCanvasComponent.h
+++ b/Gems/ScriptCanvas/Code/Editor/Include/ScriptCanvas/Components/EditorScriptCanvasComponent.h
@@ -68,7 +68,7 @@ namespace ScriptCanvasEditor
         ScriptCanvas::GraphIdentifier GetGraphIdentifier() const override;
         //=====================================================================
 
-        void OpenEditor();
+        void OpenEditor(const AZ::Data::AssetId&, const AZ::Data::AssetType&);
         
         void SetName(AZStd::string_view name) { m_name = name; }
         const AZStd::string& GetName() const;

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -22,6 +22,7 @@
 #include <Editor/SystemComponent.h>
 #include <Editor/View/Dialogs/NewGraphDialog.h>
 #include <Editor/View/Dialogs/SettingsDialog.h>
+#include <Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h>
 #include <Editor/View/Windows/MainWindow.h>
 #include <GraphCanvas/GraphCanvasBus.h>
 #include <LyViewPaneNames.h>
@@ -119,6 +120,7 @@ namespace ScriptCanvasEditor
         PopulateEditorCreatableTypes();
 
         AzToolsFramework::RegisterGenericComboBoxHandler<ScriptCanvas::VariableId>();
+        AzToolsFramework::PropertyTypeRegistrationMessages::Bus::Broadcast(&AzToolsFramework::PropertyTypeRegistrationMessages::RegisterPropertyType, aznew SourceHandlePropertyHandler());
 
         SystemRequestBus::Handler::BusConnect();
         ScriptCanvasExecutionBus::Handler::BusConnect();

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <ScriptCanvas/Components/EditorUtils.h>
+#include <Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h>
+
+#include <AzFramework/StringFunc/StringFunc.h>
+
+#include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
+
+namespace ScriptCanvasEditor
+{
+    SourceHandlePropertyAssetCtrl::SourceHandlePropertyAssetCtrl(QWidget* parent)
+        : AzToolsFramework::PropertyAssetCtrl(parent)
+    {
+    }
+
+    AzToolsFramework::AssetBrowser::AssetSelectionModel SourceHandlePropertyAssetCtrl::GetAssetSelectionModel()
+    {
+        auto selectionModel = AssetSelectionModel::SourceAssetTypeSelection(m_sourceAssetFilterPattern);
+        selectionModel.SetTitle(m_title);
+        return selectionModel;
+    }
+
+    void SourceHandlePropertyAssetCtrl::PopupAssetPicker()
+    {
+        // Request the AssetBrowser Dialog and set a type filter
+        AssetSelectionModel selection = GetAssetSelectionModel();
+        selection.SetSelectedFilePath(m_selectedSourcePath.c_str());
+
+        AZStd::string defaultDirectory;
+        if (m_defaultDirectoryCallback)
+        {
+            m_defaultDirectoryCallback->Invoke(m_editNotifyTarget, defaultDirectory);
+            selection.SetDefaultDirectory(defaultDirectory);
+        }
+
+        AssetBrowserComponentRequestBus::Broadcast(&AssetBrowserComponentRequests::PickAssets, selection, parentWidget());
+        if (selection.IsValid())
+        {
+            const auto source = azrtti_cast<const SourceAssetBrowserEntry*>(selection.GetResult());
+            AZ_Assert(source, "Incorrect entry type selected. Expected source.");
+            if (source)
+            {
+                SetSelectedSourcePath(source->GetFullPath());
+            }
+        }
+    }
+
+    void SourceHandlePropertyAssetCtrl::ClearAssetInternal()
+    {
+        SetSelectedSourcePath("");
+
+        PropertyAssetCtrl::ClearAssetInternal();
+    }
+
+    void SourceHandlePropertyAssetCtrl::SetSourceAssetFilterPattern(const QString& filterPattern)
+    {
+        m_sourceAssetFilterPattern = filterPattern;
+    }
+
+    AZ::IO::Path SourceHandlePropertyAssetCtrl::GetSelectedSourcePath() const
+    {
+        return m_selectedSourcePath;
+    }
+
+    void SourceHandlePropertyAssetCtrl::SetSelectedSourcePath(const AZ::IO::Path& sourcePath)
+    {
+        m_selectedSourcePath = sourcePath;
+
+        AZStd::string displayText;
+        if (!sourcePath.empty())
+        {
+            AzFramework::StringFunc::Path::GetFileName(sourcePath.c_str(), displayText);
+        }
+        m_browseEdit->setText(displayText.c_str());
+
+        // The AssetID gets ignored, the only important bit is triggering the change for the RequestWrite
+        emit OnAssetIDChanged(AZ::Data::AssetId());
+    }
+
+    QWidget* SourceHandlePropertyHandler::CreateGUI(QWidget* pParent)
+    {
+        SourceHandlePropertyAssetCtrl* newCtrl = aznew SourceHandlePropertyAssetCtrl(pParent);
+        connect(newCtrl, &SourceHandlePropertyAssetCtrl::OnAssetIDChanged, this, [newCtrl](AZ::Data::AssetId newAssetID)
+        {
+            (void)newAssetID;
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::RequestWrite, newCtrl);
+            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::OnEditingFinished, newCtrl);
+        });
+        return newCtrl;
+    }
+
+    void SourceHandlePropertyHandler::ConsumeAttribute(SourceHandlePropertyAssetCtrl* GUI, AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue, const char* debugName)
+    {
+        // Let the AssetPropertyHandlerDefault handle all of the common attributes
+        AzToolsFramework::AssetPropertyHandlerDefault::ConsumeAttributeInternal(GUI, attrib, attrValue, debugName);
+
+        if (attrib == AZ::Edit::Attributes::SourceAssetFilterPattern)
+        {
+            AZStd::string filterPattern;
+            if (attrValue->Read<AZStd::string>(filterPattern))
+            {
+                GUI->SetSourceAssetFilterPattern(filterPattern.c_str());
+            }
+        }
+    }
+
+    void SourceHandlePropertyHandler::WriteGUIValuesIntoProperty(size_t index, SourceHandlePropertyAssetCtrl* GUI, property_t& instance, AzToolsFramework::InstanceDataNode* node)
+    {
+        (void)index;
+        (void)node;
+
+        auto sourceHandle = SourceHandle(nullptr, {}, GUI->GetSelectedSourcePath());
+        instance = property_t(*CompleteDescription(sourceHandle));
+    }
+
+    bool SourceHandlePropertyHandler::ReadValuesIntoGUI(size_t index, SourceHandlePropertyAssetCtrl* GUI, const property_t& instance, AzToolsFramework::InstanceDataNode* node)
+    {
+        (void)index;
+        (void)node;
+
+        GUI->blockSignals(true);
+
+        GUI->SetSelectedSourcePath(instance.Path());
+        GUI->SetEditNotifyTarget(node->GetParent()->GetInstance(0));
+
+        GUI->blockSignals(false);
+        return false;
+    }
+}

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
@@ -119,7 +119,15 @@ namespace ScriptCanvasEditor
         (void)node;
 
         auto sourceHandle = SourceHandle(nullptr, {}, GUI->GetSelectedSourcePath());
-        instance = property_t(*CompleteDescription(sourceHandle));
+        auto completeSourceHandle = CompleteDescription(sourceHandle);
+        if (completeSourceHandle)
+        {
+            instance = property_t(*CompleteDescription(sourceHandle));
+        }
+        else
+        {
+            instance = property_t();
+        }
     }
 
     bool SourceHandlePropertyHandler::ReadValuesIntoGUI(size_t index, SourceHandlePropertyAssetCtrl* GUI, const property_t& instance, AzToolsFramework::InstanceDataNode* node)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#if !defined(Q_MOC_RUN)
+#include <AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx>
+
+#include <Core/Core.h>
+#endif
+
+namespace ScriptCanvasEditor
+{
+    class SourceHandlePropertyAssetCtrl
+        : public AzToolsFramework::PropertyAssetCtrl
+    {
+        Q_OBJECT
+
+    public:
+        AZ_CLASS_ALLOCATOR(SourceHandlePropertyAssetCtrl, AZ::SystemAllocator, 0);
+
+        SourceHandlePropertyAssetCtrl(QWidget* parent = nullptr);
+
+        AzToolsFramework::AssetBrowser::AssetSelectionModel GetAssetSelectionModel() override;
+        void PopupAssetPicker() override;
+        void ClearAssetInternal() override;
+
+        void SetSourceAssetFilterPattern(const QString& filterPattern);
+
+        AZ::IO::Path GetSelectedSourcePath() const;
+        void SetSelectedSourcePath(const AZ::IO::Path& sourcePath);
+
+    private:
+        //! A regular expression pattern for filtering by source assets
+        //! If this is set, the PropertyAssetCtrl will be dealing with source assets
+        //! instead of a specific asset type
+        QString m_sourceAssetFilterPattern;
+
+        AZ::IO::Path m_selectedSourcePath;
+    };
+
+    class SourceHandlePropertyHandler
+        : QObject
+        , public AzToolsFramework::PropertyHandler<SourceHandle, SourceHandlePropertyAssetCtrl>
+    {
+        Q_OBJECT
+
+    public:
+        AZ_CLASS_ALLOCATOR(SourceHandlePropertyHandler, AZ::SystemAllocator, 0);
+
+        AZ::u32 GetHandlerName(void) const override { return AZ_CRC_CE("SourceHandle"); }
+        bool IsDefaultHandler() const override { return true; }
+        QWidget* GetFirstInTabOrder(SourceHandlePropertyAssetCtrl* widget) override { return widget->GetFirstInTabOrder(); }
+        QWidget* GetLastInTabOrder(SourceHandlePropertyAssetCtrl* widget) override { return widget->GetLastInTabOrder(); }
+        void UpdateWidgetInternalTabbing(SourceHandlePropertyAssetCtrl* widget) override { widget->UpdateTabOrder(); }
+
+        QWidget* CreateGUI(QWidget* pParent) override;
+        void ConsumeAttribute(SourceHandlePropertyAssetCtrl* GUI, AZ::u32 attrib, AzToolsFramework::PropertyAttributeReader* attrValue, const char* debugName) override;
+        void WriteGUIValuesIntoProperty(size_t index, SourceHandlePropertyAssetCtrl* GUI, property_t& instance, AzToolsFramework::InstanceDataNode* node) override;
+        bool ReadValuesIntoGUI(size_t index, SourceHandlePropertyAssetCtrl* GUI, const property_t& instance, AzToolsFramework::InstanceDataNode* node)  override;
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Core.cpp
@@ -279,18 +279,6 @@ namespace ScriptCanvasEditor
                 ->Field("id", &SourceHandle::m_id)
                 ->Field("path", &SourceHandle::m_path)
                 ;
-
-            if (AZ::EditContext* editContext = serializeContext->GetEditContext())
-            {
-                editContext->Class<SourceHandle>("Script Canvas Source Handle", "References a source editor file")
-                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
-                    ->Attribute(AZ::Edit::Attributes::Category, "Scripting")
-                    ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/ScriptCanvas.svg")
-                    ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/ScriptCanvas/Viewport/ScriptCanvas.svg")
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &SourceHandle::m_path);
-                    ;
-            }
         }
     }
 

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_editor_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_editor_files.cmake
@@ -182,6 +182,8 @@ set(FILES
     Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.h
     Editor/View/Widgets/ScriptCanvasNodePaletteDockWidget.cpp
     Editor/View/Widgets/ScriptCanvasNodePaletteToolbar.ui
+    Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
+    Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
     Editor/View/Widgets/WidgetBus.h
     Editor/View/Widgets/DataTypePalette/DataTypePaletteModel.cpp
     Editor/View/Widgets/DataTypePalette/DataTypePaletteModel.h


### PR DESCRIPTION
Added new property handler for the `SourceHandle` type. This extends the `PropertyAssetCtrl` handler with the difference being it filters only source files, instead of products. Updated the Script Canvas component to leverage this handler.

![SourceHandlePickerMostlyWorking](https://user-images.githubusercontent.com/7519264/142691881-63c094bb-fde6-45a8-b1bc-cbce6c0b0947.gif)

Signed-off-by: Chris Galvan chgalvan@amazon.com