### PR TITLE
 Temp Fix: Resolve Aliases to Stop Editor Crash

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -27,6 +27,7 @@
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 #include <AzToolsFramework/Prefab/PrefabUndoHelpers.h>
 #include <AzToolsFramework/Prefab/Spawnable/PrefabConverterStackProfileNames.h>
+#include "AzFramework/Spawnable/SpawnableAssetBus.h"
 
 namespace AzToolsFramework
 {
@@ -466,6 +467,11 @@ namespace AzToolsFramework
                 // This is a workaround until the replacement for GameEntityContext is done
                 AzFramework::GameEntityContextEventBus::Broadcast(
                     &AzFramework::GameEntityContextEventBus::Events::OnGameEntitiesStarted);
+
+                auto* spawnable = createRootSpawnableResult.GetValue().GetAs<AzFramework::Spawnable>();
+                AzFramework::Spawnable::EntityAliasVisitor aliases = spawnable->TryGetAliases();
+                AzFramework::SpawnableAssetEventsBus::Broadcast(
+                    &AzFramework::SpawnableAssetEvents::OnResolveAliases, aliases, spawnable->GetMetaData(), spawnable->GetEntities());
             }
             else
             {


### PR DESCRIPTION
Temp fix from Sergey for stopping editor crashing in CTRL+G whenever network entities are present.

Tested by apply code change, and seeing the editor no longer crashes.
Signed-off-by: Gene Walters <genewalt@amazon.com>