### PR TITLE
Add autogen jinja template and registry for function use case

### DIFF
--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -81,7 +81,9 @@ ly_add_target(
             AZ::AzCore
             AZ::AzFramework
             Gem::ScriptCanvasDebugger
+            Gem::ScriptCanvas.AutoGen
     AUTOGEN_RULES
+        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,$path/$fileprefix.generated.cpp
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Header.jinja,$path/$fileprefix.generated.h
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Source.jinja,$path/$fileprefix.generated.cpp
         *.ScriptCanvasNodeable.xml,ScriptCanvasNodeable_Header.jinja,$path/$fileprefix.generated.h
@@ -104,6 +106,20 @@ ly_add_target(
             .
             Include
             ${SCRIPT_CANVAS_AUTOGEN_BUILD_DIR}
+)
+
+ly_add_target(
+    NAME ScriptCanvas.AutoGen STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        scriptcanvasgem_autogen_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            Include/ScriptCanvas/AutoGen
+    BUILD_DEPENDENCIES
+        PUBLIC
+            AZ::AzCore
+            AZ::AzFramework
 )
 
 ly_add_target(

--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -54,6 +54,20 @@ ly_create_alias(NAME ScriptCanvasDebugger.Clients  NAMESPACE Gem TARGETS Gem::Sc
 ly_create_alias(NAME ScriptCanvasDebugger.Servers  NAMESPACE Gem TARGETS Gem::ScriptCanvasDebugger)
 
 ly_add_target(
+    NAME ScriptCanvas.Extensions STATIC
+    NAMESPACE Gem
+    FILES_CMAKE
+        scriptcanvasgem_autogen_files.cmake
+    INCLUDE_DIRECTORIES
+        PUBLIC
+            Include/ScriptCanvas/AutoGen
+    BUILD_DEPENDENCIES
+        PUBLIC
+            AZ::AzCore
+            AZ::AzFramework
+)
+
+ly_add_target(
     NAME ScriptCanvas.Static STATIC
     NAMESPACE Gem
     FILES_CMAKE
@@ -81,7 +95,7 @@ ly_add_target(
             AZ::AzCore
             AZ::AzFramework
             Gem::ScriptCanvasDebugger
-            Gem::ScriptCanvas.AutoGen
+            Gem::ScriptCanvas.Extensions
     AUTOGEN_RULES
         *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,$path/$fileprefix.generated.cpp
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Header.jinja,$path/$fileprefix.generated.h
@@ -106,20 +120,6 @@ ly_add_target(
             .
             Include
             ${SCRIPT_CANVAS_AUTOGEN_BUILD_DIR}
-)
-
-ly_add_target(
-    NAME ScriptCanvas.AutoGen STATIC
-    NAMESPACE Gem
-    FILES_CMAKE
-        scriptcanvasgem_autogen_files.cmake
-    INCLUDE_DIRECTORIES
-        PUBLIC
-            Include/ScriptCanvas/AutoGen
-    BUILD_DEPENDENCIES
-        PUBLIC
-            AZ::AzCore
-            AZ::AzFramework
 )
 
 ly_add_target(

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <algorithm>
+
+#include "ScriptCanvasAutoGenRegistry.h"
+
+namespace ScriptCanvas
+{
+    AutoGenRegistry::~AutoGenRegistry()
+    {
+        m_functions.clear();
+    }
+
+    AutoGenRegistry* AutoGenRegistry::GetInstance()
+    {
+        // Use static object so each module will keep its own registry collection
+        static AutoGenRegistry s_autogenRegistry;
+
+        return &s_autogenRegistry;
+    }
+
+    void AutoGenRegistry::ReflectFunctions(AZ::ReflectContext* context)
+    {
+        if (auto registry = GetInstance())
+        {
+            for (auto& iter : registry->m_functions)
+            {
+                if (iter.second)
+                {
+                    iter.second->Reflect(context);
+                }
+            }
+        }
+    }
+
+    void AutoGenRegistry::RegisterFunction(const char* className, IScriptCanvasFunctionRegistry* registry)
+    {
+        if (m_functions.find(className) == m_functions.end() && registry != nullptr)
+        {
+            m_functions.emplace(className, registry);
+        }
+    }
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/std/string/fixed_string.h>
 #include "ScriptCanvasAutoGenRegistry.h"
 
 namespace ScriptCanvas
@@ -53,9 +54,9 @@ namespace ScriptCanvas
     {
         if (m_functions.find(functionName) != m_functions.end())
         {
-            char message[MaxMessageLength];
-            azsnprintf(message, MaxMessageLength, ScriptCanvasAutoGenFunctionRegistrationWarningMessage, functionName);
-            AZ::Debug::Platform::OutputToDebugger(ScriptCanvasAutoGenRegistryName, message);
+            AZ::Debug::Platform::OutputToDebugger(
+                ScriptCanvasAutoGenRegistryName,
+                AZStd::fixed_string<MaxMessageLength>::format(ScriptCanvasAutoGenFunctionRegistrationWarningMessage, functionName).c_str());
         }
         else if (registry != nullptr)
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Serialization/EditContext.h>
+#include <AzCore/Serialization/SerializeContext.h>
+
+namespace ScriptCanvas
+{
+    class IScriptCanvasFunctionRegistry
+    {
+    public:
+        virtual void Reflect(AZ::ReflectContext* context) = 0;
+    };
+
+    class AutoGenRegistry
+    {
+    public:
+        AutoGenRegistry() = default;
+        ~AutoGenRegistry();
+
+        static AutoGenRegistry* GetInstance();
+        static void ReflectFunctions(AZ::ReflectContext* context);
+
+        void RegisterFunction(const char* className, IScriptCanvasFunctionRegistry* registry);
+
+        std::unordered_map<std::string, IScriptCanvasFunctionRegistry*> m_functions;
+    };
+} // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -11,9 +11,10 @@
 #include <string>
 #include <unordered_map>
 
-#include <AzCore/RTTI/BehaviorContext.h>
-#include <AzCore/Serialization/EditContext.h>
-#include <AzCore/Serialization/SerializeContext.h>
+namespace AZ
+{
+    class ReflectContext;
+}
 
 namespace ScriptCanvas
 {
@@ -30,10 +31,13 @@ namespace ScriptCanvas
         ~AutoGenRegistry();
 
         static AutoGenRegistry* GetInstance();
-        static void ReflectFunctions(AZ::ReflectContext* context);
+        static void Reflect(AZ::ReflectContext* context);
 
-        void RegisterFunction(const char* className, IScriptCanvasFunctionRegistry* registry);
+        void RegisterFunction(const char* functionName, IScriptCanvasFunctionRegistry* registry);
+        void UnregisterFunction(const char* functionName);
 
         std::unordered_map<std::string, IScriptCanvasFunctionRegistry*> m_functions;
+    private:
+        static void ReflectFunctions(AZ::ReflectContext* context);
     };
 } // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -1,0 +1,72 @@
+{#
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+#}
+
+{% import 'ScriptCanvas_Macros.jinja' as macros %}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// This code was produced with AzAutoGen, any modifications made will not be preserved.
+// If you need to modify this code see:
+//
+// Gems\ScriptCanvas\Code\Include\ScriptCanvas\AutoGen\ScriptCanvasFunction_Source.jinja
+//
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <ScriptCanvasAutoGenRegistry.h>
+
+{% for xml in dataFiles %}
+{% for Library in xml.iter('ScriptCanvasFunction') %}
+
+#include "{{ Library.attrib['Include'] }}"
+
+{% set className = macros.CleanName('ScriptCanvasFunction' + Library.attrib['Name']) %}
+{% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
+{% set prettyNamespaceName = macros.CleanName(Library.attrib['Namespace'].replace('::', '_')) %}
+{% set categoryName = Library.attrib['Category']%}
+
+{% for namespace in namespaceList %}
+namespace {{namespace}}
+{
+{% endfor %}
+
+    class {{className}}
+        : public ScriptCanvas::IScriptCanvasFunctionRegistry
+    {
+    public:
+        {{className}}()
+        {
+            ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{className}}", this);
+        }
+
+        ~{{className}}() = default;
+ 
+        void Reflect(AZ::ReflectContext* context) override
+        {
+            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+            {
+{% for function in Library.findall('Function') %}
+{% set functionName = macros.CleanName(function.attrib['Name'])%}
+                behaviorContext->Method("{{prettyNamespaceName}}_{{functionName}}", &{{functionName}}, 
+{{macros.GenerateFunctionMetaData(function)}})
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                    ->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
+                ;
+
+{% endfor %}
+            }
+        }
+    };
+
+    static {{className}} s_{{className}};
+
+{% for namespace in namespaceList %}
+}
+{% endfor %}
+
+{% endfor %}
+{% endfor %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -19,15 +19,21 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <ScriptCanvasAutoGenRegistry.h>
 
-{% for xml in dataFiles %}
-{% for Library in xml.iter('ScriptCanvasFunction') %}
+{% for ScriptCanvasFunction in dataFiles %}
 
-#include "{{ Library.attrib['Include'] }}"
+{{- macros.Required('Include', ScriptCanvasFunction, ScriptCanvasFunction) -}}
+{{- macros.Required('Name', ScriptCanvasFunction, ScriptCanvasFunction) -}}
 
-{% set className = macros.CleanName('ScriptCanvasFunction' + Library.attrib['Name']) %}
-{% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
-{% set prettyNamespaceName = macros.CleanName(Library.attrib['Namespace'].replace('::', '_')) %}
-{% set categoryName = Library.attrib['Category']%}
+#include "{{ ScriptCanvasFunction.attrib['Include'] }}"
+
+{% set className = macros.CleanName('ScriptCanvasFunction' + ScriptCanvasFunction.attrib['Name']) %}
+{% set namespaceList = [] %}
+{% set sanitizedNamespaceName = 'GlobalMethod' %}
+{% if ScriptCanvasFunction.attrib['Namespace'] is defined and ScriptCanvasFunction.attrib['Namespace'] %}
+{% set namespaceList = macros.CleanName(ScriptCanvasFunction.attrib['Namespace']).split('::') %}
+{% set sanitizedNamespaceName = macros.CleanName(ScriptCanvasFunction.attrib['Namespace'].replace('::', '_')) %}
+{% endif %}
+{% set categoryName = ScriptCanvasFunction.attrib['Category'] %}
 
 {% for namespace in namespaceList %}
 namespace {{namespace}}
@@ -40,21 +46,27 @@ namespace {{namespace}}
     public:
         {{className}}()
         {
-            ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{className}}", this);
+            ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{sanitizedNamespaceName}}_{{className}}", this);
         }
 
-        ~{{className}}() = default;
+        virtual ~{{className}}()
+        {
+            ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction("{{sanitizedNamespaceName}}_{{className}}");
+        }
  
         void Reflect(AZ::ReflectContext* context) override
         {
             if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
-{% for function in Library.findall('Function') %}
+{% for function in ScriptCanvasFunction.findall('Function') %}
+{{ macros.Required('Name', function, ScriptCanvasFunction) }}
 {% set functionName = macros.CleanName(function.attrib['Name'])%}
-                behaviorContext->Method("{{prettyNamespaceName}}_{{functionName}}", &{{functionName}}, 
+                behaviorContext->Method("{{sanitizedNamespaceName}}_{{functionName}}", &{{functionName}}, 
 {{macros.GenerateFunctionMetaData(function)}})
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+{% if categoryName %}
                     ->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
+{% endif %}
                 ;
 
 {% endfor %}
@@ -68,5 +80,6 @@ namespace {{namespace}}
 }
 {% endfor %}
 
-{% endfor %}
+{{ macros.ReportErrors() }}
+
 {% endfor %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -60,8 +60,9 @@ namespace {{namespace}}
             {
 {% for function in ScriptCanvasFunction.findall('Function') %}
 {{ macros.Required('Name', function, ScriptCanvasFunction) }}
-{% set functionName = macros.CleanName(function.attrib['Name'])%}
-                behaviorContext->Method("{{sanitizedNamespaceName}}_{{functionName}}", &{{functionName}}, 
+{% set functionName = macros.CleanName(function.attrib['Name']) %}
+{% set sanitizedFunctionName = macros.CleanName(function.attrib['Name']).replace('::', '_') %}
+                behaviorContext->Method("{{sanitizedNamespaceName}}_{{sanitizedFunctionName}}", &{{functionName}},
 {{macros.GenerateFunctionMetaData(function)}})
                     ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
 {% if categoryName %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
@@ -44,6 +44,27 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 
 {# ------- #}
 
+{%- macro GenerateFunctionMetaData(function) -%}
+{% set parameters = function.findall('Parameter') %}
+{% if not parameters %}
+{ { } }
+{%- else -%}
+{ {
+{% for index in range(0, parameters|length()) %}
+{% set parameterName = parameters[index].attrib['Name'] %}
+{% set parameterDefaultValue = parameters[index].attrib['DefaultValue'] %}
+{% set parameterDescription = parameters[index].attrib['Description'] %}
+    { {%- if parameterName is defined %}"{{parameterName}}"{% else %}""{% endif %},
+      {%- if parameterDescription is defined %} "{{parameterDescription}}"{% else %} ""{% endif %},
+      {%- if parameterDefaultValue is defined %} behaviorContext->MakeDefaultValue({{parameterDefaultValue}}){% else %} nullptr{% endif %} }{% if index != parameters|length() - 1 %},{% endif %}
+
+{% endfor %}
+} }
+{%- endif -%}
+{%- endmacro -%}
+
+{# ------- #}
+
 {%- macro SlotName(slotName) -%}
 {{slotName|replace("\\", '')|replace("\"", '')}}
 {%- endmacro -%}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {% macro Required(attribute, element, Class) %}
 {% set name = "unknown" %}
 {% if element.attrib['Name'] is defined %}{% set name = element.attrib['Name'] %}{% endif %}
-{% if element.attrib[attribute] is not defined %}
+{% if element.attrib[attribute] is not defined or not element.attrib[attribute] %}
 {{ AddError(Class, "| You must specify the attribute: " + attribute + " for " + name) }}
 {% endif %}
 {% endmacro %}

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -14,6 +14,7 @@
 #include <AzCore/Serialization/Utils.h>
 #include <Libraries/Libraries.h>
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
+#include <ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h>
 #include <ScriptCanvas/Core/Contract.h>
 #include <ScriptCanvas/Core/Graph.h>
 #include <ScriptCanvas/Core/Node.h>
@@ -59,6 +60,7 @@ namespace ScriptCanvas
 {
     void SystemComponent::Reflect(AZ::ReflectContext* context)
     {
+        AutoGenRegistry::ReflectFunctions(context);
         VersionData::Reflect(context);
         Nodeable::Reflect(context);
         ReflectLibraries(context);

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -60,7 +60,7 @@ namespace ScriptCanvas
 {
     void SystemComponent::Reflect(AZ::ReflectContext* context)
     {
-        AutoGenRegistry::ReflectFunctions(context);
+        AutoGenRegistry::Reflect(context);
         VersionData::Reflect(context);
         Nodeable::Reflect(context);
         ReflectLibraries(context);

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_autogen_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_autogen_files.cmake
@@ -1,0 +1,12 @@
+#
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
+#
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+#
+
+set(FILES
+    Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+    Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+)

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
@@ -67,6 +67,8 @@ set(FILES
     Include/ScriptCanvas/PerformanceTracker.h
     Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+    Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
+    Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Header.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Source.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
@@ -67,7 +67,6 @@ set(FILES
     Include/ScriptCanvas/PerformanceTracker.h
     Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
-    Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Header.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Source.jinja


### PR DESCRIPTION
Duplicate from https://github.com/o3de/o3de/pull/8420

Instead of merging to dev branch directly, will put all required code changes in [remote branch](https://github.com/aws-lumberyard-dev/o3de/tree/sc-autogen-function)

New revision change support with more flexible function name:
```
namespace TestCustomFunction
{
    class DummyLibrary
    {
    public:
        static int DummySum(int, int);
    };

    int DummySubtract(int, int);
}
```

```
<ScriptCanvasFunction
    Include="TestCustomFunction.h"
    Name="TestCustom"
    Namespace="TestCustomFunction"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
    
    <Function Name="DummyLibrary::DummySum"/>

    <Function Name="DummySubtract"/>
</ScriptCanvasFunction>
```

## Testing
Tested in ScriptCanvas Gem and project, try to use this template to reflect custom function.