### PR TITLE
Fix cloth skinning for assets that have different influence counts for each sub-mesh

### DIFF
--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothSkinning.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothSkinning.cpp
@@ -226,7 +226,7 @@ namespace NvCloth
             ClothComponentMesh::RenderData& renderData) override;
 
     private:
-        AZ::Matrix3x4 ComputeVertexSkinnningTransform(
+        AZ::Matrix3x4 ComputeVertexSkinningTransform(
             AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex);
 
         const AZ::Matrix3x4* m_skinningMatrices = nullptr;
@@ -259,7 +259,7 @@ namespace NvCloth
         for (size_t index = 0; index < vertexCount; ++index)
         {
             const SimulatedVertex& vertex = m_simulatedVertices[index];
-            const AZ::Matrix3x4 vertexSkinningTransform = ComputeVertexSkinnningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
+            const AZ::Matrix3x4 vertexSkinningTransform = ComputeVertexSkinningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
 
             const AZ::Vector3 skinnedPosition = vertexSkinningTransform * originalPositions[index].GetAsVector3();
             positions[index].Set(skinnedPosition, positions[index].GetW()); // Avoid overwriting the w component
@@ -283,7 +283,7 @@ namespace NvCloth
         {
             const AZ::u32 index = vertex.m_originalVertexIndex;
             const AZ::Matrix3x4 vertexSkinningTransform =
-                ComputeVertexSkinnningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
+                ComputeVertexSkinningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
 
             const AZ::Vector3 skinnedPosition = vertexSkinningTransform * originalData.m_particles[index].GetAsVector3();
             renderData.m_particles[index].Set(skinnedPosition, renderData.m_particles[index].GetW()); // Avoid overwriting the w component
@@ -301,7 +301,7 @@ namespace NvCloth
         }
     }
 
-    AZ::Matrix3x4 ActorClothSkinningLinear::ComputeVertexSkinnningTransform(
+    AZ::Matrix3x4 ActorClothSkinningLinear::ComputeVertexSkinningTransform(
         AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex)
     {
         AZ::Matrix3x4 vertexSkinningTransform = s_zeroMatrix3x4;
@@ -339,7 +339,7 @@ namespace NvCloth
             ClothComponentMesh::RenderData& renderData) override;
 
     private:
-        MCore::DualQuaternion ComputeVertexSkinnningTransform(
+        MCore::DualQuaternion ComputeVertexSkinningTransform(
             AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex);
 
         AZStd::unordered_map<AZ::u16, MCore::DualQuaternion> m_skinningDualQuaternions;
@@ -373,7 +373,7 @@ namespace NvCloth
         {
             const SimulatedVertex& vertex = m_simulatedVertices[index];
             const MCore::DualQuaternion vertexSkinningTransform =
-                ComputeVertexSkinnningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
+                ComputeVertexSkinningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
 
             const AZ::Vector3 skinnedPosition = vertexSkinningTransform.TransformPoint(originalPositions[index].GetAsVector3());
             positions[index].Set(skinnedPosition, positions[index].GetW()); // Avoid overwriting the w component
@@ -397,12 +397,12 @@ namespace NvCloth
         {
             const AZ::u32 index = vertex.m_originalVertexIndex;
             const MCore::DualQuaternion vertexSkinningTransform =
-                ComputeVertexSkinnningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
+                ComputeVertexSkinningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
 
             const AZ::Vector3 skinnedPosition = vertexSkinningTransform.TransformPoint(originalData.m_particles[index].GetAsVector3());
             renderData.m_particles[index].Set(skinnedPosition, renderData.m_particles[index].GetW()); // Avoid overwriting the w component
 
-            // ComputeVertexSkinnningTransform is normalizing the blended dual quaternion. This means the dual
+            // ComputeVertexSkinningTransform is normalizing the blended dual quaternion. This means the dual
             // quaternion will not have any scale and there is no need to compute the reciprocal scale version
             // for transforming normals.
             // Note: The GPU skinning shader does the same operation.
@@ -413,7 +413,7 @@ namespace NvCloth
         }
     }
 
-    MCore::DualQuaternion ActorClothSkinningDualQuaternion::ComputeVertexSkinnningTransform(AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex)
+    MCore::DualQuaternion ActorClothSkinningDualQuaternion::ComputeVertexSkinningTransform(AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex)
     {
         MCore::DualQuaternion vertexSkinningTransform = s_zeroDualQuaternion;
         for (size_t influenceIndex = 0; influenceIndex < numberOfInfluencesPerVertex; ++influenceIndex)

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothSkinning.cpp
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothSkinning.cpp
@@ -26,8 +26,8 @@ namespace NvCloth
         bool ObtainSkinningInfluences(
             AZ::EntityId entityId, 
             const MeshNodeInfo& meshNodeInfo,
-            const size_t numVertices,
-            AZStd::vector<SkinningInfluence>& skinningInfluences)
+            AZStd::vector<SkinningInfluence>& skinningInfluences,
+            AZStd::vector<AZ::u32>& influencesPerVertex)
         {
             AZ::Data::Asset<AZ::RPI::ModelAsset> modelAsset;
             AZ::Render::MeshComponentRequestBus::EventResult(
@@ -63,9 +63,10 @@ namespace NvCloth
 
             const auto& skinToSkeletonIndexMap = actor->GetSkinToSkeletonIndexMap();
 
-            size_t numberOfInfluencesPerVertex = 0;
-
-            // For each submesh...
+            // Pre-calculate the total number of vertices and the number of influences per-vertex
+            size_t totalInfluenceCount = 0;
+            influencesPerVertex.clear();
+            influencesPerVertex.reserve(meshNodeInfo.m_subMeshes.size());
             for (const auto& subMeshInfo : meshNodeInfo.m_subMeshes)
             {
                 if (modelLodAsset->GetMeshes().size() < subMeshInfo.m_primitiveIndex)
@@ -102,40 +103,38 @@ namespace NvCloth
                     "Size of skin joint indices buffer (%zu) different from skin weights buffer (%zu)",
                     sourceSkinJointIndices.size(), sourceSkinWeights.size());
 
-                const size_t subMeshInfluenceCount = sourceSkinWeights.size() / sourcePositions.size();
+                const AZ::u32 subMeshInfluenceCount = aznumeric_caster(sourceSkinWeights.size() / sourcePositions.size());
                 AZ_Assert(subMeshInfluenceCount > 0,
                     "Submesh %d skinning data has zero joint influences per vertex.",
                     subMeshInfo.m_primitiveIndex);
 
-                if (numberOfInfluencesPerVertex == 0)
-                {
-                    // Resize only in the first loop once we know the number of influences per vertex.
-                    // The other submeshes should match the number of influences.
-                    numberOfInfluencesPerVertex = subMeshInfluenceCount;
-                    skinningInfluences.resize(numVertices * numberOfInfluencesPerVertex);
-                }
-                else if (subMeshInfluenceCount != numberOfInfluencesPerVertex)
-                {
-                    AZ_Error("ActorClothSkinning", false,
-                        "Submesh %d number of influences (%d) is different from a previous submesh (%d).",
-                        subMeshInfo.m_primitiveIndex,
-                        subMeshInfluenceCount,
-                        numberOfInfluencesPerVertex);
-                    return false;
-                }
+                influencesPerVertex.push_back(subMeshInfluenceCount);
+                totalInfluenceCount += sourceSkinWeights.size();
+            }
 
-                for (int vertexIndex = 0; vertexIndex < subMeshInfo.m_numVertices; ++vertexIndex)
+            skinningInfluences.resize(totalInfluenceCount);
+
+            // For each submesh...
+            size_t currentInfluenceIndex = 0;
+            for (size_t meshIndex = 0; meshIndex < meshNodeInfo.m_subMeshes.size(); ++meshIndex)
+            {
+                const auto& subMeshInfo = meshNodeInfo.m_subMeshes[meshIndex];
+                const AZ::RPI::ModelLodAsset::Mesh& subMesh = modelLodAsset->GetMeshes()[subMeshInfo.m_primitiveIndex];
+                const auto sourceSkinJointIndices = subMesh.GetSemanticBufferTyped<uint16_t>(AZ::Name("SKIN_JOINTINDICES"));
+                const auto sourceSkinWeights = subMesh.GetSemanticBufferTyped<float>(AZ::Name("SKIN_WEIGHTS"));
+
+                size_t numberOfInfluencesPerVertex = aznumeric_caster(influencesPerVertex[meshIndex]);
+
+                for (int subMeshVertexIndex = 0; subMeshVertexIndex < subMeshInfo.m_numVertices; ++subMeshVertexIndex)
                 {
-                    const size_t subMeshVertexIndex = vertexIndex * numberOfInfluencesPerVertex;
-                    const size_t meshVertexIndex = (subMeshInfo.m_verticesFirstIndex + vertexIndex) * numberOfInfluencesPerVertex;
+                    // sourceSkinJointIndices and sourceSkinWeights buffers are views into the influences for the current mesh.
+                    // Get the offset to the start of the influences for the current vertex
+                    const size_t influenceStart = subMeshVertexIndex * numberOfInfluencesPerVertex;
 
                     for (size_t influenceIndex = 0; influenceIndex < numberOfInfluencesPerVertex; ++influenceIndex)
                     {
-                        const size_t subMeshVertexInfluenceIndex = subMeshVertexIndex + influenceIndex;
-                        const size_t meshVertexInfluenceIndex = meshVertexIndex + influenceIndex;
-
-                        const AZ::u16 jointIndex = sourceSkinJointIndices[subMeshVertexInfluenceIndex];
-                        const float weight = sourceSkinWeights[subMeshVertexInfluenceIndex];
+                        const AZ::u16 jointIndex = sourceSkinJointIndices[influenceStart + influenceIndex];
+                        const float weight = sourceSkinWeights[influenceStart + influenceIndex];
 
                         auto skeletonIndexIt = skinToSkeletonIndexMap.find(jointIndex);
                         if (skeletonIndexIt == skinToSkeletonIndexMap.end())
@@ -146,8 +145,11 @@ namespace NvCloth
                             return false;
                         }
 
-                        skinningInfluences[meshVertexInfluenceIndex].m_jointIndex = skeletonIndexIt->second;
-                        skinningInfluences[meshVertexInfluenceIndex].m_jointWeight = weight;
+                        // currentInfluenceIndex is the offset into the unified buffer of skin influences
+                        // that combines all sub-meshes
+                        skinningInfluences[currentInfluenceIndex].m_jointIndex = skeletonIndexIt->second;
+                        skinningInfluences[currentInfluenceIndex].m_jointWeight = weight;
+                        ++currentInfluenceIndex;
                     }
                 }
             }
@@ -195,10 +197,19 @@ namespace NvCloth
                 return {};
             }
 
+            constexpr AZ::u16 invalidJointId = AZStd::numeric_limits<AZ::u16>::max();
             AZStd::unordered_map<AZ::u16, MCore::DualQuaternion> skinningDualQuaternions;
             for (AZ::u16 jointIndex : jointIndices)
             {
-                skinningDualQuaternions.emplace(jointIndex, MCore::DualQuaternion(AZ::Transform::CreateFromMatrix3x4(skinningMatrices[jointIndex])));
+                if (jointIndex != invalidJointId)
+                {
+                    skinningDualQuaternions.emplace(jointIndex, MCore::DualQuaternion(AZ::Transform::CreateFromMatrix3x4(skinningMatrices[jointIndex])));
+                }
+                else
+                {
+                    // Use an identity quaternion for an invalid jointId. It will ultimately be ignored, since it's corresponding weight should be 0
+                    skinningDualQuaternions.emplace(jointIndex, MCore::DualQuaternion());
+                }
             }
             return skinningDualQuaternions;
         }
@@ -224,7 +235,8 @@ namespace NvCloth
             ClothComponentMesh::RenderData& renderData) override;
 
     private:
-        AZ::Matrix3x4 ComputeVertexSkinnningTransform(AZ::u32 vertexIndex);
+        AZ::Matrix3x4 ComputeVertexSkinnningTransform(
+            AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex);
 
         const AZ::Matrix3x4* m_skinningMatrices = nullptr;
 
@@ -255,7 +267,8 @@ namespace NvCloth
         const size_t vertexCount = m_simulatedVertices.size();
         for (size_t index = 0; index < vertexCount; ++index)
         {
-            const AZ::Matrix3x4 vertexSkinningTransform = ComputeVertexSkinnningTransform(m_simulatedVertices[index]);
+            const SimulatedVertex& vertex = m_simulatedVertices[index];
+            const AZ::Matrix3x4 vertexSkinningTransform = ComputeVertexSkinnningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
 
             const AZ::Vector3 skinnedPosition = vertexSkinningTransform * originalPositions[index].GetAsVector3();
             positions[index].Set(skinnedPosition, positions[index].GetW()); // Avoid overwriting the w component
@@ -268,17 +281,18 @@ namespace NvCloth
     {
         if (!m_skinningMatrices ||
             originalData.m_particles.empty() ||
-            originalData.m_particles.size() != renderData.m_particles.size() ||
-            originalData.m_particles.size() != m_skinningInfluences.size() / m_numberOfInfluencesPerVertex)
+            originalData.m_particles.size() != renderData.m_particles.size())
         {
             return;
         }
 
         AZ_PROFILE_FUNCTION(Cloth);
 
-        for (const AZ::u32 index : m_nonSimulatedVertices)
+        for (const NonSimulatedVertex& vertex : m_nonSimulatedVertices)
         {
-            const AZ::Matrix3x4 vertexSkinningTransform = ComputeVertexSkinnningTransform(index);
+            const AZ::u32 index = vertex.m_originalVertexIndex;
+            const AZ::Matrix3x4 vertexSkinningTransform =
+                ComputeVertexSkinnningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
 
             const AZ::Vector3 skinnedPosition = vertexSkinningTransform * originalData.m_particles[index].GetAsVector3();
             renderData.m_particles[index].Set(skinnedPosition, renderData.m_particles[index].GetW()); // Avoid overwriting the w component
@@ -296,19 +310,24 @@ namespace NvCloth
         }
     }
 
-    AZ::Matrix3x4 ActorClothSkinningLinear::ComputeVertexSkinnningTransform(AZ::u32 vertexIndex)
+    AZ::Matrix3x4 ActorClothSkinningLinear::ComputeVertexSkinnningTransform(
+        AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex)
     {
         AZ::Matrix3x4 vertexSkinningTransform = s_zeroMatrix3x4;
-        for (size_t influenceIndex = 0; influenceIndex < m_numberOfInfluencesPerVertex; ++influenceIndex)
+        for (size_t influenceIndex = 0; influenceIndex < numberOfInfluencesPerVertex; ++influenceIndex)
         {
-            const size_t vertexInfluenceIndex = vertexIndex * m_numberOfInfluencesPerVertex + influenceIndex;
+            const size_t vertexInfluenceIndex = influenceOffset + influenceIndex;
 
             const AZ::u16 jointIndex = m_skinningInfluences[vertexInfluenceIndex].m_jointIndex;
-            const float jointWeight = m_skinningInfluences[vertexInfluenceIndex].m_jointWeight;
+            constexpr AZ::u16 invalidJointId = AZStd::numeric_limits<AZ::u16>::max();
+            if (jointIndex != invalidJointId)
+            {
+                const float jointWeight = m_skinningInfluences[vertexInfluenceIndex].m_jointWeight;
 
-            // Blending matrices the same way done in GPU shaders, by adding each weighted matrix element by element.
-            // This operation results in a non orthogonal matrix, but it's done this way because it's fast to perform.
-            vertexSkinningTransform += m_skinningMatrices[jointIndex] * jointWeight;
+                // Blending matrices the same way done in GPU shaders, by adding each weighted matrix element by element.
+                // This operation results in a non orthogonal matrix, but it's done this way because it's fast to perform.
+                vertexSkinningTransform += m_skinningMatrices[jointIndex] * jointWeight;
+            }
         }
         return vertexSkinningTransform;
     }
@@ -333,7 +352,8 @@ namespace NvCloth
             ClothComponentMesh::RenderData& renderData) override;
 
     private:
-        MCore::DualQuaternion ComputeVertexSkinnningTransform(AZ::u32 vertexIndex);
+        MCore::DualQuaternion ComputeVertexSkinnningTransform(
+            AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex);
 
         AZStd::unordered_map<AZ::u16, MCore::DualQuaternion> m_skinningDualQuaternions;
 
@@ -364,7 +384,9 @@ namespace NvCloth
         const size_t vertexCount = m_simulatedVertices.size();
         for (size_t index = 0; index < vertexCount; ++index)
         {
-            const MCore::DualQuaternion vertexSkinningTransform = ComputeVertexSkinnningTransform(m_simulatedVertices[index]);
+            const SimulatedVertex& vertex = m_simulatedVertices[index];
+            const MCore::DualQuaternion vertexSkinningTransform =
+                ComputeVertexSkinnningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
 
             const AZ::Vector3 skinnedPosition = vertexSkinningTransform.TransformPoint(originalPositions[index].GetAsVector3());
             positions[index].Set(skinnedPosition, positions[index].GetW()); // Avoid overwriting the w component
@@ -377,17 +399,18 @@ namespace NvCloth
     {
         if (m_skinningDualQuaternions.empty() ||
             originalData.m_particles.empty() ||
-            originalData.m_particles.size() != renderData.m_particles.size() ||
-            originalData.m_particles.size() != m_skinningInfluences.size() / m_numberOfInfluencesPerVertex)
+            originalData.m_particles.size() != renderData.m_particles.size())
         {
             return;
         }
 
         AZ_PROFILE_FUNCTION(Cloth);
 
-        for (const AZ::u32 index : m_nonSimulatedVertices)
+        for (const NonSimulatedVertex& vertex : m_nonSimulatedVertices)
         {
-            const MCore::DualQuaternion vertexSkinningTransform = ComputeVertexSkinnningTransform(index);
+            const AZ::u32 index = vertex.m_originalVertexIndex;
+            const MCore::DualQuaternion vertexSkinningTransform =
+                ComputeVertexSkinnningTransform(vertex.m_influenceOffset, vertex.m_influenceCount);
 
             const AZ::Vector3 skinnedPosition = vertexSkinningTransform.TransformPoint(originalData.m_particles[index].GetAsVector3());
             renderData.m_particles[index].Set(skinnedPosition, renderData.m_particles[index].GetW()); // Avoid overwriting the w component
@@ -403,12 +426,12 @@ namespace NvCloth
         }
     }
 
-    MCore::DualQuaternion ActorClothSkinningDualQuaternion::ComputeVertexSkinnningTransform(AZ::u32 vertexIndex)
+    MCore::DualQuaternion ActorClothSkinningDualQuaternion::ComputeVertexSkinnningTransform(AZ::u32 influenceOffset, AZ::u32 numberOfInfluencesPerVertex)
     {
         MCore::DualQuaternion vertexSkinningTransform = s_zeroDualQuaternion;
-        for (size_t influenceIndex = 0; influenceIndex < m_numberOfInfluencesPerVertex; ++influenceIndex)
+        for (size_t influenceIndex = 0; influenceIndex < numberOfInfluencesPerVertex; ++influenceIndex)
         {
-            const size_t vertexInfluenceIndex = vertexIndex * m_numberOfInfluencesPerVertex + influenceIndex;
+            const size_t vertexInfluenceIndex = influenceOffset + influenceIndex;
 
             const AZ::u16 jointIndex = m_skinningInfluences[vertexInfluenceIndex].m_jointIndex;
             const float jointWeight = m_skinningInfluences[vertexInfluenceIndex].m_jointWeight;
@@ -433,7 +456,8 @@ namespace NvCloth
         const size_t numVertices = originalMeshParticles.size();
 
         AZStd::vector<SkinningInfluence> skinningInfluences;
-        if (!Internal::ObtainSkinningInfluences(entityId, meshNodeInfo, numVertices, skinningInfluences))
+        AZStd::vector<AZ::u32> influencesPerVertex;
+        if (!Internal::ObtainSkinningInfluences(entityId, meshNodeInfo, skinningInfluences, influencesPerVertex))
         {
             return nullptr;
         }
@@ -456,14 +480,6 @@ namespace NvCloth
             return nullptr;
         }
 
-        actorClothSkinning->m_numberOfInfluencesPerVertex = skinningInfluences.size() / numVertices;
-        if (actorClothSkinning->m_numberOfInfluencesPerVertex == 0)
-        {
-            AZ_Error("ActorClothSkinning", false,
-                "Number of skinning joint influences per vertex is zero.");
-            return nullptr;
-        }
-
         // Collect all indices of the joints that influence the vertices
         AZStd::set<AZ::u16> jointIndices;
         for (const auto& skinningInfluence : skinningInfluences)
@@ -473,23 +489,48 @@ namespace NvCloth
         actorClothSkinning->m_jointIndices.assign(jointIndices.begin(), jointIndices.end());
 
         // Collect the indices for simulated and non-simulated vertices
+        constexpr AZ::u32 invalidIndex = AZStd::numeric_limits<AZ::u32>::max();
         actorClothSkinning->m_simulatedVertices.resize(numSimulatedVertices);
         actorClothSkinning->m_nonSimulatedVertices.reserve(numVertices);
-        for (size_t vertexIndex = 0; vertexIndex < numVertices; ++vertexIndex)
+
+        
+        // For each submesh...
+        int meshIndexOffset = 0;
+        AZ::u32 meshInfluenceOffset = 0;
+        for (size_t subMeshIndex = 0; subMeshIndex < meshNodeInfo.m_subMeshes.size(); ++subMeshIndex)
         {
-            const int remappedIndex = meshRemappedVertices[vertexIndex];
+            const auto& subMeshInfo = meshNodeInfo.m_subMeshes[subMeshIndex];
 
-            if (remappedIndex >= 0)
+            for (int vertexIndex = meshIndexOffset; vertexIndex < meshIndexOffset + subMeshInfo.m_numVertices; ++vertexIndex)
             {
-                actorClothSkinning->m_simulatedVertices[remappedIndex] = static_cast<AZ::u32>(vertexIndex);
+                const AZ::u32 influenceOffset = meshInfluenceOffset + (vertexIndex - meshIndexOffset) * influencesPerVertex[subMeshIndex];
+
+                // The cloth cooker has previously simplified the original mesh and re-mapped the vertices 
+                const int remappedIndex = meshRemappedVertices[vertexIndex];
+
+                // If the vertex has been remapped, it's part of the simulation
+                if (remappedIndex >= 0)
+                {
+                    SimulatedVertex vertex;
+                    vertex.m_influenceOffset = influenceOffset;
+                    vertex.m_influenceCount = influencesPerVertex[subMeshIndex];
+                    actorClothSkinning->m_simulatedVertices[remappedIndex] = vertex;
+                }
+
+                if (remappedIndex < 0 || originalMeshParticles[vertexIndex].GetW() == 0.0f)
+                {
+                    NonSimulatedVertex vertex;
+                    vertex.m_originalVertexIndex = static_cast<AZ::u32>(vertexIndex);
+                    vertex.m_influenceOffset = influenceOffset;
+                    vertex.m_influenceCount = influencesPerVertex[subMeshIndex];
+                    actorClothSkinning->m_nonSimulatedVertices.emplace_back(vertex);
+                }
             }
 
-            if (remappedIndex < 0 ||
-                originalMeshParticles[vertexIndex].GetW() == 0.0f)
-            {
-                actorClothSkinning->m_nonSimulatedVertices.emplace_back(static_cast<AZ::u32>(vertexIndex));
-            }
+            meshIndexOffset += subMeshInfo.m_numVertices;
+            meshInfluenceOffset += subMeshInfo.m_numVertices * influencesPerVertex[subMeshIndex];
         }
+
         actorClothSkinning->m_nonSimulatedVertices.shrink_to_fit();
 
         actorClothSkinning->m_skinningInfluences = AZStd::move(skinningInfluences);
@@ -528,3 +569,4 @@ namespace NvCloth
         return m_wasActorVisible;
     }
 } // namespace NvCloth
+

--- a/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothSkinning.h
+++ b/Gems/NvCloth/Code/Source/Components/ClothComponentMesh/ActorClothSkinning.h
@@ -72,16 +72,34 @@ namespace NvCloth
     protected:
         AZ::EntityId m_entityId;
 
-        size_t m_numberOfInfluencesPerVertex = 0;
-
         // Skinning influences of all vertices
         AZStd::vector<SkinningInfluence> m_skinningInfluences;
 
-        // Indices to skinning influences that are part of the simulation
-        AZStd::vector<AZ::u32> m_simulatedVertices;
+        struct SimulatedVertex
+        {
+            AZ::u32 m_influenceOffset = 0;
+            // Influence count is a bit redundant since that is uniform across a sub-mesh,
+            // not unique to each vertex. However, it is necessary to track it here,
+            // since m_simulatedVertices remapped out of the original vertex order,
+            // and there is no way to correlate an element of m_simulatedVertices to which
+            // sub-mesh it came from
+            AZ::u32 m_influenceCount = 0;
+        };
+        // Offsets to skinning influences that are part of the simulation
+        AZStd::vector<SimulatedVertex> m_simulatedVertices;
 
-        // Indices to skinning influences that are not part of the simulation
-        AZStd::vector<AZ::u32> m_nonSimulatedVertices;
+        struct NonSimulatedVertex
+        {
+            AZ::u32 m_originalVertexIndex = 0;
+            AZ::u32 m_influenceOffset = 0;
+            // Influence count is a bit redundant since that is uniform across a sub-mesh,
+            // not unique to each vertex. However, the code is simpler and less error
+            // prone to just track the influence count here instead of associating a range
+            // of non-simulated vertices to a particular sub-mesh
+            AZ::u32 m_influenceCount = 0;
+        };
+        // Offsets to skinning influences that are not part of the simulation
+        AZStd::vector<NonSimulatedVertex> m_nonSimulatedVertices;
 
         // Collection of skeleton joint indices that influence the vertices
         AZStd::vector<AZ::u16> m_jointIndices;


### PR DESCRIPTION
-Updated the logic to no longer assume that all sub-meshes will have the same number of influences per-vertex, since that is now possible with the latest skinning updates in the staging branch

Tested the chicken asset and the legionnaire asset. Modified the legionairre asset to have a cloth mesh node on the upper body, and added different material assignments to the uppder body so that there are 4 sub-meshes, some of which have 4 influences per-vertex and others with 6 influences per-vertex, to cover the case with a single cloth component that affects multiple sub-meshes. Tested multiple cloth components on one actor. Tested both dual-quaternion and linear skinning. Entered/exited game mode, and simulated in-editor.

Signed-off-by: Tommy Walton <waltont@amazon.com>