### PR TITLE
One SkinnedMesh Dispatch Per Mesh Part 2: Morph targets

### DIFF
--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
@@ -59,6 +59,9 @@ namespace AZ
             float m_minDelta;
             float m_maxDelta;
             uint32_t m_vertexCount;
+            // Each morph target dispatch is associated with a single mesh. We need to keep track of which mesh
+            // so that we can calculate the maximum range a given mesh might be morphed if all of the morph targets
+            // associated with it were active at once.
             uint32_t m_meshIndex;
         };
 

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
@@ -52,14 +52,13 @@ namespace AZ
             Data::Instance<RPI::Buffer> m_vertexDeltaBuffer;
         };
 
-        struct MorphTargetMetaData
+        struct MorphTargetComputeMetaData
         {
             float m_minWeight;
             float m_maxWeight;
             float m_minDelta;
             float m_maxDelta;
             uint32_t m_vertexCount;
-            uint32_t m_positionOffset;
         };
 
         namespace MorphTargetConstants

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/MorphTargets/MorphTargetInputBuffers.h
@@ -59,6 +59,7 @@ namespace AZ
             float m_minDelta;
             float m_maxDelta;
             uint32_t m_vertexCount;
+            uint32_t m_meshIndex;
         };
 
         namespace MorphTargetConstants

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInputBuffers.h
@@ -61,11 +61,8 @@ namespace AZ
             //! Number of influences per vertex across the sub-mesh
             uint32_t m_skinInfluenceCountPerVertex;
 
-            //! Container with one MorphTargetMetaData per morph target that can potentially be applied to an instance of this mesh
-            AZStd::vector<MorphTargetComputeMetaData> m_morphTargetComputeMetaDatas;
-
-            //! Container with one MorphTargetInputBuffers per morph target that can potentially be applied to an instance of this mesh
-            AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>> m_morphTargetInputBuffers;
+            //! See Render::ComputeMorphTargetIntegerEncoding. A negative value indicates there are no morph targets that impact this mesh
+            float m_morphTargetIntegerEncoding = -1.0f;
         };
 
         //! Container for all the buffers and views needed for a single lod of a skinned mesh
@@ -113,24 +110,26 @@ namespace AZ
 
             //! Add a single morph target that can be applied to an instance of this skinned mesh
             //! Creates a view into the larger morph target buffer to be used for applying an individual morph
-            //! @param meshIndex The mesh that this morph target should be applied to
             //! @param morphTarget The metadata that has info such as the min/max weight, offset, and vertex count for the morph
             //! @param morphBufferAssetView The view of all the morph target deltas that can be applied to this mesh
             //! @param bufferNamePrefix A prefix that can be used to identify this morph target when creating the view into the morph target buffer.
             //! @param minWeight The minimum weight that might be applied to this morph target. It's possible for the weight of a morph target to be outside the 0-1 range. Defaults to 0
             //! @param maxWeight The maximum weight that might be applied to this morph target. It's possible for the weight of a morph target to be outside the 0-1 range. 
             void AddMorphTarget(
-                uint32_t meshIndex,
                 const RPI::MorphTargetMetaAsset::MorphTarget& morphTarget,
                 const RPI::BufferAssetView* morphBufferAssetView,
                 const AZStd::string& bufferNamePrefix,
                 float minWeight,
                 float maxWeight);
+
             //! Get the MetaDatas for all the morph targets that can be applied to an instance of this skinned mesh
-            const AZStd::vector<MorphTargetComputeMetaData>& GetMorphTargetComputeMetaDatas(uint32_t meshIndex) const;
+            const AZStd::vector<MorphTargetComputeMetaData>& GetMorphTargetComputeMetaDatas() const;
 
             //! Get the MorphTargetInputBuffers for all the morph targets that can be applied to an instance of this skinned mesh
-            const AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>>& GetMorphTargetInputBuffers(uint32_t meshIndex) const;
+            const AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>>& GetMorphTargetInputBuffers() const;
+
+            //! Check if there are any morph targets that can be applied to a particular sub-mesh
+            bool HasMorphTargetsForMesh(uint32_t meshIndex) const;
 
             //! Sets the input vertex stream from an existing buffer asset.
             void SetSkinningInputBufferAsset(const Data::Asset<RPI::BufferAsset> bufferAsset, SkinnedMeshInputVertexStreams inputStream);
@@ -143,19 +142,6 @@ namespace AZ
 
             //! Calls RPI::Buffer::WaitForUpload for each buffer in the lod.
             void WaitForUpload();
-
-            struct MorphIndex
-            {
-                uint32_t m_meshIndex = 0;
-                uint32_t m_morphIndex = 0;
-            };
-
-            //! Get the order that the morph targets were added for the lod.
-            //! This is used to keep the dispatches in sync with the animation system.
-            const AZStd::vector<MorphIndex>& GetMorphTargetDispatchOrder() const
-            {
-                return m_morphDispatchOrder;
-            }
 
         private:
             RHI::BufferViewDescriptor CreateInputViewDescriptor(
@@ -175,6 +161,9 @@ namespace AZ
                 SkinnedMeshOutputVertexOffsets& currentMeshOffsetFromStreamStart);
 
             void TrackStaticBufferViews(uint32_t meshIndex);
+            
+            //! After all morph targets have been added, determine the integer encoding for each mesh.
+            void CalculateMorphTargetIntegerEncodings();
 
             //! The lod asset from the underlying mesh
             Data::Asset<RPI::ModelLodAsset> m_modelLodAsset;
@@ -201,9 +190,11 @@ namespace AZ
             Data::Asset<RPI::BufferAsset> m_indexBufferAsset;
             Data::Instance<RPI::Buffer> m_indexBuffer;
 
-            //! Keep track of the order in which morph targets were added, so that the weights coming from the animation
-            //! system will be in sync with the morph target dispatch items
-            AZStd::vector<MorphIndex> m_morphDispatchOrder;
+            //! Container with one MorphTargetMetaData per morph target that can potentially be applied to an instance of this lod
+            AZStd::vector<MorphTargetComputeMetaData> m_morphTargetComputeMetaDatas;
+
+            //! Container with one MorphTargetInputBuffers per morph target that can potentially be applied to an instance of this lod
+            AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>> m_morphTargetInputBuffers;
 
             //! Total number of indices for the entire lod
             uint32_t m_indexCount = 0;
@@ -266,23 +257,19 @@ namespace AZ
             bool IsUploadPending() const;
 
             //! Returns a vector of MorphTargetMetaData with one entry for each morph target that could be applied to this mesh
-            const AZStd::vector<MorphTargetComputeMetaData>& GetMorphTargetComputeMetaDatas(uint32_t lodIndex, uint32_t meshIndex) const
-            {
-                return m_lods[lodIndex].GetMorphTargetComputeMetaDatas(meshIndex);
-            }
-
-            const AZStd::vector<SkinnedMeshInputLod::MorphIndex>& GetMorphTargetDispatchOrder(uint32_t lodIndex) const
-            {
-                return m_lods[lodIndex].GetMorphTargetDispatchOrder();
-            }
+            const AZStd::vector<MorphTargetComputeMetaData>& GetMorphTargetComputeMetaDatas(uint32_t lodIndex) const;
 
             //! Returns a vector of MorphTargetInputBuffers which serve as input to the morph target pass
-            const AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>>& GetMorphTargetInputBuffers(uint32_t lodIndex, uint32_t meshIndex) const { return m_lods[lodIndex].GetMorphTargetInputBuffers(meshIndex); }
+            const AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>>& GetMorphTargetInputBuffers(uint32_t lodIndex) const;
+
+            //! Return the integer encoding used for the morph targets for a given lod/mesh, or -1 if there are no morph targets for the mesh.
+            //! If the values are not yet pre-calculated, they will be when calling this function
+            float GetMorphTargetIntegerEncoding(uint32_t lodIndex, uint32_t meshIndex) const;
 
             //! Add a single morph target that can be applied to an instance of this skinned mesh
             //! Creates a view into the larger morph target buffer to be used for applying an individual morph
+            //! Must call Finalize after all morph targets have been added
             //! @param lodIndex The index of the lod modified by the morph target
-            //! @param meshIndex The index of the mesh modified by the morph target
             //! @param morphTarget The metadata that has info such as the min/max weight, offset, and vertex count for the morph
             //! @param morphBufferAssetView The view of all the morph target deltas that can be applied to this mesh
             //! @param bufferNamePrefix A prefix that can be used to identify this morph target when creating the view into the morph target buffer.
@@ -290,16 +277,15 @@ namespace AZ
             //! @param maxWeight The maximum weight that might be applied to this morph target. It's possible for the weight of a morph target to be outside the 0-1 range.
             void AddMorphTarget(
                 uint32_t lodIndex,
-                uint32_t meshIndex,
                 const RPI::MorphTargetMetaAsset::MorphTarget& morphTarget,
                 const RPI::BufferAssetView* morphBufferAssetView,
                 const AZStd::string& bufferNamePrefix,
                 float minWeight,
-                float maxWeight)
-            {
-                m_lods[lodIndex].AddMorphTarget(meshIndex, morphTarget, morphBufferAssetView, bufferNamePrefix, minWeight, maxWeight);
-            }
+                float maxWeight);
 
+            //! Do any internal calculations that must be done after the input buffers are created from the model
+            //! and after all morph targets have been added
+            void Finalize();
         private:
             void CreateLod(size_t lodIndex);
             AZStd::fixed_vector<SkinnedMeshInputLod, RPI::ModelLodAsset::LodCountMax> m_lods;

--- a/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInstance.h
+++ b/Gems/Atom/Feature/Common/Code/Include/Atom/Feature/SkinnedMesh/SkinnedMeshInstance.h
@@ -45,7 +45,7 @@ namespace AZ
 
             //! Offsets into the output stream buffer to a location that contains accumulated morph target deltas from the morph pass. One offset per-lod.
             //! Set to MorphTargetConstants::s_invalidDeltaOffset if there are no morph targets for the lod
-            AZStd::vector<MorphTargetInstanceMetaData> m_morphTargetInstanceMetaData;
+            AZStd::vector<AZStd::vector<MorphTargetInstanceMetaData>> m_morphTargetInstanceMetaData;
 
             //! Typically, when a SkinnedMeshInstance goes out of scope and the memory is freed, the SkinnedMeshOutputStreamManager will signal an event indicating more memory is available
             //! If the creation of a SkinnedMeshInstance fails part way through after some memory has already been allocated,

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.cpp
@@ -26,12 +26,12 @@ namespace AZ
     {
         MorphTargetDispatchItem::MorphTargetDispatchItem(
             const AZStd::intrusive_ptr<MorphTargetInputBuffers> inputBuffers,
-            const MorphTargetMetaData& morphTargetMetaData,
+            const MorphTargetComputeMetaData& morphTargetComputeMetaData,
             SkinnedMeshFeatureProcessor* skinnedMeshFeatureProcessor,
             MorphTargetInstanceMetaData morphInstanceMetaData,
             float morphDeltaIntegerEncoding)
             : m_inputBuffers(inputBuffers)
-            , m_morphTargetMetaData(morphTargetMetaData)
+            , m_morphTargetComputeMetaData(morphTargetComputeMetaData)
             , m_morphInstanceMetaData(morphInstanceMetaData)
             , m_accumulatedDeltaIntegerEncoding(morphDeltaIntegerEncoding)
         {
@@ -86,7 +86,7 @@ namespace AZ
                 AZ_Error("MorphTargetDispatchItem", false, outcome.GetError().c_str());
             }
 
-            arguments.m_totalNumberOfThreadsX = m_morphTargetMetaData.m_vertexCount;
+            arguments.m_totalNumberOfThreadsX = m_morphTargetComputeMetaData.m_vertexCount;
             arguments.m_totalNumberOfThreadsY = 1;
             arguments.m_totalNumberOfThreadsZ = 1;
 
@@ -140,11 +140,11 @@ namespace AZ
             AZ_Error("MorphTargetDispatchItem", m_weightIndex.IsValid(), "Could not find root constant 's_weight' in the shader");
 
             m_rootConstantData = AZ::RHI::ConstantsData(rootConstantsLayout);
-            m_rootConstantData.SetConstant(minIndex, m_morphTargetMetaData.m_minDelta);
-            m_rootConstantData.SetConstant(maxIndex, m_morphTargetMetaData.m_maxDelta);
+            m_rootConstantData.SetConstant(minIndex, m_morphTargetComputeMetaData.m_minDelta);
+            m_rootConstantData.SetConstant(maxIndex, m_morphTargetComputeMetaData.m_maxDelta);
             m_rootConstantData.SetConstant(morphDeltaIntegerEncodingIndex, m_accumulatedDeltaIntegerEncoding);
             m_rootConstantData.SetConstant(m_weightIndex, 0.0f);
-            m_rootConstantData.SetConstant(vertexCountIndex, m_morphTargetMetaData.m_vertexCount);
+            m_rootConstantData.SetConstant(vertexCountIndex, m_morphTargetComputeMetaData.m_vertexCount);
             // The buffer is using 32-bit integers, so divide the offset by 4 here so it doesn't have to be done in the shader
             m_rootConstantData.SetConstant(positionOffsetIndex, m_morphInstanceMetaData.m_accumulatedPositionDeltaOffsetInBytes / 4);
             m_rootConstantData.SetConstant(normalOffsetIndex, m_morphInstanceMetaData.m_accumulatedNormalDeltaOffsetInBytes / 4);
@@ -195,12 +195,12 @@ namespace AZ
             }
         }
 
-        float ComputeMorphTargetIntegerEncoding(const AZStd::vector<MorphTargetMetaData>& morphTargetMetaDatas)
+        float ComputeMorphTargetIntegerEncoding(const AZStd::vector<MorphTargetComputeMetaData>& morphTargetComputeMetaDatas)
         {
             // The accumulation buffer must be stored as an int to support InterlockedAdd in AZSL
             // Conservatively determine the largest value, positive or negative across the entire skinned mesh lod, which is used for encoding/decoding the accumulation buffer
             float range = 0.0f;
-            for (const MorphTargetMetaData& metaData : morphTargetMetaDatas)
+            for (const MorphTargetComputeMetaData& metaData : morphTargetComputeMetaDatas)
             {
                 float maxWeight = AZStd::max(std::abs(metaData.m_minWeight), std::abs(metaData.m_maxWeight));
                 float maxDelta = AZStd::max(std::abs(metaData.m_minDelta), std::abs(metaData.m_maxDelta));

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.h
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.h
@@ -46,7 +46,7 @@ namespace AZ
             //! Create one dispatch item per morph target
             explicit MorphTargetDispatchItem(
                 const AZStd::intrusive_ptr<MorphTargetInputBuffers> inputBuffers,
-                const MorphTargetMetaData& morphTargetMetaData,
+                const MorphTargetComputeMetaData& morphTargetMetaData,
                 SkinnedMeshFeatureProcessor* skinnedMeshFeatureProcessor,
                 MorphTargetInstanceMetaData morphInstanceMetaData,
                 float accumulatedDeltaRange
@@ -83,7 +83,7 @@ namespace AZ
             Data::Instance<RPI::ShaderResourceGroup> m_instanceSrg;
 
             // Metadata used to set the root constants for the shader
-            MorphTargetMetaData m_morphTargetMetaData;
+            MorphTargetComputeMetaData m_morphTargetComputeMetaData;
 
             AZ::RHI::ConstantsData m_rootConstantData;
 
@@ -96,6 +96,6 @@ namespace AZ
             RHI::ShaderInputConstantIndex m_weightIndex;
         };
 
-        float ComputeMorphTargetIntegerEncoding(const AZStd::vector<MorphTargetMetaData>& morphTargetMetaDatas);
+        float ComputeMorphTargetIntegerEncoding(const AZStd::vector<MorphTargetComputeMetaData>& morphTargetMetaDatas);
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.h
+++ b/Gems/Atom/Feature/Common/Code/Source/MorphTargets/MorphTargetDispatchItem.h
@@ -95,7 +95,5 @@ namespace AZ
             // Keep track of the constant index of m_weight since it is updated frequently
             RHI::ShaderInputConstantIndex m_weightIndex;
         };
-
-        float ComputeMorphTargetIntegerEncoding(const AZStd::vector<MorphTargetComputeMetaData>& morphTargetMetaDatas);
     } // namespace Render
 } // namespace AZ

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshInputBuffers.cpp
@@ -378,25 +378,40 @@ namespace AZ
             }
         }
 
-        void SkinnedMeshInputLod::AddMorphTarget(const RPI::MorphTargetMetaAsset::MorphTarget& morphTarget, const Data::Asset<RPI::BufferAsset>& morphBufferAsset, const AZStd::string& bufferNamePrefix, float minWeight = 0.0f, float maxWeight = 1.0f)
+        void SkinnedMeshInputLod::AddMorphTarget(
+            uint32_t meshIndex,
+            const RPI::MorphTargetMetaAsset::MorphTarget& morphTarget,
+            const RPI::BufferAssetView* morphBufferAssetView,
+            const AZStd::string& bufferNamePrefix,
+            float minWeight = 0.0f,
+            float maxWeight = 1.0f)
         {
-            m_morphTargetMetaDatas.push_back(MorphTargetMetaData{ minWeight, maxWeight, morphTarget.m_minPositionDelta, morphTarget.m_maxPositionDelta, morphTarget.m_numVertices, morphTarget.m_startIndex });
+            m_meshes[meshIndex].m_morphTargetComputeMetaDatas.push_back(MorphTargetComputeMetaData{
+                minWeight, maxWeight, morphTarget.m_minPositionDelta, morphTarget.m_maxPositionDelta, morphTarget.m_numVertices });
             
             // Create a view into the larger per-lod morph buffer for this particular morph
-            RHI::BufferViewDescriptor morphView = RHI::BufferViewDescriptor::CreateStructured(morphTarget.m_startIndex, morphTarget.m_numVertices, sizeof(RPI::PackedCompressedMorphTargetDelta));
-            RPI::BufferAssetView morphTargetDeltaView{ morphBufferAsset, morphView };
+            // The morphTarget itself refers to an offset from within the mesh, so combine that
+            // with the mesh offset to get the view within the lod buffer
+            RHI::BufferViewDescriptor morphView = morphBufferAssetView->GetBufferViewDescriptor();
+            morphView.m_elementOffset += morphTarget.m_startIndex;
+            morphView.m_elementCount = morphTarget.m_numVertices;
+            RPI::BufferAssetView morphTargetDeltaView{ morphBufferAssetView->GetBufferAsset(), morphView };
 
-            m_morphTargetInputBuffers.push_back(aznew MorphTargetInputBuffers{ morphTargetDeltaView, bufferNamePrefix });
+            m_meshes[meshIndex].m_morphTargetInputBuffers.push_back(aznew MorphTargetInputBuffers{ morphTargetDeltaView, bufferNamePrefix });
+
+            // Keep track of the order in which the morphs were added, so that we can keep
+            // the dispatch item order in sync with the weights coming from the animation system
+            m_morphDispatchOrder.push_back(MorphIndex{ meshIndex, aznumeric_cast<uint32_t>(m_meshes[meshIndex].m_morphTargetInputBuffers.size()) - 1u });
         }
         
-        const AZStd::vector<MorphTargetMetaData>& SkinnedMeshInputLod::GetMorphTargetMetaDatas() const
+        const AZStd::vector<MorphTargetComputeMetaData>& SkinnedMeshInputLod::GetMorphTargetComputeMetaDatas(uint32_t meshIndex) const
         {
-            return m_morphTargetMetaDatas;
+            return m_meshes[meshIndex].m_morphTargetComputeMetaDatas;
         }
 
-        const AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>>& SkinnedMeshInputLod::GetMorphTargetInputBuffers() const
+        const AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>>& SkinnedMeshInputLod::GetMorphTargetInputBuffers(uint32_t meshIndex) const
         {
-            return m_morphTargetInputBuffers;
+            return m_meshes[meshIndex].m_morphTargetInputBuffers;
         }
 
         SkinnedMeshInputBuffers::SkinnedMeshInputBuffers() = default;
@@ -552,63 +567,72 @@ namespace AZ
             return true;
         }
 
-        static bool AllocateMorphTargetsForLod(const SkinnedMeshInputLod& lod, size_t vertexCount, AZStd::intrusive_ptr<SkinnedMeshInstance> instance, AZStd::vector<AZStd::intrusive_ptr<SkinnedMeshOutputStreamAllocation>>& lodAllocations)
+        static bool AllocateMorphTargetsForLod(const SkinnedMeshInputLod& lod, AZStd::intrusive_ptr<SkinnedMeshInstance> instance, AZStd::vector<AZStd::intrusive_ptr<SkinnedMeshOutputStreamAllocation>>& lodAllocations)
         {
-            // If this skinned mesh lod has morph targets, allocate a buffer for the accumulated deltas that come from the morph target pass
-            if (lod.GetMorphTargetMetaDatas().size() > 0)
+            AZStd::vector<MorphTargetInstanceMetaData> instanceMetaDatas;
+            for (uint32_t meshIndex = 0; meshIndex < lod.GetModelLodAsset()->GetMeshes().size(); ++meshIndex)
             {
-                // Naively, we're going to allocate enough memory to store the accumulated delta for every vertex.
-                // This makes it simple for the skinning shader to index into the buffer, but the memory cost
-                // could be reduced by keeping a buffer that maps from vertexId to morph target delta offset ATOM-14427
+                uint32_t vertexCount = lod.GetModelLodAsset()->GetMeshes()[meshIndex].GetVertexCount();
 
-                // We're also using the skinned mesh output buffer, since it gives us a read-write pool of memory that can be
-                // used for dependency tracking between passes. This can be switched to a transient memory pool so that the memory is free
-                // later in the frame once skinning is finished ATOM-14429
-
-                size_t perVertexSizeInBytes = static_cast<size_t>(MorphTargetConstants::s_unpackedMorphTargetDeltaSizeInBytes) * MorphTargetConstants::s_morphTargetDeltaTypeCount;
-
-                AZStd::intrusive_ptr<SkinnedMeshOutputStreamAllocation> allocation = SkinnedMeshOutputStreamManagerInterface::Get()->Allocate(vertexCount * perVertexSizeInBytes);
-                if (!allocation)
+                // If this skinned mesh has morph targets, allocate a buffer for the accumulated deltas that come from the morph target pass
+                if (!lod.GetMorphTargetComputeMetaDatas(meshIndex).empty())
                 {
-                    // Suppress the OnMemoryFreed signal when releasing the previous successful allocations
-                    // The memory was already free before this function was called, so it's not really newly available memory
-                    AZ_Error("SkinnedMeshInputBuffers", false, "Out of memory to create a skinned mesh instance. Consider increasing r_skinnedMeshInstanceMemoryPoolSize");
-                    instance->m_allocations.push_back(lodAllocations);
-                    instance->SuppressSignalOnDeallocate();
-                    return false;
+                    // Naively, we're going to allocate enough memory to store the accumulated delta for every vertex.
+                    // This makes it simple for the skinning shader to index into the buffer, but the memory cost
+                    // could be reduced by keeping a buffer that maps from vertexId to morph target delta offset ATOM-14427
+
+                    // We're also using the skinned mesh output buffer, since it gives us a read-write pool of memory that can be
+                    // used for dependency tracking between passes. This can be switched to a transient memory pool so that the memory is free
+                    // later in the frame once skinning is finished ATOM-14429
+
+                    size_t perVertexSizeInBytes = static_cast<size_t>(MorphTargetConstants::s_unpackedMorphTargetDeltaSizeInBytes) * MorphTargetConstants::s_morphTargetDeltaTypeCount;
+
+                    AZStd::intrusive_ptr<SkinnedMeshOutputStreamAllocation> allocation = SkinnedMeshOutputStreamManagerInterface::Get()->Allocate(vertexCount * perVertexSizeInBytes);
+                    if (!allocation)
+                    {
+                        // Suppress the OnMemoryFreed signal when releasing the previous successful allocations
+                        // The memory was already free before this function was called, so it's not really newly available memory
+                        AZ_Error("SkinnedMeshInputBuffers", false, "Out of memory to create a skinned mesh instance. Consider increasing r_skinnedMeshInstanceMemoryPoolSize");
+                        instance->m_allocations.push_back(lodAllocations);
+                        instance->SuppressSignalOnDeallocate();
+                        return false;
+                    }
+                    else
+                    {
+                        // We're using an offset into a global buffer to be able to access the morph target offsets in a bindless manner.
+                        // The offset can at most be a 32-bit uint until AZSL supports 64-bit uints. This gives us a 4GB limit for where the
+                        // morph target deltas can live. In practice, the offsets could end up outside that range even if less that 4GB is used
+                        // if the memory becomes fragmented. To address it, we can split morph target deltas into their own buffer, allocate
+                        // memory in pages with a buffer for each page, or create and bind a buffer view
+                        // so we are not doing an offset from the beginning of the buffer
+                        AZ_Error("SkinnedMeshInputBuffers", allocation->GetVirtualAddress().m_ptr < static_cast<uintptr_t>(std::numeric_limits<uint32_t>::max()), "Morph target deltas allocated from the skinned mesh memory pool are outside the range that can be accessed from the skinning shader");
+
+                        MorphTargetInstanceMetaData instanceMetaData;
+
+                        // Positions start at the beginning of the allocation
+                        instanceMetaData.m_accumulatedPositionDeltaOffsetInBytes = static_cast<int32_t>(allocation->GetVirtualAddress().m_ptr);
+                        uint32_t deltaStreamSizeInBytes = static_cast<uint32_t>(vertexCount * MorphTargetConstants::s_unpackedMorphTargetDeltaSizeInBytes);
+
+                        // Followed by normals, tangents, and bitangents
+                        instanceMetaData.m_accumulatedNormalDeltaOffsetInBytes = instanceMetaData.m_accumulatedPositionDeltaOffsetInBytes + deltaStreamSizeInBytes;
+                        instanceMetaData.m_accumulatedTangentDeltaOffsetInBytes = instanceMetaData.m_accumulatedNormalDeltaOffsetInBytes + deltaStreamSizeInBytes;
+                        instanceMetaData.m_accumulatedBitangentDeltaOffsetInBytes = instanceMetaData.m_accumulatedTangentDeltaOffsetInBytes + deltaStreamSizeInBytes;
+
+                        // Track both the allocation and the metadata in the instance
+                        instanceMetaDatas.push_back(instanceMetaData);
+                        lodAllocations.push_back(allocation);
+                    }
                 }
                 else
                 {
-                    // We're using an offset into a global buffer to be able to access the morph target offsets in a bindless manner.
-                    // The offset can at most be a 32-bit uint until AZSL supports 64-bit uints. This gives us a 4GB limit for where the
-                    // morph target deltas can live. In practice, the offsets could end up outside that range even if less that 4GB is used
-                    // if the memory becomes fragmented. To address it, we can split morph target deltas into their own buffer, allocate
-                    // memory in pages with a buffer for each page, or create and bind a buffer view
-                    // so we are not doing an offset from the beginning of the buffer
-                    AZ_Error("SkinnedMeshInputBuffers", allocation->GetVirtualAddress().m_ptr < static_cast<uintptr_t>(std::numeric_limits<uint32_t>::max()), "Morph target deltas allocated from the skinned mesh memory pool are outside the range that can be accessed from the skinning shader");
-
-                    MorphTargetInstanceMetaData instanceMetaData;
-
-                    // Positions start at the beginning of the allocation
-                    instanceMetaData.m_accumulatedPositionDeltaOffsetInBytes = static_cast<int32_t>(allocation->GetVirtualAddress().m_ptr);
-                    uint32_t deltaStreamSizeInBytes = static_cast<uint32_t>(vertexCount * MorphTargetConstants::s_unpackedMorphTargetDeltaSizeInBytes);
-
-                    // Followed by normals, tangents, and bitangents
-                    instanceMetaData.m_accumulatedNormalDeltaOffsetInBytes = instanceMetaData.m_accumulatedPositionDeltaOffsetInBytes + deltaStreamSizeInBytes;
-                    instanceMetaData.m_accumulatedTangentDeltaOffsetInBytes = instanceMetaData.m_accumulatedNormalDeltaOffsetInBytes + deltaStreamSizeInBytes;
-                    instanceMetaData.m_accumulatedBitangentDeltaOffsetInBytes = instanceMetaData.m_accumulatedTangentDeltaOffsetInBytes + deltaStreamSizeInBytes;
-
-                    // Track both the allocation and the metadata in the instance
-                    instance->m_morphTargetInstanceMetaData.push_back(instanceMetaData);
-                    lodAllocations.push_back(allocation);
+                    // Use invalid offsets to indicate there are no morph targets for this mesh
+                    // This allows the SkinnedMeshDispatchItem to know it doesn't need to consume morph target deltas during skinning.
+                    MorphTargetInstanceMetaData instanceMetaData{ MorphTargetConstants::s_invalidDeltaOffset, MorphTargetConstants::s_invalidDeltaOffset, MorphTargetConstants::s_invalidDeltaOffset, MorphTargetConstants::s_invalidDeltaOffset };
+                    instanceMetaDatas.push_back(instanceMetaData);
                 }
             }
-            else
-            {
-                // No morph targets for this lod
-                MorphTargetInstanceMetaData instanceMetaData{ MorphTargetConstants::s_invalidDeltaOffset, MorphTargetConstants::s_invalidDeltaOffset, MorphTargetConstants::s_invalidDeltaOffset, MorphTargetConstants::s_invalidDeltaOffset };
-                instance->m_morphTargetInstanceMetaData.push_back(instanceMetaData);
-            }
+
+            instance->m_morphTargetInstanceMetaData.push_back(instanceMetaDatas);
 
             return true;
         }
@@ -718,7 +742,7 @@ namespace AZ
                     }
                 }
 
-                if (!AllocateMorphTargetsForLod(lod, lod.m_vertexCount, instance, lodAllocations))
+                if (!AllocateMorphTargetsForLod(lod, instance, lodAllocations))
                 {
                     return nullptr;
                 }

--- a/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshRenderProxy.cpp
+++ b/Gems/Atom/Feature/Common/Code/Source/SkinnedMesh/SkinnedMeshRenderProxy.cpp
@@ -53,6 +53,41 @@ namespace AZ
             return true;
         }
 
+        static AZStd::vector<float> CalculateMorphTargetIntegerEncodingsForLod(uint32_t modelLodIndex, Data::Instance<SkinnedMeshInputBuffers> skinnedMeshInputBuffers)
+        {
+            uint32_t meshCount = skinnedMeshInputBuffers->GetMeshCount(modelLodIndex);
+            AZStd::vector<float> morphDeltaIntegerEncodings;
+            morphDeltaIntegerEncodings.reserve(meshCount);
+
+            for (uint32_t meshIndex = 0; meshIndex < meshCount; ++meshIndex)
+            {
+                // Get the value needed for encoding/decoding floats as integers when passing them
+                // from the morph target pass to the skinning pass.
+                // Integer encoding is used so that AZSL's InterlockedAdd can be used, which only supports int/uint
+                const AZStd::vector<MorphTargetComputeMetaData>& morphTargetComputeMetaDatas =
+                    skinnedMeshInputBuffers->GetMorphTargetComputeMetaDatas(modelLodIndex, meshIndex);
+
+                // Verify the morph targets were created correctly for this mesh
+                // With an equal number of metadatas and input buffers
+                const AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>>& morphTargetInputBuffersVector =
+                    skinnedMeshInputBuffers->GetMorphTargetInputBuffers(modelLodIndex, meshIndex);
+                AZ_Assert(
+                    morphTargetComputeMetaDatas.size() == morphTargetInputBuffersVector.size(),
+                    "Skinned Mesh Feature Processor - Mismatch in morph target metadata count and morph target input buffer count");
+
+                float morphDeltaIntegerEncoding = 0.0f;
+                if (morphTargetComputeMetaDatas.size() > 0)
+                {
+                    morphDeltaIntegerEncoding = ComputeMorphTargetIntegerEncoding(morphTargetComputeMetaDatas);
+                }
+
+                // Keep track of the integer encoding for this mesh, so it can be used when adding morph targets later
+                morphDeltaIntegerEncodings.push_back(morphDeltaIntegerEncoding);
+            }
+
+            return morphDeltaIntegerEncodings;
+        }
+
         bool SkinnedMeshRenderProxy::BuildDispatchItem([[maybe_unused]] const RPI::Scene& scene, uint32_t modelLodIndex, [[maybe_unused]] const SkinnedMeshShaderOptions& shaderOptions)
         {
             Data::Instance<RPI::Shader> skinningShader = m_featureProcessor->GetSkinningShader();
@@ -74,36 +109,11 @@ namespace AZ
             m_dispatchItemsByLod.emplace_back(AZStd::vector<AZStd::unique_ptr<SkinnedMeshDispatchItem>>());
             m_morphTargetDispatchItemsByLod.emplace_back(AZStd::vector<AZStd::unique_ptr<MorphTargetDispatchItem>>());
 
-            uint32_t meshCount = m_inputBuffers->GetMeshCount(modelLodIndex);
-            AZStd::vector<float> morphDeltaIntegerEncodings;
-            morphDeltaIntegerEncodings.reserve(meshCount);
+            AZStd::vector<float> morphDeltaIntegerEncodings = CalculateMorphTargetIntegerEncodingsForLod(modelLodIndex, m_inputBuffers);
 
             // Populate the vector with a dispatch item for each mesh
-            for (uint32_t meshIndex = 0; meshIndex < meshCount; ++meshIndex)
+            for (uint32_t meshIndex = 0; meshIndex < m_inputBuffers->GetMeshCount(modelLodIndex); ++meshIndex)
             {
-                // Get the value needed for encoding/decoding floats as integers when passing them
-                // from the morph target pass to the skinning pass.
-                // Integer encoding is used so that AZSL's InterlockedAdd can be used, which only supports int/uint
-                const AZStd::vector<MorphTargetComputeMetaData>& morphTargetComputeMetaDatas =
-                    m_inputBuffers->GetMorphTargetComputeMetaDatas(modelLodIndex, meshIndex);
-                    
-                // Verify the morph targets were created correctly for this mesh
-                // With an equal number of metadatas and input buffers
-                const AZStd::vector<AZStd::intrusive_ptr<MorphTargetInputBuffers>>& morphTargetInputBuffersVector =
-                    m_inputBuffers->GetMorphTargetInputBuffers(modelLodIndex, meshIndex);
-                AZ_Assert(
-                    morphTargetComputeMetaDatas.size() == morphTargetInputBuffersVector.size(),
-                    "Skinned Mesh Feature Processor - Mismatch in morph target metadata count and morph target input buffer count");
-                    
-                float morphDeltaIntegerEncoding = 0.0f;
-                if (morphTargetComputeMetaDatas.size() > 0)
-                {
-                    morphDeltaIntegerEncoding = ComputeMorphTargetIntegerEncoding(morphTargetComputeMetaDatas);
-                }
-                
-                // Keep track of the integer encoding for this mesh, so it can be used when adding morph targets later
-                morphDeltaIntegerEncodings.push_back(morphDeltaIntegerEncoding);
-
                 // Create the skinning dispatch Item
                 m_dispatchItemsByLod[modelLodIndex].emplace_back(
                     aznew SkinnedMeshDispatchItem{
@@ -114,16 +124,24 @@ namespace AZ
                         m_shaderOptions,
                         m_featureProcessor,
                         m_instance->m_morphTargetInstanceMetaData[modelLodIndex][meshIndex],
-                        morphDeltaIntegerEncoding });
-
-                
+                        morphDeltaIntegerEncodings[meshIndex] });
             }
 
+            AZ_Assert(m_dispatchItemsByLod.size() == modelLodIndex + 1, "Skinned Mesh Feature Processor - Mismatch in size between the fixed vector of dispatch items and the lod being initialized");
+            for (uint32_t meshIndex = 0; meshIndex < m_inputBuffers->GetMeshCount(modelLodIndex); ++meshIndex)
+            {
+                if (!m_dispatchItemsByLod[modelLodIndex][meshIndex]->Init())
+                {
+                    return false;
+                }
+            }
+            
             // Now loop over the morph targets create the morph target dispatch items
             const AZStd::vector<SkinnedMeshInputLod::MorphIndex>& morphTargetDispatchItemOrder =
                 m_inputBuffers->GetMorphTargetDispatchOrder(modelLodIndex);
 
-            // Create one dispatch item per morph target
+            // Create one dispatch item per morph target, in the order that they were originally added
+            // to the skinned mesh to stay in sync with the animation system
             for (const SkinnedMeshInputLod::MorphIndex& morphTargetIndex : morphTargetDispatchItemOrder)
             {
                 m_morphTargetDispatchItemsByLod[modelLodIndex].emplace_back(aznew MorphTargetDispatchItem{
@@ -139,16 +157,6 @@ namespace AZ
                     return false;
                 }
             }
-
-            AZ_Assert(m_dispatchItemsByLod.size() == modelLodIndex + 1, "Skinned Mesh Feature Processor - Mismatch in size between the fixed vector of dispatch items and the lod being initialized");
-            for (uint32_t meshIndex = 0; meshIndex < m_inputBuffers->GetMeshCount(modelLodIndex); ++meshIndex)
-            {
-                if (!m_dispatchItemsByLod[modelLodIndex][meshIndex]->Init())
-                {
-                    return false;
-                }
-            }
-
             
             return true;
         }

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h
@@ -38,8 +38,12 @@ namespace AZ::RPI
         {
             AZ_TYPE_INFO(MorphTargetMetaAsset::MorphTarget, "{13AA0784-26EE-48D4-9418-691B693716B1}")
 
-            AZStd::string m_meshNodeName; /**< The name of the mesh we are referring to. */
+            AZStd::string m_meshNodeName; /**< The name of the mesh we are referring to. One morph target may refer to multiple meshes.*/
             AZStd::string m_morphTargetName; /**< The name of the morph target we are referring to. */
+
+            // !The index of the sub-mesh impacted by this morph target.
+            // !There may be multiple MorphTarget objects which all refer to the same animation, linked by m_morphTargetName. 
+            uint32_t m_meshIndex;
 
             //! All vertex deltas for all meshes and for all morph targets are stored in a giant buffer.
             //! This indicates the start index for the deform deltas for the given mesh and morph target.

--- a/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h
+++ b/Gems/Atom/RPI/Code/Include/Atom/RPI.Reflect/Model/MorphTargetMetaAsset.h
@@ -42,7 +42,7 @@ namespace AZ::RPI
             AZStd::string m_morphTargetName; /**< The name of the morph target we are referring to. */
 
             // !The index of the sub-mesh impacted by this morph target.
-            // !There may be multiple MorphTarget objects which all refer to the same animation, linked by m_morphTargetName. 
+            // !There may be multiple MorphTarget objects which all refer to different meshes for the same animation, linked by m_morphTargetName.
             uint32_t m_meshIndex;
 
             //! All vertex deltas for all meshes and for all morph targets are stored in a giant buffer.

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
@@ -61,8 +61,11 @@ namespace AZ::RPI
         return result;
     }
 
-    void MorphTargetExporter::ProduceMorphTargets(const Containers::Scene& scene,
-        uint32_t vertexOffset,
+    void MorphTargetExporter::ProduceMorphTargets(
+        uint32_t productMeshIndex,
+        uint32_t startVertex,
+        const AZStd::map<uint32_t, uint32_t>& oldToNewIndicesMap,
+        const Containers::Scene& scene,
         const ModelAssetBuilderComponent::SourceMeshContent& sourceMesh,
         ModelAssetBuilderComponent::ProductMeshContent& productMesh,
         MorphTargetMetaAssetCreator& metaAssetCreator,
@@ -96,7 +99,9 @@ namespace AZ::RPI
                         AZ_STRING_ARG(sourceMeshName), AZ_STRING_ARG(baseMeshName));
 
                     const DataTypes::MatrixType globalTransform = Utilities::BuildWorldTransform(sceneGraph, sceneNodeIndex);
-                    BuildMorphTargetMesh(vertexOffset, sourceMesh, productMesh, metaAssetCreator, blendShapeName, blendShapeData, globalTransform, coordSysConverter, scene.GetSourceFilename());
+                    BuildMorphTargetMesh(
+                        productMeshIndex, startVertex, oldToNewIndicesMap, sourceMesh, productMesh, metaAssetCreator, blendShapeName, blendShapeData, globalTransform,
+                        coordSysConverter, scene.GetSourceFilename());
                 }
             }
         }
@@ -132,7 +137,10 @@ namespace AZ::RPI
         return static_cast<StorageType>((value - minValue) * f);
     };
 
-    void MorphTargetExporter::BuildMorphTargetMesh(uint32_t vertexOffset,
+    void MorphTargetExporter::BuildMorphTargetMesh(
+        uint32_t productMeshIndex,
+        uint32_t startVertex,
+        const AZStd::map<uint32_t, uint32_t>& oldToNewIndicesMap,
         const ModelAssetBuilderComponent::SourceMeshContent& sourceMesh,
         ModelAssetBuilderComponent::ProductMeshContent& productMesh,
         MorphTargetMetaAssetCreator& metaAssetCreator,
@@ -150,10 +158,17 @@ namespace AZ::RPI
         MorphTargetMetaAsset::MorphTarget metaData;
         metaData.m_meshNodeName = sourceMesh.m_name.GetStringView();
         metaData.m_morphTargetName = blendShapeName;
+        metaData.m_meshIndex = productMeshIndex;
+        // The start index is after any previously added deltas from other morph targets
+        // that are part of the same product mesh
+        metaData.m_startIndex = aznumeric_cast<uint32_t>(packedCompressedMorphTargetVertexData.size());
 
         // Determine the vertex index range for the morph target.
-        const uint32_t numVertices = blendShapeData->GetVertexCount();
-        if (blendShapeData->GetVertexCount() != sourceMesh.m_meshData->GetVertexCount())
+        // Ignore any vertices that are associated with a later product mesh
+        uint32_t endVertex = startVertex + aznumeric_cast<uint32_t>(productMesh.m_positions.size() / 3);
+        const uint32_t numVertices = endVertex - startVertex;
+        if (blendShapeData->GetVertexCount() != sourceMesh.m_meshData->GetVertexCount()
+            || blendShapeData->GetVertexCount() < endVertex)
         {
             AZ_Error(ModelAssetBuilderComponent::s_builderName, false,
                 "Skipping blend shape (%s) as it contains more/less vertices (%d) than the neutral mesh (%d). "
@@ -161,10 +176,6 @@ namespace AZ::RPI
                 blendShapeName.c_str(), numVertices, sourceMesh.m_meshData->GetVertexCount());
             return;
         }
-
-        // The start index is after any previously added deltas
-        metaData.m_startIndex = aznumeric_cast<uint32_t>(packedCompressedMorphTargetVertexData.size());
-
 
         // Multiply normal by inverse transpose to avoid incorrect values produced by non-uniformly scaled transforms.
         DataTypes::MatrixType globalTransformN = globalTransform.GetInverseFull().GetTranspose();
@@ -177,7 +188,8 @@ namespace AZ::RPI
         compressedDeltas.reserve(numVertices);
 
         uint32_t numMorphedVertices = 0;
-        for (uint32_t vertexIndex = 0; vertexIndex < numVertices; ++vertexIndex)
+
+        for (uint32_t vertexIndex = startVertex; vertexIndex < endVertex; ++vertexIndex)
         {
             AZ::Vector3 targetPosition = blendShapeData->GetPosition(vertexIndex);
             targetPosition = globalTransform * targetPosition;
@@ -196,7 +208,15 @@ namespace AZ::RPI
                 RPI::CompressedMorphTargetDelta& currentDelta = compressedDeltas.back();
 
                 // Set the morphed index
-                currentDelta.m_morphedVertexIndex = vertexIndex + vertexOffset;
+                const auto& iter = oldToNewIndicesMap.find(vertexIndex);
+                if (iter != oldToNewIndicesMap.end())
+                {
+                    currentDelta.m_morphedVertexIndex = iter->second;
+                }
+                else
+                {
+                    AZ_Assert(false, "%s: Attempting to add a morph target that influences a vertex that is not part of the current mesh.", ModelAssetBuilderComponent::s_builderName);
+                }
 
                 const AZ::Vector3 deltaPosition = targetPosition - neutralPosition;
                 deltaPositionAabb.AddPoint(deltaPosition);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.cpp
@@ -165,8 +165,9 @@ namespace AZ::RPI
 
         // Determine the vertex index range for the morph target.
         // Ignore any vertices that are associated with a later product mesh
-        uint32_t endVertex = startVertex + aznumeric_cast<uint32_t>(productMesh.m_positions.size() / 3);
-        const uint32_t numVertices = endVertex - startVertex;
+        uint32_t numVertices = aznumeric_cast<uint32_t>(productMesh.m_positions.size() / 3);
+        uint32_t endVertex = startVertex + numVertices;
+
         if (blendShapeData->GetVertexCount() != sourceMesh.m_meshData->GetVertexCount()
             || blendShapeData->GetVertexCount() < endVertex)
         {

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/MorphTargetExporter.h
@@ -24,8 +24,11 @@ namespace AZ
         public:
             AZ_RTTI(MorphTargetExporter, "{A684EBE7-03A2-4877-B6F7-83FC0029CC38}");
 
-            void ProduceMorphTargets(const AZ::SceneAPI::Containers::Scene& scene,
-                uint32_t vertexOffset,
+            void ProduceMorphTargets(
+                uint32_t productMeshIndex,
+                uint32_t startVertex,
+                const AZStd::map<uint32_t, uint32_t>& oldToNewIndicesMap,
+                const AZ::SceneAPI::Containers::Scene& scene,
                 const ModelAssetBuilderComponent::SourceMeshContent& sourceMesh,
                 ModelAssetBuilderComponent::ProductMeshContent& productMesh,
                 MorphTargetMetaAssetCreator& metaAssetCreator,
@@ -50,7 +53,10 @@ namespace AZ
             static StorageType Compress(float value, float minValue, float maxValue);
 
             // Extract the morph target vertex and meta data and save it into the product mesh content.
-            void BuildMorphTargetMesh(uint32_t vertexOffset,
+            void BuildMorphTargetMesh(
+                uint32_t productMeshIndex,
+                uint32_t startVertex,
+                const AZStd::map<uint32_t, uint32_t>& oldToNewIndicesMap,
                 const ModelAssetBuilderComponent::SourceMeshContent& sourceMesh,
                 ModelAssetBuilderComponent::ProductMeshContent& productMesh,
                 MorphTargetMetaAssetCreator& metaAssetCreator,

--- a/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/MorphTargetMetaAsset.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Reflect/Model/MorphTargetMetaAsset.cpp
@@ -26,6 +26,7 @@ namespace AZ::RPI
                 ->Field("minPositionDelta", &MorphTargetMetaAsset::MorphTarget::m_minPositionDelta)
                 ->Field("maxPositionDelta", &MorphTargetMetaAsset::MorphTarget::m_maxPositionDelta)
                 ->Field("wrinkleMask", &MorphTargetMetaAsset::MorphTarget::m_wrinkleMask)
+                ->Field("meshIndex", &MorphTargetMetaAsset::MorphTarget::m_meshIndex)
                 ;
         }
     }

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -170,7 +170,7 @@ namespace AZ
                                 modelLodMesh.GetSemanticBufferAssetView(Name{ "MORPHTARGET_VERTEXDELTAS" });
 
                             skinnedMeshInputBuffers->AddMorphTarget(
-                                lodIndex, metaData.m_meshIndex, metaData, morphBufferAssetView, morphString, minWeight, maxWeight);
+                                lodIndex, metaData, morphBufferAssetView, morphString, minWeight, maxWeight);
                         }
                     }
                 }
@@ -308,6 +308,7 @@ namespace AZ
                 ProcessMorphsForLod(lodIndex, actor, fullFileName, skinnedMeshInputBuffers);
             } // for all lods
 
+            skinnedMeshInputBuffers->Finalize();
             return skinnedMeshInputBuffers;
         }
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -130,11 +130,17 @@ namespace AZ
             }
         }
         
-        static void ProcessMorphsForLod(const EMotionFX::Actor* actor, [[maybe_unused]]const Data::Asset<RPI::BufferAsset>& morphBufferAsset, uint32_t lodIndex, const AZStd::string& fullFileName, [[maybe_unused]]const SkinnedMeshInputLod& skinnedMeshLod)
+        static void ProcessMorphsForLod(
+            uint32_t lodIndex,
+            const EMotionFX::Actor* actor,
+            const AZStd::string& fullFileName,
+            AZStd::intrusive_ptr<SkinnedMeshInputBuffers> skinnedMeshInputBuffers)
         {
             EMotionFX::MorphSetup* morphSetup = actor->GetMorphSetup(lodIndex);
             if (morphSetup)
             {
+                const auto& modelLodAsset = skinnedMeshInputBuffers->GetLod(lodIndex).GetModelLodAsset();
+
                 AZ_Assert(actor->GetMorphTargetMetaAsset().IsReady(), "Trying to create morph targets from actor '%s', but the MorphTargetMetaAsset isn't loaded.", actor->GetName());
                 const AZStd::vector<AZ::RPI::MorphTargetMetaAsset::MorphTarget>& metaDatas = actor->GetMorphTargetMetaAsset()->GetMorphTargets();
 
@@ -145,7 +151,8 @@ namespace AZ
                     EMotionFX::MorphTargetStandard* morphTarget = static_cast<EMotionFX::MorphTargetStandard*>(morphSetup->GetMorphTarget(morphTargetIndex));
                     for (const auto& metaData : metaDatas)
                     {
-                        // Loop through the metadatas to find the one that corresponds with the current morph target
+                        // Loop through the metadatas to find any that correspond with the current morph target.
+                        // There may be more than one, since a single morph target may be distributed across multiple meshes.
                         // This ensures the order stays in sync with the order in the MorphSetup,
                         // so that the correct weights are applied to the correct morphs later
                         // Skip any that don't modify any vertices
@@ -154,10 +161,16 @@ namespace AZ
                             // The skinned mesh lod gets a unique morph for each meta, since each one has unique min/max delta values to use for decompression
                             const AZStd::string morphString = AZStd::string::format("%s_Lod%zu_Morph_%s", fullFileName.c_str(), lodIndex, metaData.m_meshNodeName.c_str());
 
-                            [[maybe_unused]]float minWeight = morphTarget->GetRangeMin();
-                            [[maybe_unused]]float maxWeight = morphTarget->GetRangeMax();
+                            float minWeight = morphTarget->GetRangeMin();
+                            float maxWeight = morphTarget->GetRangeMax();
 
-                            //skinnedMeshLod.AddMorphTarget(metaData, morphBufferAsset, morphString, minWeight, maxWeight);
+                            const auto& modelLodMesh = modelLodAsset->GetMeshes()[metaData.m_meshIndex];
+
+                            const RPI::BufferAssetView* morphBufferAssetView =
+                                modelLodMesh.GetSemanticBufferAssetView(Name{ "MORPHTARGET_VERTEXDELTAS" });
+
+                            skinnedMeshInputBuffers->AddMorphTarget(
+                                lodIndex, metaData.m_meshIndex, metaData, morphBufferAssetView, morphString, minWeight, maxWeight);
                         }
                     }
                 }
@@ -247,7 +260,6 @@ namespace AZ
 
                 const RPI::BufferAssetView* jointIndicesBufferView = nullptr;
                 const RPI::BufferAssetView* skinWeightsBufferView = nullptr;
-                const RPI::BufferAssetView* morphBufferAssetView = nullptr;
 
                 for (const auto& modelLodMesh : modelLodAsset->GetMeshes())
                 {
@@ -263,12 +275,6 @@ namespace AZ
                             AZ_Error("CreateSkinnedMeshInputFromActor", skinWeightsBufferView, "Mesh '%s' on actor '%s' has joint indices but no joint weights", modelLodMesh.GetName().GetCStr(), fullFileName.c_str());
                             break;
                         }
-                    }
-
-                    // If the morph target buffer hasn't been found on a mesh yet, keep looking
-                    if (!morphBufferAssetView)
-                    {
-                        morphBufferAssetView = modelLodMesh.GetSemanticBufferAssetView(Name{ "MORPHTARGET_VERTEXDELTAS" });
                     }
                 }
 
@@ -299,10 +305,7 @@ namespace AZ
                     }
                 }
 
-                if (morphBufferAssetView)
-                {
-                    ProcessMorphsForLod(actor, morphBufferAssetView->GetBufferAsset(), static_cast<uint32_t>(lodIndex), fullFileName, skinnedMeshLod);
-                }
+                ProcessMorphsForLod(lodIndex, actor, fullFileName, skinnedMeshInputBuffers);
             } // for all lods
 
             return skinnedMeshInputBuffers;

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/AtomActorInstance.cpp
@@ -557,7 +557,7 @@ namespace AZ::Render
                         EMotionFX::MorphSetupInstance::MorphTarget* morphTargetSetupInstance = m_actorInstance->GetMorphSetupInstance()->FindMorphTargetByID(morphTargetStandard->GetID());
 
                         // Each morph target is split into several deform datas, all of which share the same weight but have unique min/max delta values
-                        // and thus correspond with unique dispatches in the morph target pass
+                        // and impact a unique mesh and thus correspond with unique dispatches in the morph target pass
                         for (size_t deformDataIndex = 0; deformDataIndex < morphTargetStandard->GetNumDeformDatas(); ++deformDataIndex)
                         {
                             // Morph targets that don't deform any vertices (e.g. joint-based morph targets) are not registered in the render proxy. Skip adding their weights.


### PR DESCRIPTION
This builds upon the one dispatch per mesh change for skinned meshes to add back support for morph targets. It also fixes a long standing bug where morph targets would not work if they covered more than one mesh. https://github.com/o3de/o3de/issues/3037

Previously, an intermediate buffer the size of the entire lod for the model was created to accumulate deltas from the morph target pass to be applied in the skinned mesh pass. Now, the multiple smaller intermediate buffers are created, and only for meshes that might actually be modified by a morph target, which can represent a significant memory savings for large models that only use morph targets for facial animation (which is pretty common).

Previously, one MorphTargetMetaAsset::MorphTarget was created per 'source mesh' in the builder. But each source mesh might be split into multiple 'product meshes' if there are multiple materials on the mesh. Now, there is one MorphTargetMetaAsset::MorphTarget per 'product mesh', where a product mesh corresponds to an Atom sub-mesh. This still corresponds to a single controllable morph target animation in the animation editor, it is just split into multiple MorphTargetStandard::DeformData's (in emfx parlance) which corresponds to multiple MorphTargetDispatchItem's (in Atom parlance).

The morph target exporter is now also accounting for the vertex re-mapping that is done in the Atom model builder.

I also re-named MorphTargetMetaData to MorphTargetComputeMetaData to differentiate the metadata needed for the compute shader from the MorphTragetMetaAsset::MorphTarget, which are related but not the same.

I tested with a new simplified asset I created to debug the issue with morph targets spread across multiple sub-meshes, as well as with some customer models.

ASV tests pass, with the exception of a known spotlight banding screenshot failure
![ASVResults](https://user-images.githubusercontent.com/82672795/156454010-ee0ea4d7-e2aa-4ab7-887c-dfce0c8d2622.PNG)

