### PR TITLE
Support varying influence counts per mesh

### DIFF
--- a/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.azsl
+++ b/Gems/Atom/Feature/Common/Assets/Shaders/SkinnedMesh/LinearSkinningCS.azsl
@@ -101,9 +101,7 @@ void GetInfluences(in uint weightStartOffsetForVertex, in uint jointIdStartOffse
     // Two indices, 16-bits each, stored in a 32-bit uint
     uint rawIndex = InstanceSrg::m_sourceBlendIndices.Load(jointIdStartOffsetForVertex + influenceIndex);
         
-    // Although the first index in each 32-bit pair is in the most significant bits in the cpu buffer,
-    // the indices get swapped within the 32-bit uint when they are loaded so we treat them
-    // as if the first (even) indices are is in the least significant bits
+    // The first index in each 32-bit pair is in the most significant bits in the buffer
     jointIds.x = rawIndex >> 16 & 0x0000FFFF;
     jointIds.y = rawIndex & 0x0000FFFF;
 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -958,7 +958,7 @@ namespace AZ
 
                         const float weight = link.weight;
 
-                        if (weight > m_skinRuleSettings.m_skinWeightThreshold)
+                        if (weight > m_skinRuleSettings.m_weightThreshold)
                         {
                             influenceCountPerVertex[influenceCountIndex]++;
                         }
@@ -1024,6 +1024,7 @@ namespace AZ
 
                     // Add skin influence
                     if (weight > m_skinRuleSettings.m_weightThreshold)
+                    {
                         if (numInfluencesAdded < productMesh.m_influencesPerVertex)
                         {
                             skinJointIndices.push_back(jointIndex);

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.cpp
@@ -774,6 +774,13 @@ namespace AZ
                             bitangents.resize(vertexCount * BitangentFloatsPerVert, 1.0f);
                             AZ_Warning(s_builderName, false, "Mesh '%s' is missing bitangents and no defaults were generated. Skinned meshes require bitangents. Dummy bitangents will be inserted, which may result in rendering artifacts.", sourceMesh.m_name.GetCStr());
                         }
+
+                        CalculateMaxUsedSkinInfluencesPerVertex(
+                            sourceMesh, productMesh, oldToNewIndices, warnedExcessOfSkinInfluences);
+
+                        uint32_t totalInfluences = productMesh.m_influencesPerVertex * aznumeric_cast<uint32_t>(vertexCount);
+                        productMesh.m_skinJointIndices.reserve(totalInfluences + CalculateJointIdPaddingCount(totalInfluences));
+                        productMesh.m_skinWeights.reserve(totalInfluences);
                     }
 
                     for (const auto& itr : oldToNewIndices)
@@ -876,7 +883,7 @@ namespace AZ
                         if (hasSkinData)
                         {
                             // Warn about excess of skin influences once per-source mesh.
-                            GatherVertexSkinningInfluences(sourceMesh, productMesh, jointNameToIndexMap, oldIndex, warnedExcessOfSkinInfluences);
+                            GatherVertexSkinningInfluences(sourceMesh, productMesh, jointNameToIndexMap, oldIndex);
                         }
                     }// for each vertex in old to new indices
 
@@ -925,12 +932,72 @@ namespace AZ
             }
         }
 
+        void ModelAssetBuilderComponent::CalculateMaxUsedSkinInfluencesPerVertex(
+            const SourceMeshContent& sourceMesh,
+            ProductMeshContent& productMesh,
+            const AZStd::map<uint32_t, uint32_t>& oldToNewIndicesMap,
+            bool& warnedExcessOfSkinInfluences) const
+        {
+            size_t vertexCount = oldToNewIndicesMap.size();
+            AZStd::vector<uint32_t> influenceCountPerVertex(vertexCount, 0);
+
+            for (const auto& skinData : sourceMesh.m_skinData)
+            {
+                // The old and new indices are a subset of the total indices across the source mesh
+                // that represent the indices which are used by a particular product mesh (submesh)
+                // Since neither of those are in the range of 0->vertexCount, we track another index for influenceCountPerVertex
+                size_t influenceCountIndex = 0;
+                for (const auto& [oldIndex, newIndex] : oldToNewIndicesMap)
+                {
+                    const size_t numSkinInfluences = skinData->GetLinkCount(oldIndex);
+
+                    // Check all the links and add any with a weight over the threshold to the running count
+                    for (size_t influenceIndex = 0; influenceIndex < numSkinInfluences; ++influenceIndex)
+                    {
+                        const AZ::SceneAPI::DataTypes::ISkinWeightData::Link& link = skinData->GetLink(oldIndex, influenceIndex);
+
+                        const float weight = link.weight;
+
+                        if (weight > m_skinRuleSettings.m_skinWeightThreshold)
+                        {
+                            influenceCountPerVertex[influenceCountIndex]++;
+                        }
+                    }
+
+                    influenceCountIndex++;
+                }
+            }
+
+            // Now do a pass over the counts to see what the maximum influences actually needed for this mesh is
+            uint32_t influencesPerVertex = 0;
+            for (const uint32_t& influenceCount : influenceCountPerVertex)
+            {
+                influencesPerVertex = AZStd::max(influencesPerVertex, influenceCount);
+            }
+
+            if (influencesPerVertex > m_skinRuleSettings.m_maxInfluencesPerVertex)
+            {
+                AZ_Warning(
+                    s_builderName, warnedExcessOfSkinInfluences,
+                    "Mesh %s has more skin influences (%d) than the maximum (%d). Skinning influences won't be normalized. "
+                    "It's also not guaranteed that the excess skin influences that are cut off will be the lowest weight influences. "
+                    "Maximum number of skin influences can be increased with a Skin Modifier in Scene Settings.",
+                    sourceMesh.m_name.GetCStr(), influencesPerVertex,
+                    m_skinRuleSettings.m_maxInfluencesPerVertex);
+                warnedExcessOfSkinInfluences = true;
+            }
+
+            influencesPerVertex = AZStd::min(influencesPerVertex, m_skinRuleSettings.m_maxInfluencesPerVertex);
+
+            // Round up to a multiple of two, since influences are processed two at a time in the shader
+            productMesh.m_influencesPerVertex = AZ::RoundUpToMultiple(influencesPerVertex, 2);
+        }
+
         void ModelAssetBuilderComponent::GatherVertexSkinningInfluences(
             const SourceMeshContent& sourceMesh,
             ProductMeshContent& productMesh,
             AZStd::unordered_map<AZStd::string, uint16_t>& jointNameToIndexMap,
-            size_t vertexIndex,
-            bool& warnedExcessOfSkinInfluences) const
+            size_t vertexIndex) const
         {
             AZStd::vector<uint16_t>& skinJointIndices = productMesh.m_skinJointIndices;
             AZStd::vector<float>& skinWeights = productMesh.m_skinWeights;
@@ -939,8 +1006,6 @@ namespace AZ
             for (const auto& skinData : sourceMesh.m_skinData)
             {
                 const size_t numSkinInfluences = skinData->GetLinkCount(vertexIndex);
-
-                size_t numInfluencesExcess = 0;
 
                 for (size_t influenceIndex = 0; influenceIndex < numSkinInfluences; ++influenceIndex)
                 {
@@ -959,33 +1024,17 @@ namespace AZ
 
                     // Add skin influence
                     if (weight > m_skinRuleSettings.m_weightThreshold)
-                    {
-                        if (numInfluencesAdded < m_skinRuleSettings.m_maxInfluencesPerVertex)
+                        if (numInfluencesAdded < productMesh.m_influencesPerVertex)
                         {
                             skinJointIndices.push_back(jointIndex);
                             skinWeights.push_back(weight);
                             numInfluencesAdded++;
                         }
-                        else
-                        {
-                            numInfluencesExcess++;
-                        }
                     }
-                }
-
-                if (numInfluencesExcess > 0)
-                {
-                    AZ_Warning(s_builderName, warnedExcessOfSkinInfluences,
-                        "Mesh %s has more skin influences (%d) than the maximum (%d). Skinning influences won't be normalized. Maximum number of skin influences can be increased with a Skin Modifier in Scene Settings.",
-                        sourceMesh.m_name.GetCStr(),
-                        m_skinRuleSettings.m_maxInfluencesPerVertex + numInfluencesExcess,
-                        m_skinRuleSettings.m_maxInfluencesPerVertex);
-                    warnedExcessOfSkinInfluences = true;
-                    break;
                 }
             }
 
-            for (size_t influenceIndex = numInfluencesAdded; influenceIndex < m_skinRuleSettings.m_maxInfluencesPerVertex; ++influenceIndex)
+            for (size_t influenceIndex = numInfluencesAdded; influenceIndex < productMesh.m_influencesPerVertex; ++influenceIndex)
             {
                 skinJointIndices.push_back(0);
                 skinWeights.push_back(0.0f);
@@ -1097,11 +1146,11 @@ namespace AZ
             }
             if (!mesh.m_skinJointIndices.empty())
             {
-                ValidateStreamSize(expectedVertexCount * m_skinRuleSettings.m_maxInfluencesPerVertex, mesh.m_skinJointIndices, AZ::RHI::Format::R16_UINT, ShaderSemanticName_SkinJointIndices);
+                ValidateStreamSize(expectedVertexCount * mesh.m_influencesPerVertex, mesh.m_skinJointIndices, AZ::RHI::Format::R16_UINT, ShaderSemanticName_SkinJointIndices);
             }
             if (!mesh.m_skinWeights.empty())
             {
-                ValidateStreamSize(expectedVertexCount * m_skinRuleSettings.m_maxInfluencesPerVertex, mesh.m_skinWeights, SkinWeightFormat, ShaderSemanticName_SkinWeights);
+                ValidateStreamSize(expectedVertexCount * mesh.m_influencesPerVertex, mesh.m_skinWeights, SkinWeightFormat, ShaderSemanticName_SkinWeights);
             }
         }
 
@@ -1163,13 +1212,6 @@ namespace AZ
 
             if (!mesh.m_skinJointIndices.empty() && !mesh.m_skinWeights.empty())
             {
-                AZ_Assert(mesh.m_skinJointIndices.size() == mesh.m_skinWeights.size(),
-                    "Number of skin influence joint indices (%d) should match the number of weights (%d).",
-                    mesh.m_skinJointIndices.size(), mesh.m_skinWeights.size());
-
-                AZ_Assert(mesh.m_skinWeights.size() % m_skinRuleSettings.m_maxInfluencesPerVertex == 0,
-                    "The number of skin influences per vertex (%d) is not a multiple of the total number of skinning weights (%d). This means that not every vertex has exactly (%d) skinning weights and invalidates the data.",
-                    mesh.m_skinWeights.size(), m_skinRuleSettings.m_maxInfluencesPerVertex, m_skinRuleSettings.m_maxInfluencesPerVertex);
                 const size_t numSkinInfluences = mesh.m_skinWeights.size();
 
                 uint32_t jointIndicesSizeInBytes = static_cast<uint32_t>(numSkinInfluences * sizeof(uint16_t));
@@ -1337,9 +1379,9 @@ namespace AZ
                         "Number of skin influence joint indices (%d) should match the number of weights (%d).",
                         mesh.m_skinJointIndices.size(), mesh.m_skinWeights.size());
 
-                    AZ_Assert(mesh.m_skinWeights.size() % m_skinRuleSettings.m_maxInfluencesPerVertex == 0,
+                    AZ_Assert(mesh.m_skinWeights.size() % mesh.m_influencesPerVertex == 0,
                         "The number of skin influences per vertex (%d) is not a multiple of the total number of skinning weights (%d). This means that not every vertex has exactly (%d) skinning weights and invalidates the data.",
-                        mesh.m_skinWeights.size(), m_skinRuleSettings.m_maxInfluencesPerVertex, m_skinRuleSettings.m_maxInfluencesPerVertex);
+                        mesh.m_skinWeights.size(), mesh.m_influencesPerVertex, mesh.m_influencesPerVertex);
 
                     uint32_t prevJointIdCount = aznumeric_cast<uint32_t>(lodBufferInfo.m_jointIdsCount);
                     uint32_t newJointIdCount = aznumeric_cast<uint32_t>(mesh.m_skinJointIndices.size());
@@ -1759,15 +1801,12 @@ namespace AZ
             const AZStd::vector<float>& skinWeights = lodBufferContent.m_skinWeights;
             if (!skinJointIndices.empty() && !skinWeights.empty())
             {
-                const size_t vertexCount = positions.size() / PositionFloatsPerVert;
-                const size_t numSkinInfluences = vertexCount * m_skinRuleSettings.m_maxInfluencesPerVertex;
-
                 if (!BuildRawStreamBuffer<uint16_t>(outStreamBuffers, skinJointIndices, RHI::ShaderSemantic{ShaderSemanticName_SkinJointIndices}))
                 {
                     return false;
                 }
 
-                if (!BuildStreamBuffer<float>(numSkinInfluences, outStreamBuffers, skinWeights, SkinWeightFormat, RHI::ShaderSemantic{ShaderSemanticName_SkinWeights}))
+                if (!BuildStreamBuffer<float>(skinWeights.size(), outStreamBuffers, skinWeights, SkinWeightFormat, RHI::ShaderSemantic{ShaderSemanticName_SkinWeights}))
                 {
                     return false;
                 }

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
@@ -120,7 +120,14 @@ namespace AZ
                 AZStd::vector<RPI::PackedCompressedMorphTargetDelta> m_morphTargetVertexData;
 
                 MaterialUid m_materialUid;
-                bool CanBeMerged() const { return m_clothData.empty(); }
+                uint32_t m_influencesPerVertex = 0;
+
+                bool CanBeMerged() const
+                {
+                    // Temporarily disable merging skinned meshes to avoid merging meshes that have different
+                    // per-vertex influence counts. This can be reverted when GHI-7588 is resolved 
+                    return m_clothData.empty() && m_influencesPerVertex == 0;
+                }
             };
             using ProductMeshContentList = AZStd::vector<ProductMeshContent>;
 
@@ -377,12 +384,18 @@ namespace AZ
 
         private:
             //! Collects skinning influences of a vertex from the SceneAPI source mesh and fills them in the resulting mesh
+            void CalculateMaxUsedSkinInfluencesPerVertex(
+                const SourceMeshContent& sourceMesh,
+                ProductMeshContent& productMesh,
+                const AZStd::map<uint32_t, uint32_t>& oldToNewIndicesMap,
+                bool& warnedExcessOfSkinInfluences) const;
+
+            //! Collects skinning influences of a vertex from the SceneAPI source mesh and fills them in the resulting mesh
             void GatherVertexSkinningInfluences(
                 const SourceMeshContent& sourceMesh,
                 ProductMeshContent& productMesh,
                 AZStd::unordered_map<AZStd::string, uint16_t>& jointNameToIndexMap,
-                size_t vertexIndex,
-                bool& warnedExcessOfSkinInfluences) const;
+                size_t vertexIndex) const;
         };
     } // namespace RPI
 } // namespace AZ

--- a/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
+++ b/Gems/Atom/RPI/Code/Source/RPI.Builders/Model/ModelAssetBuilderComponent.h
@@ -384,9 +384,8 @@ namespace AZ
 
         private:
             //! Collects skinning influences of a vertex from the SceneAPI source mesh and fills them in the resulting mesh
-            void CalculateMaxUsedSkinInfluencesPerVertex(
+            uint32_t CalculateMaxUsedSkinInfluencesPerVertex(
                 const SourceMeshContent& sourceMesh,
-                ProductMeshContent& productMesh,
                 const AZStd::map<uint32_t, uint32_t>& oldToNewIndicesMap,
                 bool& warnedExcessOfSkinInfluences) const;
 

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -57,8 +57,7 @@ namespace AZ
             const EMotionFX::SubMesh* subMesh,
             const uint32_t maxInfluencesPerVertex,
             AZStd::vector<uint32_t>& blendIndexBufferData,
-            AZStd::vector<float>& blendWeightBufferData,
-            bool hasClothData)
+            AZStd::vector<float>& blendWeightBufferData)
         {
             EMotionFX::SkinningInfoVertexAttributeLayer* sourceSkinningInfo = static_cast<EMotionFX::SkinningInfoVertexAttributeLayer*>(mesh->FindSharedVertexAttributeLayer(EMotionFX::SkinningInfoVertexAttributeLayer::TYPE_ID));
             
@@ -74,49 +73,30 @@ namespace AZ
                     const uint32_t originalVertex = sourceOriginalVertex[vertexIndex + vertexStart];
                     const uint32_t influenceCount = AZStd::GetMin<uint32_t>(
                         maxInfluencesPerVertex, static_cast<uint32_t>(sourceSkinningInfo->GetNumInfluences(originalVertex)));
-                    uint32_t influenceIndex = 0;
 
-                    AZStd::vector<uint32_t> localIndices;
-                    AZStd::vector<float> localWeights;
+                    uint32_t influenceIndex = 0;
                     for (; influenceIndex < influenceCount; ++influenceIndex)
                     {
                         EMotionFX::SkinInfluence* influence = sourceSkinningInfo->GetInfluence(originalVertex, influenceIndex);
-                        localIndices.push_back(static_cast<uint32_t>(influence->GetNodeNr()));
+                        if (influenceIndex % 2 == 0)
+                        {
+                            blendIndexBufferData.push_back(static_cast<uint32_t>(influence->GetNodeNr()) << 16);
+                        }
+                        else
+                        {
+                            blendIndexBufferData.back() |= static_cast<uint32_t>(influence->GetNodeNr());
+                        }
                         blendWeightBufferData.push_back(influence->GetWeight());
                     }
 
                     // Zero out any unused ids/weights
                     for (; influenceIndex < maxInfluencesPerVertex; ++influenceIndex)
                     {
-                        localIndices.push_back(0);
-                        blendWeightBufferData.push_back(0.0f);
-                    }
-
-
-                    // [TODO ATOM-15288]
-                    // Temporary workaround. If there is cloth data, set all the blend weights to zero to indicate
-                    // the vertices will be updated by cpu. When meshes with cloth data are not dispatched for skinning
-                    // this can be hasClothData can be removed.
-
-                    // If there is no skinning info, default to 0 weights and display an error
-                    if (hasClothData || !sourceSkinningInfo)
-                    {
-                        for (influenceIndex = 0; influenceIndex < maxInfluencesPerVertex; ++influenceIndex)
+                        if (influenceIndex % 2 == 0)
                         {
-                            blendWeightBufferData[influenceIndex] = 0.0f;
+                            blendIndexBufferData.push_back(0);
                         }
-                    }
-
-                    // Make sure we have an even number of indices for packing into 32-bit uints
-                    if (localIndices.size() % 2 != 0)
-                    {
-                        localIndices.push_back(0);
-                    }
-
-                    // Now that we have the 16-bit indices, pack them into 32-bit uints
-                    for (size_t i = 0; i < localIndices.size(); i+=2)
-                    {
-                        blendIndexBufferData.push_back(localIndices[i] << 16 | localIndices[i+1]);
+                        blendWeightBufferData.push_back(0.0f);
                     }
                 }
 
@@ -252,10 +232,7 @@ namespace AZ
                         // Skip empty sub-meshes and sub-meshes that would put the total vertex count beyond the supported range
                         if (vertexCount > 0 && IsVertexCountWithinSupportedRange(vertexBufferOffset, vertexCount))
                         {
-                            // Check if the model mesh asset has cloth data. One ModelLodAsset::Mesh corresponds to one EMotionFX::SubMesh.
-                            const bool hasClothData = modelLodAsset->GetMeshes()[subMeshIndex].GetSemanticBufferAssetView(AZ::Name("CLOTH_DATA")) != nullptr;
-
-                            ProcessSkinInfluences(mesh, subMesh, skinnedMeshInputBuffers->GetInfluenceCountPerVertex(lodIndex, subMeshIndex), blendIndexBufferData, blendWeightBufferData, hasClothData);
+                            ProcessSkinInfluences(mesh, subMesh, skinnedMeshInputBuffers->GetInfluenceCountPerVertex(lodIndex, subMeshIndex), blendIndexBufferData, blendWeightBufferData);
 
                             // Increment offsets so that the next sub-mesh can start at the right place
                             vertexBufferOffset += vertexCount;

--- a/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
+++ b/Gems/AtomLyIntegration/EMotionFXAtom/Code/Source/ActorAsset.cpp
@@ -78,6 +78,7 @@ namespace AZ
                     for (; influenceIndex < influenceCount; ++influenceIndex)
                     {
                         EMotionFX::SkinInfluence* influence = sourceSkinningInfo->GetInfluence(originalVertex, influenceIndex);
+                        // Pack the 16-bit indices into 32-bit uints, putting the first of each index pair in the most significant bits
                         if (influenceIndex % 2 == 0)
                         {
                             blendIndexBufferData.push_back(static_cast<uint32_t>(influence->GetNodeNr()) << 16);

--- a/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/Mesh.cpp
@@ -181,7 +181,7 @@ namespace EMotionFX
             const AZ::RPI::BufferAssetView* weightView = mesh.GetSemanticBufferAssetView(AZ::Name{"SKIN_WEIGHTS"});
             if(weightView)
             {
-                AZ::u32 meshInfluenceCount = weightView->GetBufferViewDescriptor().m_elementCount / mesh.GetVertexCount();
+                const AZ::u32 meshInfluenceCount = weightView->GetBufferViewDescriptor().m_elementCount / mesh.GetVertexCount();
                 maxSkinInfluences = AZStd::max(maxSkinInfluences, meshInfluenceCount);
             }
         }
@@ -306,10 +306,10 @@ namespace EMotionFX
                 const AZ::RPI::BufferAssetView* jointIdView = sourceMesh.GetSemanticBufferAssetView(AZ::Name{"SKIN_JOINTINDICES"});
                 if (weightView && jointIdView)
                 {                    
-                    AZ::u32 meshInfluenceCount = weightView->GetBufferViewDescriptor().m_elementCount / meshVertexCount;
-                    AZ::u32 weightOffsetInElements = weightView->GetBufferViewDescriptor().m_elementOffset;
+                    const AZ::u32 meshInfluenceCount = weightView->GetBufferViewDescriptor().m_elementCount / meshVertexCount;
+                    const AZ::u32 weightOffsetInElements = weightView->GetBufferViewDescriptor().m_elementOffset;
                     // We multiply by two here since there are two jointId's packed per-element
-                    AZ::u32 jointIdOffsetInElements = jointIdView->GetBufferViewDescriptor().m_elementOffset * 2;
+                    const AZ::u32 jointIdOffsetInElements = jointIdView->GetBufferViewDescriptor().m_elementOffset * 2;
 
                     // Fill in skinning data from atom buffer
                     for (AZ::u32 v = 0; v < meshVertexCount; ++v)


### PR DESCRIPTION
Each mesh now has its own value for the maximum influences per vertex. This means that a character with a body that only uses at most two influences per-vertex and a face that uses 8 will only do 8 iterations in the skinning loop for the face mesh and and not the body mesh.

For the example of 20 instances of the pyro character skinning ~7million vertices, this reduces the skinning pass time about 7% from 1.5ms->1.4ms per frame.