### PR TITLE
Added new Blast Material Asset where 1 asset is 1 material

### DIFF
--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
@@ -127,6 +127,7 @@ namespace Blast
         materialAsset->Register();
         m_assetHandlers.emplace_back(materialAsset);
 
+        // TODO: "blastmaterial2" is temporary until the library asset is removed.
         auto materialAsset2 = aznew AzFramework::GenericAssetHandler<MaterialAsset>(
             "Blast Material 2", "Blast Material", "blastmaterial2");
         materialAsset2->Register();

--- a/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastSystemComponent.cpp
@@ -22,6 +22,7 @@
 #include <Blast/BlastDebug.h>
 #include <Blast/BlastFamilyComponentBus.h>
 #include <Blast/BlastMaterial.h>
+#include <Material/MaterialAsset.h>
 #include <IConsole.h>
 #include <NvBlastExtPxSerialization.h>
 #include <NvBlastExtTkSerialization.h>
@@ -42,6 +43,9 @@ namespace Blast
     void BlastSystemComponent::Reflect(AZ::ReflectContext* context)
     {
         BlastGlobalConfiguration::Reflect(context);
+
+        MaterialConfiguration::Reflect(context);
+        MaterialAsset::Reflect(context);
 
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
@@ -119,9 +123,14 @@ namespace Blast
         m_assetHandlers.emplace_back(blastAssetHandler);
 
         auto materialAsset = aznew AzFramework::GenericAssetHandler<BlastMaterialLibraryAsset>(
-            "Blast Material", "Blast", "blastmaterial");
+            "Blast Material", "Blast Material", "blastmaterial");
         materialAsset->Register();
         m_assetHandlers.emplace_back(materialAsset);
+
+        auto materialAsset2 = aznew AzFramework::GenericAssetHandler<MaterialAsset>(
+            "Blast Material 2", "Blast Material", "blastmaterial2");
+        materialAsset2->Register();
+        m_assetHandlers.emplace_back(materialAsset2);
 
         // Add asset types and extensions to AssetCatalog. Uses "AssetCatalogService".
         auto assetCatalog = AZ::Data::AssetCatalogRequestBus::FindFirstHandler();

--- a/Gems/Blast/Code/Source/Material/Material.cpp
+++ b/Gems/Blast/Code/Source/Material/Material.cpp
@@ -16,8 +16,7 @@ namespace Blast
         m_stressLinearFactor = configuration.m_stressLinearFactor;
         m_stressAngularFactor = configuration.m_stressAngularFactor;
 
-        // This is not an error, health in ExtPxMaterial is actually damage divider and not health
-        m_blastMaterial.health = configuration.m_forceDivider;
+        m_blastMaterial.health = configuration.m_forceDivider; // This is not an error, health in ExtPxMaterial is actually damage divider and not health.
         m_blastMaterial.minDamageThreshold = configuration.m_minDamageThreshold;
         m_blastMaterial.maxDamageThreshold = configuration.m_maxDamageThreshold;
     }
@@ -54,14 +53,21 @@ namespace Blast
 
     float Material::GetNormalizedDamage(float damage) const
     {
-        // Same clamping behavior as NvBlastExtMaterial::getNormalizedDamage function.
+        // Same normalization behavior as NvBlastExtMaterial::getNormalizedDamage function.
         // Since the damage input parameter is expected in the right range already, it's better
         // to do the operation directly rather than passing an scaled value of damage expecting
-        // getNormalizedDamage to invert that scale to return to the original number, which due
-        // to floating precision issues could result in an slightly different number causing
-        // the clamping to return unexpected results in the limits.
+        // getNormalizedDamage to invert that scale to get the original value, which due
+        // to floating precision issues it results in an slightly different number, causing
+        // the normalization to return unexpected results in the limits.
         damage = (m_blastMaterial.health > 0.0f) ? damage : 1.0f;
-        return damage > m_blastMaterial.minDamageThreshold ? (damage < m_blastMaterial.maxDamageThreshold ? damage : m_blastMaterial.maxDamageThreshold) : 0.0f;
+        if (damage > m_blastMaterial.minDamageThreshold)
+        {
+            return (damage < m_blastMaterial.maxDamageThreshold) ? damage : m_blastMaterial.maxDamageThreshold;
+        }
+        else
+        {
+            return 0.0f;
+        }
     }
 
     Nv::Blast::ExtStressSolverSettings Material::GetStressSolverSettings(uint32_t iterationsCount) const

--- a/Gems/Blast/Code/Source/Material/Material.cpp
+++ b/Gems/Blast/Code/Source/Material/Material.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Material/Material.h>
+
+namespace Blast
+{
+    Material::Material(const MaterialConfiguration& configuration)
+    {
+        m_health = configuration.m_health;
+        m_stressLinearFactor = configuration.m_stressLinearFactor;
+        m_stressAngularFactor = configuration.m_stressAngularFactor;
+
+        // This is not an error, health in ExtPxMaterial is actually damage divider and not health
+        m_blastMaterial.health = configuration.m_forceDivider;
+        m_blastMaterial.minDamageThreshold = configuration.m_minDamageThreshold;
+        m_blastMaterial.maxDamageThreshold = configuration.m_maxDamageThreshold;
+    }
+
+    float Material::GetHealth() const
+    {
+        return m_health;
+    }
+
+    float Material::GetForceDivider() const
+    {
+        return m_blastMaterial.health;
+    }
+
+    float Material::GetMinDamageThreshold() const
+    {
+        return m_blastMaterial.minDamageThreshold;
+    }
+
+    float Material::GetMaxDamageThreshold() const
+    {
+        return m_blastMaterial.maxDamageThreshold;
+    }
+
+    float Material::GetStressLinearFactor() const
+    {
+        return m_stressLinearFactor;
+    }
+
+    float Material::GetStressAngularFactor() const
+    {
+        return m_stressAngularFactor;
+    }
+
+    float Material::GetNormalizedDamage(float damage) const
+    {
+        // Same clamping behavior as NvBlastExtMaterial::getNormalizedDamage function.
+        // Since the damage input parameter is expected in the right range already, it's better
+        // to do the operation directly rather than passing an scaled value of damage expecting
+        // getNormalizedDamage to invert that scale to return to the original number, which due
+        // to floating precision issues could result in an slightly different number causing
+        // the clamping to return unexpected results in the limits.
+        damage = (m_blastMaterial.health > 0.0f) ? damage : 1.0f;
+        return damage > m_blastMaterial.minDamageThreshold ? (damage < m_blastMaterial.maxDamageThreshold ? damage : m_blastMaterial.maxDamageThreshold) : 0.0f;
+    }
+
+    Nv::Blast::ExtStressSolverSettings Material::GetStressSolverSettings(uint32_t iterationsCount) const
+    {
+        Nv::Blast::ExtStressSolverSettings settings;
+        settings.hardness = m_blastMaterial.health;
+        settings.stressLinearFactor = m_stressLinearFactor;
+        settings.stressAngularFactor = m_stressAngularFactor;
+        settings.graphReductionLevel = 0;
+        settings.bondIterationsPerFrame = iterationsCount;
+        return settings;
+    }
+
+    void* Material::GetNativePointer()
+    {
+        return &m_blastMaterial;
+    }
+} // namespace Blast

--- a/Gems/Blast/Code/Source/Material/Material.h
+++ b/Gems/Blast/Code/Source/Material/Material.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Material/MaterialConfiguration.h>
+
+#include <NvBlastExtDamageShaders.h>
+#include <NvBlastExtStressSolver.h>
+
+namespace Blast
+{
+    //! Runtime blast material, created from a MaterialConfiguration.
+    class Material
+    {
+    public:
+        Material(const MaterialConfiguration& configuration);
+
+        //! Amount of damage destructible object with this material can withstand.
+        float GetHealth() const;
+
+        //! Amount by which magnitude of stress forces applied is divided before being subtracted from health.
+        float GetForceDivider() const;
+
+        //! Any amount lower than this threshold will not be applied. Only affects non-stress damage.
+        float GetMinDamageThreshold() const;
+
+        //! Any amount higher than this threshold will be capped by it. Only affects non-stress damage.
+        float GetMaxDamageThreshold() const;
+
+        //! Factor with which linear stress is applied to destructible objects. Linear stress includes
+        //! direct application of BlastFamilyDamageRequests::StressDamage, collisions and gravity (only for static
+        //! actors).
+        float GetStressLinearFactor() const;
+
+        //! Factor with which angular stress is applied to destructible objects. Angular stress is
+        //! calculated based on angular velocity of an object (only non-static actors).
+        float GetStressAngularFactor() const;
+
+        //! Normalizes the non-stress damage based on the thresholds.
+        float GetNormalizedDamage(float damage) const;
+
+        //! Generates NvBlast stress solver settings from this material and provided iterationsCount.
+        Nv::Blast::ExtStressSolverSettings GetStressSolverSettings(uint32_t iterationsCount) const;
+
+        //! Returns underlying pointer of the native type.
+        void* GetNativePointer();
+
+    private:
+        float m_health;
+        float m_stressLinearFactor;
+        float m_stressAngularFactor;
+        NvBlastExtMaterial m_blastMaterial;
+    };
+} // namespace Blast

--- a/Gems/Blast/Code/Source/Material/MaterialAsset.cpp
+++ b/Gems/Blast/Code/Source/Material/MaterialAsset.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+
+#include <Material/MaterialAsset.h>
+
+namespace Blast
+{
+    void MaterialAsset::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<Blast::MaterialAsset, AZ::Data::AssetData>()
+                ->Version(1)
+                ->Attribute(AZ::Edit::Attributes::EnableForAssetEditor, true)
+                ->Field("MaterialConfiguration", &MaterialAsset::m_materialConfiguration)
+                ;
+
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<Blast::MaterialAsset>("", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &MaterialAsset::m_materialConfiguration, "Blast Material",
+                        "Blast material properties")
+                        ->Attribute(AZ::Edit::Attributes::ForceAutoExpand, true);
+            }
+        }
+    }
+
+    const MaterialConfiguration& MaterialAsset::GetMaterialConfiguration() const
+    {
+        return m_materialConfiguration;
+    }
+} // namespace Blast

--- a/Gems/Blast/Code/Source/Material/MaterialAsset.h
+++ b/Gems/Blast/Code/Source/Material/MaterialAsset.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+
+#include <Material/MaterialConfiguration.h>
+
+namespace Blast
+{
+    //! MaterialAsset defines a single material, which includes the configuration to create a Material instance to use at runtime.
+    class MaterialAsset
+        : public AZ::Data::AssetData
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(Blast::MaterialAsset, AZ::SystemAllocator, 0);
+        AZ_RTTI(Blast::MaterialAsset, "{BA261DAC-2B87-4461-833B-914FD9020BD8}", AZ::Data::AssetData);
+
+        MaterialAsset() = default;
+        virtual ~MaterialAsset() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        const MaterialConfiguration& GetMaterialConfiguration() const;
+
+    protected:
+        MaterialConfiguration m_materialConfiguration;
+    };
+} // namespace Blast

--- a/Gems/Blast/Code/Source/Material/MaterialConfiguration.cpp
+++ b/Gems/Blast/Code/Source/Material/MaterialConfiguration.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+
+#include <Material/MaterialConfiguration.h>
+
+namespace Blast
+{
+    void MaterialConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<Blast::MaterialConfiguration>()
+                ->Version(1)
+                ->Field("Health", &MaterialConfiguration::m_health)
+                ->Field("ForceDivider", &MaterialConfiguration::m_forceDivider)
+                ->Field("MinDamageThreshold", &MaterialConfiguration::m_minDamageThreshold)
+                ->Field("MaxDamageThreshold", &MaterialConfiguration::m_maxDamageThreshold)
+                ->Field("StressLinearFactor", &MaterialConfiguration::m_stressLinearFactor)
+                ->Field("StressAngularFactor", &MaterialConfiguration::m_stressAngularFactor);
+
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<Blast::MaterialConfiguration>("", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "Blast Material")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_health, "Health",
+                        "All damage is subtracted from this value")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_forceDivider, "Force divider",
+                        "All damage which originates with force is divided by this amount")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_minDamageThreshold,
+                        "Minimum damage threshold", "Incoming damage is discarded if it is less than this value")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_maxDamageThreshold,
+                        "Maximum damage threshold", "Incoming damage is capped at this value")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_stressLinearFactor,
+                        "Stress linear factor",
+                        "Factor with which linear stress such as gravity, direct impulse, collision is applied")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_stressAngularFactor,
+                        "Stress angular factor", "Factor with which angular stress is applied")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f);
+            }
+        }
+    }
+} // namespace Blast

--- a/Gems/Blast/Code/Source/Material/MaterialConfiguration.h
+++ b/Gems/Blast/Code/Source/Material/MaterialConfiguration.h
@@ -19,10 +19,10 @@ namespace Blast
 
         static void Reflect(AZ::ReflectContext* context);
 
-        float m_health = 1.0;
-        float m_forceDivider = 1.0;
-        float m_minDamageThreshold = 0.0;
-        float m_maxDamageThreshold = 1.0;
+        float m_health = 1.0f;
+        float m_forceDivider = 1.0f;
+        float m_minDamageThreshold = 0.0f;
+        float m_maxDamageThreshold = 1.0f;
         float m_stressLinearFactor = 1.0f;
         float m_stressAngularFactor = 1.0f;
     };

--- a/Gems/Blast/Code/Source/Material/MaterialConfiguration.h
+++ b/Gems/Blast/Code/Source/Material/MaterialConfiguration.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/ReflectContext.h>
+
+namespace Blast
+{
+    //! Properties of a blast material.
+    struct MaterialConfiguration
+    {
+        AZ_TYPE_INFO(Blast::MaterialConfiguration, "{50A5FB6E-99BA-433B-9A6A-618AB4952161}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        float m_health = 1.0;
+        float m_forceDivider = 1.0;
+        float m_minDamageThreshold = 0.0;
+        float m_maxDamageThreshold = 1.0;
+        float m_stressLinearFactor = 1.0f;
+        float m_stressAngularFactor = 1.0f;
+    };
+} // namespace Blast

--- a/Gems/Blast/Code/Tests/BlastMaterialTest.cpp
+++ b/Gems/Blast/Code/Tests/BlastMaterialTest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzTest/AzTest.h>
+
+#include <Material/Material.h>
+
+namespace UnitTest
+{
+    static constexpr float Tolerance = 1e-4f;
+
+    TEST(BlastMaterial, Material_ReturnsCorrect_Health)
+    {
+        Blast::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_health = 68.6f;
+
+        Blast::Material material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetHealth(), 68.6f, Tolerance);
+    }
+
+    TEST(BlastMaterial, Material_ReturnsCorrect_ForceDivider)
+    {
+        Blast::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_forceDivider = 0.6f;
+
+        Blast::Material material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetForceDivider(), 0.6f, Tolerance);
+    }
+
+    TEST(BlastMaterial, Material_ReturnsCorrect_DamageThresholds)
+    {
+        Blast::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_minDamageThreshold = 0.2f;
+        materialConfiguration.m_maxDamageThreshold = 0.8f;
+
+        Blast::Material material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetMinDamageThreshold(), 0.2f, Tolerance);
+        EXPECT_NEAR(material.GetMaxDamageThreshold(), 0.8f, Tolerance);
+    }
+
+    TEST(BlastMaterial, Material_ReturnsCorrect_StressFactors)
+    {
+        Blast::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_stressLinearFactor = 0.6f;
+        materialConfiguration.m_stressAngularFactor = 0.7f;
+
+        Blast::Material material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetStressLinearFactor(), 0.6f, Tolerance);
+        EXPECT_NEAR(material.GetStressAngularFactor(), 0.7f, Tolerance);
+    }
+
+    TEST(BlastMaterial, Material_ReturnsCorrect_NormalizedDamage_WithForceDividerZero)
+    {
+        Blast::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_forceDivider = 0.0f;
+        materialConfiguration.m_minDamageThreshold = 0.2f;
+        materialConfiguration.m_maxDamageThreshold = 0.8f;
+
+        Blast::Material material(materialConfiguration);
+
+        // When forceDivider is 0 the damage value that will be normalized is always
+        // 1.0f (ignoring input parameter), which will be clamped by min/max thresholds.
+        EXPECT_NEAR(material.GetNormalizedDamage(0.0f), 0.8f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.2f), 0.8f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.5f), 0.8f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.8f), 0.8f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(-0.3f), 0.8f, Tolerance);
+    }
+
+    using BlastMaterialForceDividerFixture = ::testing::TestWithParam<float>;
+
+    TEST_P(BlastMaterialForceDividerFixture, Material_ReturnsCorrect_NormalizedDamage)
+    {
+        Blast::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_forceDivider = GetParam(); // Force divider shouldn't affect the result of damage normalization (except when it's 0)
+        materialConfiguration.m_minDamageThreshold = 0.2f;
+        materialConfiguration.m_maxDamageThreshold = 0.8f;
+
+        Blast::Material material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetNormalizedDamage(0.0f), 0.0f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.2f), 0.0f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.21f), 0.21f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.3f), 0.3f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.5f), 0.5f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.79f), 0.79f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.8f), 0.8f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(0.9f), 0.8f, Tolerance);
+        EXPECT_NEAR(material.GetNormalizedDamage(-0.3f), 0.0f, Tolerance);
+    }
+
+    INSTANTIATE_TEST_CASE_P(
+        All,
+        BlastMaterialForceDividerFixture,
+        ::testing::Values(
+            1.0f, 0.2f, 0.6f, 0.8f, 1.3f
+        ));
+
+    TEST(BlastMaterial, Material_ReturnsCorrect_StressSolverSettings)
+    {
+        Blast::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_health = 68.6f;
+        materialConfiguration.m_forceDivider = 0.6f;
+        materialConfiguration.m_minDamageThreshold = 0.2f;
+        materialConfiguration.m_maxDamageThreshold = 0.8f;
+        materialConfiguration.m_stressLinearFactor = 0.65f;
+        materialConfiguration.m_stressAngularFactor = 0.7f;
+
+        Blast::Material material(materialConfiguration);
+
+        //! Generates NvBlast stress solver settings from this material and provided iterationsCount.
+        const uint32_t iterationsCount = 2;
+        const Nv::Blast::ExtStressSolverSettings stressSolverSettings = material.GetStressSolverSettings(iterationsCount);
+
+        EXPECT_NEAR(stressSolverSettings.hardness, 0.6f, Tolerance);
+        EXPECT_NEAR(stressSolverSettings.stressLinearFactor, 0.65f, Tolerance);
+        EXPECT_NEAR(stressSolverSettings.stressAngularFactor, 0.7f, Tolerance);
+        EXPECT_EQ(stressSolverSettings.graphReductionLevel, 0);
+        EXPECT_EQ(stressSolverSettings.bondIterationsPerFrame, 2);
+    }
+
+    TEST(BlastMaterial, Material_ReturnsValid_NativePointer)
+    {
+        Blast::Material material(Blast::MaterialConfiguration{});
+
+        EXPECT_TRUE(material.GetNativePointer() != nullptr);
+    }
+} // namespace UnitTest

--- a/Gems/Blast/Code/blast_files.cmake
+++ b/Gems/Blast/Code/blast_files.cmake
@@ -48,4 +48,10 @@ set(FILES
     Source/Common/BlastInterfaces.h
     Source/Common/BlastMaterial.cpp
     Source/Common/Utils.h
+    Source/Material/Material.h
+    Source/Material/Material.cpp
+    Source/Material/MaterialAsset.h
+    Source/Material/MaterialAsset.cpp
+    Source/Material/MaterialConfiguration.h
+    Source/Material/MaterialConfiguration.cpp
 )

--- a/Gems/Blast/Code/blast_tests_files.cmake
+++ b/Gems/Blast/Code/blast_tests_files.cmake
@@ -13,4 +13,5 @@ set(FILES
     Tests/ActorRenderManagerTest.cpp
     Tests/BlastFamilyTest.cpp
     Tests/BlastActorTest.cpp
+    Tests/BlastMaterialTest.cpp
 )

--- a/Gems/Blast/Registry/AssetProcessorGemConfig.setreg
+++ b/Gems/Blast/Registry/AssetProcessorGemConfig.setreg
@@ -13,6 +13,12 @@
                     "critical": true,
                     "productAssetType": "{55F38C86-0767-4E7F-830A-A4BF624BE4DA}"
                 },
+                "RC blastmaterial2": {
+                    "glob": "*.blastmaterial2",
+                    "params": "copy",
+                    "critical": true,
+                    "productAssetType": "{BA261DAC-2B87-4461-833B-914FD9020BD8}"
+                },
                 "RC blastconfiguration": {
                     "glob": "*.blastconfiguration",
                     "params": "copy"


### PR DESCRIPTION
**This PR is part of the work to refactoring blast materials. It's NOT merging to development branch.**

The properties of the blast materials are the same, the difference is that the asset is now the material, not a material library, which simplifies the code and makes it work the same as render materials. 

- **MaterialConfiguration**: structure with blast properties.
- **MaterialAsset**: asset data that has a MaterialConfiguraiton. This asset will enable Asset Editor to create this assets.
- **Material**: runtime material with the blast internal classes, created from a MaterialConfiguration.

Asset Editor will create blast materials files (.blastmaterial2) in the project's asset folder, then an Asset Processor rule copies the file to the cache folder, which makes it ready for O3DE to use.

![image](https://user-images.githubusercontent.com/27999040/159659478-42ac585b-9195-4f8a-9b29-e3b9ceaec0e3.png)

Unit tests added for blast materials:

````
[----------] 7 tests from BlastMaterial
[ RUN      ] BlastMaterial.Material_ReturnsCorrect_Health
[       OK ] BlastMaterial.Material_ReturnsCorrect_Health (0 ms)
[ RUN      ] BlastMaterial.Material_ReturnsCorrect_ForceDivider
[       OK ] BlastMaterial.Material_ReturnsCorrect_ForceDivider (0 ms)
[ RUN      ] BlastMaterial.Material_ReturnsCorrect_DamageThresholds
[       OK ] BlastMaterial.Material_ReturnsCorrect_DamageThresholds (0 ms)
[ RUN      ] BlastMaterial.Material_ReturnsCorrect_StressFactors
[       OK ] BlastMaterial.Material_ReturnsCorrect_StressFactors (0 ms)
[ RUN      ] BlastMaterial.Material_ReturnsCorrect_NormalizedDamage_WithForceDividerZero
[       OK ] BlastMaterial.Material_ReturnsCorrect_NormalizedDamage_WithForceDividerZero (0 ms)
[ RUN      ] BlastMaterial.Material_ReturnsCorrect_StressSolverSettings
[       OK ] BlastMaterial.Material_ReturnsCorrect_StressSolverSettings (0 ms)
[ RUN      ] BlastMaterial.Material_ReturnsValid_NativePointer
[       OK ] BlastMaterial.Material_ReturnsValid_NativePointer (0 ms)
[----------] 7 tests from BlastMaterial (8 ms total)

[----------] 5 tests from All/BlastMaterialForceDividerFixture
[ RUN      ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/0
[       OK ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/0 (0 ms)
[ RUN      ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/1
[       OK ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/1 (0 ms)
[ RUN      ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/2
[       OK ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/2 (0 ms)
[ RUN      ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/3
[       OK ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/3 (0 ms)
[ RUN      ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/4
[       OK ] All/BlastMaterialForceDividerFixture.Material_ReturnsCorrect_NormalizedDamage/4 (0 ms)
[----------] 5 tests from All/BlastMaterialForceDividerFixture (4 ms total)
````

Signed-off-by: moraaar <moraaar@amazon.com>