### PR TITLE
Removing support for morph targets that modify vertex colors

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/MorphTargets/MorphTargetCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/MorphTargets/MorphTargetCS.azsl
@@ -17,9 +17,6 @@ rootconstant uint s_targetPositionOffset;
 rootconstant uint s_targetNormalOffset;
 rootconstant uint s_targetTangentOffset;
 rootconstant uint s_targetBitangentOffset;
-rootconstant uint s_targetColorOffset;
-
-option bool o_hasColorDeltas = false;
 
 void WriteDeltaToAccumulationBuffer(float3 delta, uint offset, uint morphedVertexIndex)
 {
@@ -87,18 +84,5 @@ void MainCS(uint3 thread_id: SV_DispatchThreadID)
         // Now that we have the compressed bitangents, unpack them and write them to the accumulation buffer      
         float3 bitangentDelta = DecodeTBNDelta(compressedBitangentDelta) * s_weight;
         WriteDeltaToAccumulationBuffer(bitangentDelta, s_targetBitangentOffset, morphedVertexIndex);
-
-        if (o_hasColorDeltas)
-        {
-            uint4 compressedColorDelta;
-            // Colors are in the least significant 24 bits (8 bits per channel)
-            compressedColorDelta.r = (delta.m_compressedColorDeltaRGBA >> 24) & 0x000000FF;
-            compressedColorDelta.g = (delta.m_compressedColorDeltaRGBA >> 16) & 0x000000FF;
-            compressedColorDelta.b = (delta.m_compressedColorDeltaRGBA >> 8)  & 0x000000FF;
-            compressedColorDelta.a =  delta.m_compressedColorDeltaRGBA        & 0x000000FF;
-
-            float4 colorDelta = DecodeColorDelta(compressedColorDelta) * s_weight;
-            WriteDeltaToAccumulationBuffer(colorDelta, s_targetColorOffset, morphedVertexIndex);
-        }
     }
 }

--- a/Gems/Atom/Feature/Common/Assets/Shaders/MorphTargets/MorphTargetSRG.azsli
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/MorphTargets/MorphTargetSRG.azsli
@@ -32,10 +32,8 @@ struct MorphTargetDelta
     uint m_compressedNormalDeltaZTangentDelta;
     // 8 bit padding plus 8 bits per component for bitangent deltas
     uint m_compressedPadBitangentDeltaXYZ;
-    // 8 bits per component for color delta
-    uint m_compressedColorDeltaRGBA;
     // Extra padding so the struct is 16 byte aligned for structured buffers
-    uint2 m_pad;
+    uint3 m_pad;
 };
 
 // Input to the morph target compute shader

--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.azsl
@@ -13,7 +13,6 @@
 
 option enum class SkinningMethod { LinearSkinning, DualQuaternion } o_skinningMethod = SkinningMethod::LinearSkinning;
 option bool o_applyMorphTargets = false;
-option bool o_applyColorMorphTargets = false;
 
 float3 ReadFloat3FromFloatBuffer(Buffer<float> buffer, uint index)
 {
@@ -195,16 +194,6 @@ void MainCS(uint3 thread_id: SV_DispatchThreadID)
             ApplyMorphTargetDelta(InstanceSrg::m_morphTargetNormalDeltaOffset, i, normal);
             ApplyMorphTargetDelta(InstanceSrg::m_morphTargetTangentDeltaOffset, i, tangent.xyz);
             ApplyMorphTargetDelta(InstanceSrg::m_morphTargetBitangentDeltaOffset, i, bitangent);
-        }
-
-        if (o_applyColorMorphTargets)
-        {
-            float4 color = InstanceSrg::m_sourceColors[i];
-            ApplyMorphTargetDelta(InstanceSrg::m_morphTargetColorDeltaOffset, i, color);
-            PassSrg::m_skinnedMeshOutputStream[InstanceSrg::m_targetColors + i * 4] = color.r;
-            PassSrg::m_skinnedMeshOutputStream[InstanceSrg::m_targetColors + i * 4 + 1] = color.g;
-            PassSrg::m_skinnedMeshOutputStream[InstanceSrg::m_targetColors + i * 4 + 2] = color.b;
-            PassSrg::m_skinnedMeshOutputStream[InstanceSrg::m_targetColors + i * 4 + 3] = color.a;
         }
         
         switch(o_skinningMethod)

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
@@ -60,7 +60,6 @@ namespace AZ
             float m_maxDelta;
             uint32_t m_vertexCount;
             uint32_t m_positionOffset;
-            bool m_hasColorDeltas;
         };
 
         namespace MorphTargetConstants
@@ -80,7 +79,6 @@ namespace AZ
             uint32_t m_accumulatedNormalDeltaOffsetInBytes;
             uint32_t m_accumulatedTangentDeltaOffsetInBytes;
             uint32_t m_accumulatedBitangentDeltaOffsetInBytes;
-            uint32_t m_accumulatedColorDeltaOffsetInBytes;
         };
 
     }// Render

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h
@@ -132,9 +132,6 @@ namespace AZ
             //! Calls RPI::Buffer::WaitForUpload for each buffer in the lod.
             void WaitForUpload();
 
-            //! Returns true if this lod has a morphed color stream
-            bool HasDynamicColors() const;
-
         private:
             RHI::BufferViewDescriptor CreateInputViewDescriptor(
                 SkinnedMeshInputVertexStreams inputStream, RHI::Format elementFormat, const RHI::StreamBufferView& streamBufferView);
@@ -190,11 +187,6 @@ namespace AZ
             //! Total number of vertices for the entire lod
             uint32_t m_vertexCount = 0;
 
-            //! Bool for keeping track of whether or not this lod has morphed colors
-            bool m_hasDynamicColors = false;
-            //! Bool for keeping track of whether or not this lod has a static color stream
-            bool m_hasStaticColors = false;
-
             SkinnedMeshOutputVertexCounts m_outputVertexCountsByStream;
         };
 
@@ -234,9 +226,6 @@ namespace AZ
 
             //! Get the buffer view for a specific input stream
             AZ::RHI::Ptr<const RHI::BufferView> GetInputBufferView(uint32_t lodIndex, uint8_t inputStream) const;
-
-            //! Check if the mesh has dynamically modified colors
-            bool HasDynamicColors(uint32_t lodIndex, uint32_t meshIndex) const;
 
             //! Get the number of vertices for the specified lod.
             uint32_t GetVertexCount(uint32_t lodIndex, uint32_t meshIndex) const;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshShaderOptions.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshShaderOptions.h
@@ -24,7 +24,6 @@ namespace AZ
         {
             SkinningMethod m_skinningMethod = SkinningMethod::LinearSkinning;
             bool m_applyMorphTargets = false;
-            bool m_applyColorMorphTargets = false;
         };
     }
 }

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshVertexStreams.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshVertexStreams.h
@@ -28,8 +28,6 @@ namespace AZ
             BiTangent,
             BlendIndices,
             BlendWeights,
-            // Optional
-            Color,
             NumVertexStreams
         };
 
@@ -40,8 +38,6 @@ namespace AZ
             Normal,
             Tangent,
             BiTangent,
-            // Optional
-            Color,
             NumVertexStreams
         };
 

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.cpp
@@ -55,7 +55,6 @@ namespace AZ
             AZ::RPI::ShaderOptionGroup shaderOptionGroup = m_morphTargetShader->CreateShaderOptionGroup();
             // In case there are several options you don't care about, it's good practice to initialize them with default values.
             shaderOptionGroup.SetUnspecifiedToDefaultValues();
-            shaderOptionGroup.SetValue(AZ::Name("o_hasColorDeltas"), RPI::ShaderOptionValue{ m_morphTargetMetaData.m_hasColorDeltas });
 
             // Get the shader variant and instance SRG
             RPI::ShaderReloadNotificationBus::Handler::BusConnect(m_morphTargetShader->GetAssetId());
@@ -130,8 +129,6 @@ namespace AZ
             AZ_Error("MorphTargetDispatchItem", tangentOffsetIndex.IsValid(), "Could not find root constant 's_targetTangentOffset' in the shader");
             auto bitangentOffsetIndex = rootConstantsLayout->FindShaderInputIndex(AZ::Name{ "s_targetBitangentOffset" });
             AZ_Error("MorphTargetDispatchItem", bitangentOffsetIndex.IsValid(), "Could not find root constant 's_targetBitangentOffset' in the shader");
-            auto colorOffsetIndex = rootConstantsLayout->FindShaderInputIndex(AZ::Name{ "s_targetColorOffset" });
-            AZ_Error("MorphTargetDispatchItem", colorOffsetIndex.IsValid(), "Could not find root constant 's_targetColorOffset' in the shader");
 
             auto minIndex = rootConstantsLayout->FindShaderInputIndex(AZ::Name{ "s_min" });
             AZ_Error("MorphTargetDispatchItem", minIndex.IsValid(), "Could not find root constant 's_min' in the shader");
@@ -153,11 +150,6 @@ namespace AZ
             m_rootConstantData.SetConstant(normalOffsetIndex, m_morphInstanceMetaData.m_accumulatedNormalDeltaOffsetInBytes / 4);
             m_rootConstantData.SetConstant(tangentOffsetIndex, m_morphInstanceMetaData.m_accumulatedTangentDeltaOffsetInBytes / 4);
             m_rootConstantData.SetConstant(bitangentOffsetIndex, m_morphInstanceMetaData.m_accumulatedBitangentDeltaOffsetInBytes / 4);
-
-            if (m_morphTargetMetaData.m_hasColorDeltas)
-            {
-                m_rootConstantData.SetConstant(colorOffsetIndex, m_morphInstanceMetaData.m_accumulatedColorDeltaOffsetInBytes / 4);
-            }
 
             m_dispatchItem.m_rootConstantSize = static_cast<uint8_t>(m_rootConstantData.GetConstantData().size());
             m_dispatchItem.m_rootConstants = m_rootConstantData.GetConstantData().data();

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshDispatchItem.cpp
@@ -53,10 +53,6 @@ namespace AZ
             {
                 m_shaderOptions.m_applyMorphTargets = true;
             }
-            if (inputBuffers->HasDynamicColors(lodIndex, meshIndex))
-            {
-                m_shaderOptions.m_applyColorMorphTargets = true;
-            }
 
             // CreateShaderOptionGroup will also connect to the SkinnedMeshShaderOptionNotificationBus
             m_shaderOptionGroup = skinnedMeshFeatureProcessor->CreateSkinningShaderOptionGroup(m_shaderOptions, *this);
@@ -131,12 +127,6 @@ namespace AZ
 
             for (uint8_t outputStream = 0; outputStream < static_cast<uint8_t>(SkinnedMeshOutputVertexStreams::NumVertexStreams); outputStream++)
             {
-                // Skip colors if they are not being morphed
-                if (outputStream == static_cast<uint8_t>(SkinnedMeshOutputVertexStreams::Color) && !m_shaderOptions.m_applyColorMorphTargets)
-                {
-                    continue;
-                }
-
                 // Set the buffer offsets
                 const SkinnedMeshOutputVertexStreamInfo& outputStreamInfo = SkinnedMeshVertexStreamPropertyInterface::Get()->GetOutputStreamInfo(static_cast<SkinnedMeshOutputVertexStreams>(outputStream));
                 {
@@ -183,13 +173,6 @@ namespace AZ
             RHI::ShaderInputConstantIndex morphBitangentOffsetIndex = m_instanceSrg->FindShaderInputConstantIndex(Name{ "m_morphTargetBitangentDeltaOffset" });
             // The buffer is using 32-bit integers, so divide the offset by 4 here so it doesn't have to be done in the shader
             m_instanceSrg->SetConstant(morphBitangentOffsetIndex, m_morphTargetInstanceMetaData.m_accumulatedBitangentDeltaOffsetInBytes / 4);
-
-            if (m_shaderOptions.m_applyColorMorphTargets)
-            {
-                RHI::ShaderInputConstantIndex morphColorOffsetIndex = m_instanceSrg->FindShaderInputConstantIndex(Name{ "m_morphTargetColorDeltaOffset" });
-                // The buffer is using 32-bit integers, so divide the offset by 4 here so it doesn't have to be done in the shader
-                m_instanceSrg->SetConstant(morphColorOffsetIndex, m_morphTargetInstanceMetaData.m_accumulatedColorDeltaOffsetInBytes / 4);
-            }
 
             RHI::ShaderInputConstantIndex morphDeltaIntegerEncodingIndex = m_instanceSrg->FindShaderInputConstantIndex(Name{ "m_morphTargetDeltaInverseIntegerEncoding" });
             m_instanceSrg->SetConstant(morphDeltaIntegerEncodingIndex, 1.0f / m_morphTargetDeltaIntegerEncoding);

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.cpp
@@ -28,10 +28,6 @@ namespace AZ
             m_applyMorphTargetFalseValue = layout->FindValue(m_applyMorphTargetOptionIndex, AZ::Name("false"));
             m_applyMorphTargetTrueValue = layout->FindValue(m_applyMorphTargetOptionIndex, AZ::Name("true"));
 
-            m_applyColorMorphTargetOptionIndex = layout->FindShaderOptionIndex(AZ::Name("o_applyColorMorphTargets"));
-            m_applyColorMorphTargetFalseValue = layout->FindValue(m_applyColorMorphTargetOptionIndex, AZ::Name("false"));
-            m_applyColorMorphTargetTrueValue = layout->FindValue(m_applyColorMorphTargetOptionIndex, AZ::Name("true"));
-
             SkinnedMeshShaderOptionNotificationBus::Event(this, &SkinnedMeshShaderOptionNotificationBus::Events::OnShaderReinitialized, this);
         }
 
@@ -60,15 +56,6 @@ namespace AZ
             else
             {
                 shaderOptionGroup.SetValue(m_applyMorphTargetOptionIndex, m_applyMorphTargetFalseValue);
-            }
-
-            if (shaderOptions.m_applyColorMorphTargets)
-            {
-                shaderOptionGroup.SetValue(m_applyColorMorphTargetOptionIndex, m_applyColorMorphTargetTrueValue);
-            }
-            else
-            {
-                shaderOptionGroup.SetValue(m_applyColorMorphTargetOptionIndex, m_applyColorMorphTargetFalseValue);
             }
 
             shaderOptionGroup.SetUnspecifiedToDefaultValues();

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.h
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshShaderOptionsCache.h
@@ -55,10 +55,6 @@ namespace AZ
             RPI::ShaderOptionIndex m_applyMorphTargetOptionIndex;
             RPI::ShaderOptionValue m_applyMorphTargetFalseValue;
             RPI::ShaderOptionValue m_applyMorphTargetTrueValue;
-
-            RPI::ShaderOptionIndex m_applyColorMorphTargetOptionIndex;
-            RPI::ShaderOptionValue m_applyColorMorphTargetFalseValue;
-            RPI::ShaderOptionValue m_applyColorMorphTargetTrueValue;
         };
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshVertexStreamProperties.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshVertexStreamProperties.cpp
@@ -82,16 +82,6 @@ namespace AZ
                 SkinnedMeshInputVertexStreams::BlendWeights
             };
 
-            m_inputStreamInfo[static_cast<uint8_t>(SkinnedMeshInputVertexStreams::Color)] = SkinnedMeshVertexStreamInfo{
-                RHI::Format::R32G32B32A32_FLOAT,
-                sizeof(AZ::Vector4),
-                Name{"SkinnedMeshInputColors"},
-                Name{"m_sourceColors"},
-                RHI::ShaderSemantic{Name{"COLOR"}},
-                true, // isOptional
-                SkinnedMeshInputVertexStreams::Color
-            };
-
             // Attributes of the vertex buffers that are not used or modified during skinning, but are shared between all target models that share the same source
             m_staticStreamInfo[static_cast<uint8_t>(SkinnedMeshStaticVertexStreams::UV_0)] = SkinnedMeshVertexStreamInfo{
                 RHI::Format::R32G32_FLOAT,
@@ -99,14 +89,6 @@ namespace AZ
                 Name{"SkinnedMeshStaticUVs"},
                 Name{"unused"},
                 RHI::ShaderSemantic{Name{"UV"}}
-            };
-
-            m_staticStreamInfo[static_cast<uint8_t>(SkinnedMeshStaticVertexStreams::Color)] = SkinnedMeshVertexStreamInfo{
-                RHI::Format::R32G32B32A32_FLOAT,
-                sizeof(AZ::Vector4),
-                Name{"SkinnedMeshStaticColors"},
-                Name{"unused"},
-                RHI::ShaderSemantic{Name{"COLOR"}}
             };
 
             // Attributes of the vertex streams of the target model that is written to during skinning
@@ -144,15 +126,6 @@ namespace AZ
                 Name{"m_targetBiTangents"},
                 RHI::ShaderSemantic{Name{"BITANGENT"}},
                 SkinnedMeshInputVertexStreams::BiTangent
-            };
-
-            m_outputStreamInfo[static_cast<uint8_t>(SkinnedMeshOutputVertexStreams::Color)] = SkinnedMeshOutputVertexStreamInfo{
-                RHI::Format::R32G32B32A32_FLOAT,
-                sizeof(AZ::Vector4),
-                Name{"SkinnedMeshOutputColors"},
-                Name{"m_targetColors"},
-                RHI::ShaderSemantic{Name{"COLOR"}},
-                SkinnedMeshInputVertexStreams::Color
             };
             
             {

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetDelta.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetDelta.h
@@ -21,12 +21,6 @@ namespace AZ::RPI
         // to modify a value from 1 to -1 or from -1 to 1
         constexpr float s_tangentSpaceDeltaMin = -2.0f;
         constexpr float s_tangentSpaceDeltaMax = 2.0f;
-
-        // A color will be between 0.0 and 1.0 for any given channel
-        // The largest a delta needs to be is positive or negative 1.0
-        // to modify a value from 0 to 1 or from 1 to 0
-        constexpr float s_colorDeltaMin = -1.0f;
-        constexpr float s_colorDeltaMax = 1.0f;
     }
 
     //! This class represents the data that is passed to the morph target compute shader for an individual delta
@@ -45,10 +39,8 @@ namespace AZ::RPI
         uint32_t m_normalZTangentXYZ;
         // 8 bit padding plus 8 bits per component for bitangent deltas
         uint32_t m_padBitangentXYZ;
-        // 8 bits per component for color deltas
-        uint32_t m_colorRGBA;
         // Explicit padding so the struct is 16 byte aligned for structured buffers
-        uint32_t m_pad[2];
+        uint32_t m_pad[3];
     };
 
     //! A morph target delta that is compressed, but split into individual components
@@ -75,12 +67,6 @@ namespace AZ::RPI
         uint8_t m_bitangentX;
         uint8_t m_bitangentY;
         uint8_t m_bitangentZ;
-
-        // 8 bits per channel for color deltas
-        uint8_t m_colorR;
-        uint8_t m_colorG;
-        uint8_t m_colorB;
-        uint8_t m_colorA;
     };
 
     PackedCompressedMorphTargetDelta PackMorphTargetDelta(const CompressedMorphTargetDelta& compressedDelta);

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h
@@ -56,9 +56,6 @@ namespace AZ::RPI
             //! Reference to the wrinkle mask, if it exists
             AZ::Data::Asset<AZ::RPI::StreamingImageAsset> m_wrinkleMask;
 
-            //! Boolean to indicate the presence or absence of color deltas
-            bool m_hasColorDeltas = false;
-
             static void Reflect(AZ::ReflectContext* context);
         };
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -890,17 +890,6 @@ namespace AZ
             // Check if this is a skinned mesh
             if (!productMeshList.empty() && !productMeshList[0].m_skinWeights.empty())
             {
-                // First, do a pass to see if any mesh has morphed colors
-                bool hasMorphedColors = false;
-                for (ProductMeshContent& productMesh : productMeshList)
-                {
-                    if (productMesh.m_hasMorphedColors)
-                    {
-                        hasMorphedColors = true;
-                        break;
-                    }
-                }
-
                 for (ProductMeshContent& productMesh : productMeshList)
                 {
                     size_t vertexCount = productMesh.m_positions.size() / PositionFloatsPerVert;
@@ -916,25 +905,6 @@ namespace AZ
                     {
                         productMesh.m_bitangents.resize(vertexCount * BitangentFloatsPerVert, 1.0f);
                         AZ_Warning(s_builderName, false, "Mesh '%s' is missing bitangents and no defaults were generated. Skinned meshes require bitangents. Dummy bitangents will be inserted, which may result in rendering artifacts.", productMesh.m_name.GetCStr());
-                    }
-
-                    // If any of the meshes have morphed colors, padd all the meshes so that the color stream is aligned with the other skinned streams
-                    if (hasMorphedColors)
-                    {
-                        if (productMesh.m_colorCustomNames.empty())
-                        {
-                            productMesh.m_colorCustomNames.push_back(Name{ "COLOR" });
-                        }
-
-                        if (productMesh.m_colorSets.empty())
-                        {
-                            productMesh.m_colorSets.resize(1);
-                        }
-
-                        if (productMesh.m_colorSets[0].empty())
-                        {
-                            productMesh.m_colorSets[0].resize(vertexCount * ColorFloatsPerVert, 0.0f);
-                        }
                     }
                 }
             }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
@@ -121,7 +121,6 @@ namespace AZ
 
                 MaterialUid m_materialUid;
                 bool CanBeMerged() const { return m_clothData.empty(); }
-                bool m_hasMorphedColors = false;
             };
             using ProductMeshContentList = AZStd::vector<ProductMeshContent>;
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
@@ -238,16 +238,6 @@ namespace AZ::RPI
                     currentDelta.m_bitangentY = Compress<uint8_t>(0.0f, MorphTargetDeltaConstants::s_tangentSpaceDeltaMin, MorphTargetDeltaConstants::s_tangentSpaceDeltaMax);
                     currentDelta.m_bitangentZ = Compress<uint8_t>(0.0f, MorphTargetDeltaConstants::s_tangentSpaceDeltaMin, MorphTargetDeltaConstants::s_tangentSpaceDeltaMax);
                 }
-
-                // Color
-                {
-                    metaData.m_hasColorDeltas = true;
-                    productMesh.m_hasMorphedColors = true;
-                    currentDelta.m_colorR = Compress<uint8_t>(0.0f, MorphTargetDeltaConstants::s_colorDeltaMin, MorphTargetDeltaConstants::s_colorDeltaMax);
-                    currentDelta.m_colorG = Compress<uint8_t>(0.0f, MorphTargetDeltaConstants::s_colorDeltaMin, MorphTargetDeltaConstants::s_colorDeltaMax);
-                    currentDelta.m_colorB = Compress<uint8_t>(0.0f, MorphTargetDeltaConstants::s_colorDeltaMin, MorphTargetDeltaConstants::s_colorDeltaMax);
-                    currentDelta.m_colorA = Compress<uint8_t>(0.0f, MorphTargetDeltaConstants::s_colorDeltaMin, MorphTargetDeltaConstants::s_colorDeltaMax);
-                }
             }
         }
 

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/MorphTargetDelta.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/MorphTargetDelta.cpp
@@ -14,7 +14,7 @@ namespace AZ::RPI
 
     PackedCompressedMorphTargetDelta PackMorphTargetDelta(const CompressedMorphTargetDelta& compressedDelta)
     {
-        PackedCompressedMorphTargetDelta packedDelta{ 0,0,0,0,0,0,{0,0} };
+        PackedCompressedMorphTargetDelta packedDelta{ 0,0,0,0,0, {0,0,0} };
         packedDelta.m_morphedVertexIndex = compressedDelta.m_morphedVertexIndex;
 
         // Position x is in the most significant 16 bits, y is in the least significant 16 bits
@@ -40,12 +40,6 @@ namespace AZ::RPI
         packedDelta.m_padBitangentXYZ |= static_cast<uint32_t>(compressedDelta.m_bitangentX) << 16;
         packedDelta.m_padBitangentXYZ |= static_cast<uint32_t>(compressedDelta.m_bitangentY) << 8;
         packedDelta.m_padBitangentXYZ |= static_cast<uint32_t>(compressedDelta.m_bitangentZ);
-
-        // Colors are in the least significant 24 bits (8 bits per channel)
-        packedDelta.m_colorRGBA |= static_cast<uint32_t>(compressedDelta.m_colorR) << 24;
-        packedDelta.m_colorRGBA |= static_cast<uint32_t>(compressedDelta.m_colorG) << 16;
-        packedDelta.m_colorRGBA |= static_cast<uint32_t>(compressedDelta.m_colorB) << 8;
-        packedDelta.m_colorRGBA |= static_cast<uint32_t>(compressedDelta.m_colorA);
 
         return packedDelta;
     }
@@ -78,12 +72,6 @@ namespace AZ::RPI
         compressedDelta.m_bitangentX = (packedDelta.m_padBitangentXYZ >> 16) & 0x000000FF;
         compressedDelta.m_bitangentY = (packedDelta.m_padBitangentXYZ >> 8 ) & 0x000000FF;
         compressedDelta.m_bitangentZ =  packedDelta.m_padBitangentXYZ        & 0x000000FF;
-
-        // Colors are 4 channels, 8 bits per channel
-        compressedDelta.m_colorR = (packedDelta.m_colorRGBA >> 24) & 0x000000FF;
-        compressedDelta.m_colorG = (packedDelta.m_colorRGBA >> 16) & 0x000000FF;
-        compressedDelta.m_colorB = (packedDelta.m_colorRGBA >> 8)  & 0x000000FF;
-        compressedDelta.m_colorA =  packedDelta.m_colorRGBA        & 0x000000FF;
 
         return compressedDelta;
     }

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/MorphTargetMetaAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/MorphTargetMetaAsset.cpp
@@ -26,7 +26,6 @@ namespace AZ::RPI
                 ->Field("minPositionDelta", &MorphTargetMetaAsset::MorphTarget::m_minPositionDelta)
                 ->Field("maxPositionDelta", &MorphTargetMetaAsset::MorphTarget::m_maxPositionDelta)
                 ->Field("wrinkleMask", &MorphTargetMetaAsset::MorphTarget::m_wrinkleMask)
-                ->Field("hasColorDeltas", &MorphTargetMetaAsset::MorphTarget::m_hasColorDeltas)
                 ;
         }
     }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -248,7 +248,6 @@ namespace AZ
                 const RPI::BufferAssetView* jointIndicesBufferView = nullptr;
                 const RPI::BufferAssetView* skinWeightsBufferView = nullptr;
                 const RPI::BufferAssetView* morphBufferAssetView = nullptr;
-                const RPI::BufferAssetView* colorView = nullptr;
 
                 for (const auto& modelLodMesh : modelLodAsset->GetMeshes())
                 {
@@ -270,11 +269,6 @@ namespace AZ
                     if (!morphBufferAssetView)
                     {
                         morphBufferAssetView = modelLodMesh.GetSemanticBufferAssetView(Name{ "MORPHTARGET_VERTEXDELTAS" });
-                    }
-
-                    if (!colorView)
-                    {
-                        colorView = modelLodMesh.GetSemanticBufferAssetView(Name{ "COLOR" });
                     }
                 }
 
@@ -309,24 +303,6 @@ namespace AZ
                 {
                     ProcessMorphsForLod(actor, morphBufferAssetView->GetBufferAsset(), static_cast<uint32_t>(lodIndex), fullFileName, skinnedMeshLod);
                 }
-
-                // Set colors after morphs are set, so that we know whether or not they are dynamic (if they exist)
-                if (colorView)
-                {
-                    if (skinnedMeshLod.HasDynamicColors())
-                    {
-                        // If colors are being morphed,
-                        // add them as input to the skinning compute shader, which will apply the morph
-                        //skinnedMeshLod.SetSkinningInputBufferAsset(colorView->GetBufferAsset(), SkinnedMeshInputVertexStreams::Color);
-                    }
-                    else
-                    {
-                        // If colors exist but are not modified dynamically,
-                        // add them to the static streams that are shared by all instances of the same skinned mesh
-                        //skinnedMeshLod.SetStaticBufferAsset(colorView->GetBufferAsset(), SkinnedMeshStaticVertexStreams::Color);
-                    }
-                }
-
             } // for all lods
 
             return skinnedMeshInputBuffers;


### PR DESCRIPTION
The idea behind updating a vertex color using a morph target is that you can change the values that are being used to blend between a multi-layered material. Possibly a MultilayerPBR material, but more likely the wrinkle layers in the Skin material. The alternative (which is supported in the Skin shader) is to have a blend mask per-morph target, blend between masks for all the active morph targets in the pixel shader using the morph target weights, and then use that result to blend between the material layers.

Using a vertex color for blending would have better performance and lower memory cost, but could come at the cost of visual artifacts from interpolating the vertex colors/blend values that don't occur using the blend mask. So in all likelihood, in a case such as wrinkle layers in the skin shader, going with higher quality is going to be the preferred approach.

More importantly, although the fbx file format supports colors on a morph target (blend shape in fbx parlance), DCC tools such as Maya, Max, and Blender do not support authoring colors as part of blend shapes. 

To make this 'feature' useful would requiring developing a tool to convert blend masks into vertex colors on the morph targets, fixing any issues in the o3de fbx pipeline to propagate those values through, and then doing a quality vs performance evaluation to determine if the color morph approach is even feasible.

With no real customer use cases or requests for this, I'm removing this unsupported feature to simplify the code.

Signed-off-by: Tommy Walton <waltont@amazon.com>