### PR TITLE
[LBC] Add xsd to guide xml file edit

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
@@ -5,7 +5,8 @@
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:element name="ScriptCanvas">
         <xs:annotation>
-            <xs:documentation>ScriptCanvas Function XML root element.</xs:documentation>
+            <xs:documentation>The ScriptCanvas Function XML definition root element, it is used to declare function definitions that become ScriptCanvas nodes.</xs:documentation>
+            <xs:documentation>See https://www.o3de.org/docs/user-guide/scripting/script-canvas for more details.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           attributeFormDefault="unqualified"
+           elementFormDefault="qualified"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="ScriptCanvas">
+        <xs:annotation>
+            <xs:documentation>ScriptCanvas Function XML root element.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element minOccurs="1" maxOccurs="unbounded" name="Library">
+                    <xs:annotation>
+                        <xs:documentation>The function library, it will be used as registry and container of functions.</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element minOccurs="1" maxOccurs="unbounded" name="Function">
+                                <xs:annotation>
+                                    <xs:documentation>The function entry to match with function declaration.</xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element minOccurs="0" maxOccurs="unbounded" name="Parameter">
+                                            <xs:annotation>
+                                                <xs:documentation>The function parameter to provide detailed information, and the order has to follow the input of function signature.</xs:documentation>
+                                            </xs:annotation>
+                                            <xs:complexType>
+                                                <xs:attribute name="Name" type="xs:string" use="required">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The name of function parameter.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="Description" type="xs:string" use="optional">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The description of function parameter.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                                <xs:attribute name="DefaultValue" type="xs:string" use="optional">
+                                                    <xs:annotation>
+                                                        <xs:documentation>The default value of function parameter.</xs:documentation>
+                                                    </xs:annotation>
+                                                </xs:attribute>
+                                            </xs:complexType>
+                                        </xs:element>
+                                    </xs:sequence>
+                                    <xs:attribute name="Name" type="xs:string" use="required">
+                                        <xs:annotation>
+                                            <xs:documentation>The name of function, it must match with function signature in given namespace.</xs:documentation>
+                                        </xs:annotation>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="Include" type="xs:string" use="required">
+                            <xs:annotation>
+                                <xs:documentation>The header file contains function declarations.</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="Name" type="xs:string" use="required">
+                            <xs:annotation>
+                                <xs:documentation>The name of library.</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="Namespace" type="xs:string" use="required">
+                            <xs:annotation>
+                                <xs:documentation>The namespace of functions, it has to be unique and same as function declaration.</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="Category" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation>The category of functions in ScriptCanvas Node Palette.</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
@@ -26,17 +26,17 @@
                                                 <xs:documentation>The function parameter to provide detailed information, and the order has to follow the input of function signature.</xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
-                                                <xs:attribute name="Name" type="xs:string" use="required">
+                                                <xs:attribute name="Name" type="NonEmptyString" use="required">
                                                     <xs:annotation>
                                                         <xs:documentation>The name of function parameter.</xs:documentation>
                                                     </xs:annotation>
                                                 </xs:attribute>
-                                                <xs:attribute name="Description" type="xs:string" use="optional">
+                                                <xs:attribute name="Description" type="NonEmptyString" use="optional">
                                                     <xs:annotation>
                                                         <xs:documentation>The description of function parameter.</xs:documentation>
                                                     </xs:annotation>
                                                 </xs:attribute>
-                                                <xs:attribute name="DefaultValue" type="xs:string" use="optional">
+                                                <xs:attribute name="DefaultValue" type="NonEmptyString" use="optional">
                                                     <xs:annotation>
                                                         <xs:documentation>The default value of function parameter.</xs:documentation>
                                                     </xs:annotation>
@@ -44,7 +44,7 @@
                                             </xs:complexType>
                                         </xs:element>
                                     </xs:sequence>
-                                    <xs:attribute name="Name" type="xs:string" use="required">
+                                    <xs:attribute name="Name" type="NonEmptyString" use="required">
                                         <xs:annotation>
                                             <xs:documentation>The name of function, it must match with function signature in given namespace.</xs:documentation>
                                         </xs:annotation>
@@ -52,22 +52,22 @@
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>
-                        <xs:attribute name="Include" type="xs:string" use="required">
+                        <xs:attribute name="Include" type="NonEmptyString" use="required">
                             <xs:annotation>
                                 <xs:documentation>The header file contains function declarations.</xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="Name" type="xs:string" use="required">
+                        <xs:attribute name="Name" type="NonEmptyString" use="required">
                             <xs:annotation>
                                 <xs:documentation>The name of library.</xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="Namespace" type="xs:string" use="required">
+                        <xs:attribute name="Namespace" type="NonEmptyString" use="required">
                             <xs:annotation>
                                 <xs:documentation>The namespace of functions, it has to be unique and same as function declaration.</xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="Category" type="xs:string" use="optional">
+                        <xs:attribute name="Category" type="NonEmptyString" use="optional">
                             <xs:annotation>
                                 <xs:documentation>The category of functions in ScriptCanvas Node Palette.</xs:documentation>
                             </xs:annotation>
@@ -77,4 +77,10 @@
             </xs:sequence>
         </xs:complexType>
     </xs:element>
+    <xs:simpleType name="NonEmptyString">
+        <xs:restriction base="xs:string">
+            <xs:minLength value="1"/>
+            <xs:pattern value=".*[^\s].*" />
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -19,21 +19,22 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <ScriptCanvasAutoGenRegistry.h>
 
-{% for ScriptCanvasFunction in dataFiles %}
+{% for ScriptCanvas in dataFiles %}
+{% for Library in ScriptCanvas%}
 
-{{- macros.Required('Include', ScriptCanvasFunction, ScriptCanvasFunction) -}}
-{{- macros.Required('Name', ScriptCanvasFunction, ScriptCanvasFunction) -}}
+{{- macros.Required('Include', Library, Library) -}}
+{{- macros.Required('Name', Library, Library) -}}
 
-#include "{{ ScriptCanvasFunction.attrib['Include'] }}"
+#include "{{ Library.attrib['Include'] }}"
 
-{% set className = macros.CleanName('ScriptCanvasFunction' + ScriptCanvasFunction.attrib['Name']) %}
+{% set className = macros.CleanName('ScriptCanvas' + Library.attrib['Name']) %}
 {% set namespaceList = [] %}
 {% set sanitizedNamespaceName = 'GlobalMethod' %}
-{% if ScriptCanvasFunction.attrib['Namespace'] is defined and ScriptCanvasFunction.attrib['Namespace'] %}
-{% set namespaceList = macros.CleanName(ScriptCanvasFunction.attrib['Namespace']).split('::') %}
-{% set sanitizedNamespaceName = macros.CleanName(ScriptCanvasFunction.attrib['Namespace'].replace('::', '_')) %}
+{% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
+{% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
+{% set sanitizedNamespaceName = macros.CleanName(Library.attrib['Namespace'].replace('::', '_')) %}
 {% endif %}
-{% set categoryName = ScriptCanvasFunction.attrib['Category'] %}
+{% set categoryName = Library.attrib['Category'] %}
 
 {% for namespace in namespaceList %}
 namespace {{namespace}}
@@ -58,8 +59,8 @@ namespace {{namespace}}
         {
             if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
             {
-{% for function in ScriptCanvasFunction.findall('Function') %}
-{{ macros.Required('Name', function, ScriptCanvasFunction) }}
+{% for function in Library.findall('Function') %}
+{{ macros.Required('Name', function, Library) }}
 {% set functionName = macros.CleanName(function.attrib['Name']) %}
 {% set sanitizedFunctionName = macros.CleanName(function.attrib['Name']).replace('::', '_') %}
                 behaviorContext->Method("{{sanitizedNamespaceName}}_{{sanitizedFunctionName}}", &{{functionName}},
@@ -83,4 +84,5 @@ namespace {{namespace}}
 
 {{ macros.ReportErrors() }}
 
+{% endfor %}
 {% endfor %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.ScriptCanvasFunction.xml
@@ -1,23 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<ScriptCanvasFunction
-    Include="Include/ScriptCanvas/Libraries/String/StringFunctions.h"
-    Name="StringFunctions"
-    Namespace="ScriptCanvas::StringFunctions"
-    Category="String"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<ScriptCanvas>
+    <Library
+        Include="Include/ScriptCanvas/Libraries/String/StringFunctions.h"
+        Name="StringFunctions"
+        Namespace="ScriptCanvas::StringFunctions"
+        Category="String">
 
-    <Function Name="ToLower">
-        <Parameter Name="Source" Description="Source string to be converted to lower case."/>
-    </Function>
+        <Function Name="ToLower">
+            <Parameter Name="Source" Description="Source string to be converted to lower case."/>
+        </Function>
 
-    <Function Name="ToUpper">
-        <Parameter Name="Source" Description="Source string to be converted to upper case."/>
-    </Function>
+        <Function Name="ToUpper">
+            <Parameter Name="Source" Description="Source string to be converted to upper case."/>
+        </Function>
 
-    <Function Name="Substring">
-        <Parameter Name="Source" Description="Source string to construct substring."/>
-        <Parameter Name="From" Description="Position of the first character to be copied as a substring."/>
-        <Parameter Name="Length" Description="Number of characters to include in the substring."/>
-    </Function>
-</ScriptCanvasFunction>
+        <Function Name="Substring">
+            <Parameter Name="Source" Description="Source string to construct substring."/>
+            <Parameter Name="From" Description="Position of the first character to be copied as a substring."/>
+            <Parameter Name="Length" Description="Number of characters to include in the substring."/>
+        </Function>
+    </Library>
+</ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_autogen_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_autogen_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
     Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
     Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
 )


### PR DESCRIPTION
## Details
As part of LBC, research how to define xsd as xml schema to guide scriptcanvas autogen xml file edit

After assigning schema to the xml file, valid element will be presented in dropdown list, and tab will help to auto complete content.
While hovering mouse over each element, there will be tooltip showing up.

https://user-images.githubusercontent.com/5900509/160925805-6595da76-eb69-411e-bc0d-37005b08de58.mp4


Signed-off-by: onecent1101 <liug@amazon.com>