### PR TITLE
Fixed asset completer model for source handle picker.

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.cpp
@@ -125,9 +125,6 @@ namespace AzToolsFramework
         int rows = m_assetBrowserFilterModel->rowCount(index);
         if (rows == 0)
         {
-            if (index != QModelIndex()) {
-                AZ_Error("AssetCompleterModel", false, "No children detected in FetchResources()");
-            }
             return;
         }
 
@@ -136,7 +133,7 @@ namespace AzToolsFramework
             QModelIndex childIndex = m_assetBrowserFilterModel->index(i, 0, index);
             AssetBrowserEntry* childEntry = GetAssetEntry(m_assetBrowserFilterModel->mapToSource(childIndex));
 
-            if (childEntry->GetEntryType() == AssetBrowserEntry::AssetEntryType::Product)
+            if (childEntry->GetEntryType() == m_entryType)
             {
                 ProductAssetBrowserEntry* productEntry = static_cast<ProductAssetBrowserEntry*>(childEntry);
                 AZStd::string assetName;
@@ -172,7 +169,6 @@ namespace AzToolsFramework
         return m_assets[index.row()].m_displayName;
     }
 
-
     const AZ::Data::AssetId AssetCompleterModel::GetAssetIdFromIndex(const QModelIndex& index) 
     {
         if (!index.isValid())
@@ -181,5 +177,20 @@ namespace AzToolsFramework
         }
 
         return m_assets[index.row()].m_assetId;
+    }
+
+    const AZStd::string_view AssetCompleterModel::GetPathFromIndex(const QModelIndex& index)
+    {
+        if (!index.isValid())
+        {
+            return "";
+        }
+
+        return m_assets[index.row()].m_path;
+    }
+
+    void AssetCompleterModel::SetFetchEntryType(AssetBrowserEntry::AssetEntryType entryType)
+    {
+        m_entryType = entryType;
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.h
@@ -40,6 +40,9 @@ namespace AzToolsFramework
 
         const AZStd::string_view GetNameFromIndex(const QModelIndex& index);
         const AZ::Data::AssetId GetAssetIdFromIndex(const QModelIndex& index);
+        const AZStd::string_view GetPathFromIndex(const QModelIndex& index);
+
+        void SetFetchEntryType(AssetBrowserEntry::AssetEntryType entryType);
 
     private:
         struct AssetItem 
@@ -58,6 +61,8 @@ namespace AzToolsFramework
         AZStd::vector<AssetItem> m_assets;
         //! String that will be highlighted in the suggestions
         QString m_highlightString;
+
+        AssetBrowserEntry::AssetEntryType m_entryType = AssetBrowserEntry::AssetEntryType::Product;
     };
 
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/PropertyEditor/PropertyAssetCtrl.hxx
@@ -173,10 +173,11 @@ namespace AzToolsFramework
         virtual void SetFolderSelection(const AZStd::string& /* folderPath */) {}
         virtual void ClearAssetInternal();
 
-        void ConfigureAutocompleter();
+        virtual void ConfigureAutocompleter();
         void RefreshAutocompleter();
         void EnableAutocompleter();
         void DisableAutocompleter();
+        const QModelIndex GetSourceIndex(const QModelIndex& index);
 
         void HandleFieldClear();
         AZStd::string AddDefaultSuffix(const AZStd::string& filename);
@@ -240,13 +241,12 @@ namespace AzToolsFramework
         virtual void OnEditButtonClicked();
         void OnThumbnailClicked();
         void OnCompletionModelReset();
-        void OnAutocomplete(const QModelIndex& index);
+        virtual void OnAutocomplete(const QModelIndex& index);
         void OnTextChange(const QString& text);
         void OnReturnPressed();
         void ShowContextMenu(const QPoint& pos);
 
     private:
-        const QModelIndex GetSourceIndex(const QModelIndex& index);
         void UpdateThumbnail();
     };
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.cpp
@@ -13,6 +13,7 @@
 
 #include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
 #include <AzToolsFramework/AssetBrowser/AssetBrowserEntry.h>
+#include <AzToolsFramework/UI/PropertyEditor/Model/AssetCompleterModel.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 
 namespace ScriptCanvasEditor
@@ -61,6 +62,20 @@ namespace ScriptCanvasEditor
         PropertyAssetCtrl::ClearAssetInternal();
     }
 
+    void SourceHandlePropertyAssetCtrl::ConfigureAutocompleter()
+    {
+        if (m_completerIsConfigured)
+        {
+            return;
+        }
+
+        AzToolsFramework::PropertyAssetCtrl::ConfigureAutocompleter();
+
+        AssetSelectionModel selection = GetAssetSelectionModel();
+        m_model->SetFetchEntryType(AssetBrowserEntry::AssetEntryType::Source);
+        m_model->SetFilter(selection.GetDisplayFilter());
+    }
+
     void SourceHandlePropertyAssetCtrl::SetSourceAssetFilterPattern(const QString& filterPattern)
     {
         m_sourceAssetFilterPattern = filterPattern;
@@ -84,6 +99,11 @@ namespace ScriptCanvasEditor
 
         // The AssetID gets ignored, the only important bit is triggering the change for the RequestWrite
         emit OnAssetIDChanged(AZ::Data::AssetId());
+    }
+
+    void SourceHandlePropertyAssetCtrl::OnAutocomplete(const QModelIndex& index)
+    {
+        SetSelectedSourcePath(m_model->GetPathFromIndex(GetSourceIndex(index)));
     }
 
     QWidget* SourceHandlePropertyHandler::CreateGUI(QWidget* pParent)

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/SourceHandlePropertyAssetCtrl.h
@@ -29,11 +29,15 @@ namespace ScriptCanvasEditor
         AzToolsFramework::AssetBrowser::AssetSelectionModel GetAssetSelectionModel() override;
         void PopupAssetPicker() override;
         void ClearAssetInternal() override;
+        void ConfigureAutocompleter() override;
 
         void SetSourceAssetFilterPattern(const QString& filterPattern);
 
         AZ::IO::Path GetSelectedSourcePath() const;
         void SetSelectedSourcePath(const AZ::IO::Path& sourcePath);
+
+    public Q_SLOTS:
+        void OnAutocomplete(const QModelIndex& index) override;
 
     private:
         //! A regular expression pattern for filtering by source assets


### PR DESCRIPTION
Fixed auto complete functionality for the `SourceHandle` property field. Tested and verified pre-existing asset property controls (e.g. mesh, material) autocomplete still work as expected as well.

![SourceHandleAutocomplete](https://user-images.githubusercontent.com/7519264/142698973-59c82ab6-e0b2-4e12-ad69-f48f1e654d4e.gif)

Signed-off-by: Chris Galvan <chgalvan@amazon.com>