### PR TITLE
Adding OnPreparingSpawnable Hooks

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableAssetBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableAssetBus.h
@@ -32,6 +32,10 @@ namespace AzFramework
         //!     an asset for loading.
         virtual void OnResolveAliases(
             Spawnable::EntityAliasVisitor& aliases, const SpawnableMetaData& metadata, const Spawnable::EntityList& entities) = 0;
+
+        //! Notification to allow systems to access a spawnable before it's been modified by aliasing.
+        //! This ebus function will be called for all spawnables, even if there are no aliases on the spawnable.
+        virtual void OnPreparingSpawnable(const Spawnable& spawnable, const AZ::Data::AssetId& id) {}
     };
 
     using SpawnableAssetEventsBus = AZ::EBus<SpawnableAssetEvents>;

--- a/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableAssetHandler.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/SpawnableAssetHandler.cpp
@@ -54,6 +54,7 @@ namespace AzFramework
         AZ::ObjectStream::FilterDescriptor filter(assetLoadFilterCB);
         if (AZ::Utils::LoadObjectFromStreamInPlace(*stream, *spawnable, nullptr /*SerializeContext*/, filter))
         {
+            SpawnableAssetEventsBus::Broadcast(&SpawnableAssetEventsBus::Events::OnPreparingSpawnable, *spawnable, asset.GetId());
             ResolveEntityAliases(spawnable, asset, stream->GetStreamingDeadline(), stream->GetStreamingPriority(), assetLoadFilterCB);
             return AZ::Data::AssetHandler::LoadResult::LoadComplete;
         }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.cpp
@@ -491,4 +491,10 @@ namespace Multiplayer
         }
     }
 
+    void MultiplayerEditorSystemComponent::OnPreparingSpawnable(
+        [[maybe_unused]] const AzFramework::Spawnable& spawnable, [[maybe_unused]] const AZ::Data::AssetId& id)
+    {
+        
+    }
+
 }

--- a/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
+++ b/Gems/Multiplayer/Code/Source/Editor/MultiplayerEditorSystemComponent.h
@@ -20,6 +20,7 @@
 #include <AzFramework/Process/ProcessWatcher.h>
 #include <AzFramework/Process/ProcessCommunicatorTracePrinter.h>
 #include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <AzFramework/Spawnable/SpawnableAssetBus.h>
 
 namespace AzNetworking
 {
@@ -51,6 +52,7 @@ namespace Multiplayer
         , private IEditorNotifyListener
         , private MultiplayerEditorServerRequestBus::Handler
         , private AZ::TickBus::Handler
+        , private AzFramework::SpawnableAssetEventsBus::Handler
     {
     public:
         AZ_COMPONENT(MultiplayerEditorSystemComponent, "{9F335CC0-5574-4AD3-A2D8-2FAEF356946C}");
@@ -87,6 +89,11 @@ namespace Multiplayer
         void LaunchEditorServer();
         bool FindServerLauncher(AZ::IO::FixedMaxPath& serverPath);
         void Connect();
+
+        //! AzFramework::SpawnableAssetEventsBus::Handler overrides
+        //! @{
+        void OnPreparingSpawnable(const AzFramework::Spawnable& spawnable, const AZ::Data::AssetId& id) override;
+        //! @
         
         //! EditorEvents::Handler overrides
         //! @{


### PR DESCRIPTION
Wip. Adding OnPreparingSpawnable to interface to unblock multiplayer hooks

Signed-off-by: Gene Walters <genewalt@amazon.com>