### PR TITLE
Prefab/selective deserialization for prefab add remove

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.cpp
@@ -295,11 +295,13 @@ namespace AzToolsFramework
                 auto instancesMemberIterator = inputValue.FindMember("Instances");
                 if (instancesMemberIterator != inputValue.MemberEnd() && instancesMemberIterator->value.IsObject())
                 {
+                    // Remove nested instances identified in patches metadata.
                     for (const AZStd::string& instanceAlias : patchesMetadata.instancesToRemove)
                     {
                         instance->DetachNestedInstance(instanceAlias);
                     }
 
+                    // Add nested instances identified in patches metadata.
                     for (const AZStd::string& instanceAlias : patchesMetadata.instancesToAdd)
                     {
                         AZStd::unique_ptr<Instance> detachedInstance = instance->DetachNestedInstance(instanceAlias);
@@ -324,6 +326,7 @@ namespace AzToolsFramework
                         }
                     }
 
+                    // Reload nested instances identified in patches metadata. This will trigger further instance loads recursively.
                     for (const AZStd::string& instanceAlias : patchesMetadata.instancesToReload)
                     {
                         InstanceOptionalReference nestedInstance = instance->FindNestedInstance(instanceAlias);
@@ -373,7 +376,7 @@ namespace AzToolsFramework
                 auto entitiesMemberIterator = inputValue.FindMember("Entities");
                 if (entitiesMemberIterator != inputValue.MemberEnd() && entitiesMemberIterator->value.IsObject())
                 {
-
+                    // Remove entities identified in patches metadata.
                     for (AZStd::string entityAlias : patchesMetadata.entitiesToRemove)
                     {
                         EntityOptionalReference existingEntity = instance->GetEntity(entityAlias);
@@ -387,6 +390,7 @@ namespace AzToolsFramework
                     EntityList entitiesLoaded;
                     entitiesLoaded.reserve(patchesMetadata.entitiesToReload.size());
 
+                    // Reload entities identified in patches metadata. This includes addition of new entities too.
                     for (AZStd::string entityAlias : patchesMetadata.entitiesToReload)
                     {
                         EntityOptionalReference existingEntity = instance->GetEntity(entityAlias);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceSerializer.h
@@ -49,9 +49,20 @@ namespace AzToolsFramework
             //! Clears all the entities in the instance and loads them from scratch using the DOM provided.
             //! @param inputValue The Dom that contains the instance information.
             //! @param context The context that could contain additional metadata needed for the deserialization.
-            //! @instance The instance in which the entities need to be reloaded.
-            //! @result The result code that could be modified during the process of reloading.
+            //! @instance The instance in which the entities need to be loaded.
+            //! @result The result code that could be modified during the process of loading.
             void ClearAndLoadEntities(
+                const rapidjson::Value& inputValue,
+                AZ::JsonDeserializerContext& context,
+                Instance* instance,
+                AZ::JsonSerializationResult::ResultCode& result);
+
+            //! Clears all the nested instances in the instance and loads them from scratch using the DOM provided.
+            //! @param inputValue The Dom that contains the instance information.
+            //! @param context The context that could contain additional metadata needed for the deserialization.
+            //! @instance The instance in which the entities need to be loaded.
+            //! @result The result code that could be modified during the process of loading.
+            void ClearAndLoadInstances(
                 const rapidjson::Value& inputValue,
                 AZ::JsonDeserializerContext& context,
                 Instance* instance,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -380,11 +380,11 @@ namespace AzToolsFramework
 
                         if (patchPath == PathMatchingEntities) // Path is /Entities
                         {
-                            patchesMetadata.clearAndLoadAllEntities = true;
+                            patchesMetadata.m_clearAndLoadAllEntities = true;
                         }
                         else if (patchPath.starts_with(PathStartingWithEntities)) // Path begins with /Entities/
                         {
-                            if (patchesMetadata.clearAndLoadAllEntities)
+                            if (patchesMetadata.m_clearAndLoadAllEntities)
                             {
                                 continue;
                             }
@@ -393,21 +393,21 @@ namespace AzToolsFramework
                             AZStd::size_t pathSeparatorIndex = patchPath.find('/');
                             if (pathSeparatorIndex != AZStd::string::npos) // Path begins with /Entities/{someString}/
                             {
-                                patchesMetadata.entitiesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
+                                patchesMetadata.m_entitiesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
                             }
                             else // Path is with /Entities/{someString}
                             {
                                 Internal::IdentifyInstanceMembersToAddAndRemove(
-                                    patchEntry, patchesMetadata.entitiesToReload, patchesMetadata.entitiesToRemove, AZStd::move(patchPath));
+                                    patchEntry, patchesMetadata.m_entitiesToReload, patchesMetadata.m_entitiesToRemove, AZStd::move(patchPath));
                             }
                         }
                         else if (patchPath == PathMatchingInstances) // Path is /Instances
                         {
-                            patchesMetadata.clearAndLoadAllInstances = true;
+                            patchesMetadata.m_clearAndLoadAllInstances = true;
                         }
-                        else if (patchPath.starts_with(PathStartingWithInstances))// Path begins with /Entities/
+                        else if (patchPath.starts_with(PathStartingWithInstances))// Path begins with /Instances/
                         {
-                            if (patchesMetadata.clearAndLoadAllInstances)
+                            if (patchesMetadata.m_clearAndLoadAllInstances)
                             {
                                 continue;
                             }
@@ -416,24 +416,23 @@ namespace AzToolsFramework
                             AZStd::size_t pathSeparatorIndex = patchPath.find('/');
                             if (pathSeparatorIndex != AZStd::string::npos) // Path begins with /Instances/{someString}/
                             {
-                                patchesMetadata.instancesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
+                                patchesMetadata.m_instancesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
                             }
                             else // Path is /Instances/{someString}
                             {
                                 Internal::IdentifyInstanceMembersToAddAndRemove(
-                                    patchEntry, patchesMetadata.instancesToAdd, patchesMetadata.instancesToRemove, AZStd::move(patchPath));
+                                    patchEntry, patchesMetadata.m_instancesToAdd, patchesMetadata.m_instancesToRemove, AZStd::move(patchPath));
                             }
                         }
                         else if (patchPath.starts_with(PathMatchingContainerEntity)) // Path begins with /ContainerEntity
                         {
-                            patchesMetadata.shouldReloadContainerEntity = true;
+                            patchesMetadata.m_shouldReloadContainerEntity = true;
                         }
                         else
                         {
                             AZ_Warning(
                                 "Prefab", false,
-                                "A patch starting with the keyword '%s' is identified. This is currently not a supported path for "
-                                "patching a prefab.",
+                                "A patch targeting '%s' is identified. Patches must be routed to Entities, Instances, or ContainerEntity.",
                                 patchPath);
                         }
                     }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -177,6 +177,29 @@ namespace AzToolsFramework
 
                     return true;
                 }
+
+                static void IdentifyInstanceMembersToAddAndRemove(
+                    const PrefabDomValue& patchEntry,
+                    AZStd::unordered_set<AZStd::string>& membersToAdd,
+                    AZStd::unordered_set<AZStd::string>& membersToRemove,
+                    AZStd::string_view memberName)
+                {
+                    PrefabDomValue::ConstMemberIterator patchEntryIterator = patchEntry.FindMember("op");
+                    if (patchEntryIterator != patchEntry.MemberEnd())
+                    {
+                        AZStd::string opPath = patchEntryIterator->value.GetString();
+
+                        if (opPath == "remove")
+                        {
+                            membersToRemove.emplace(AZStd::move(memberName));
+                        }
+                        else if (opPath == "add" || opPath == "replace")
+                        {
+                            // Could be an add or change from empty->full. The later case is rare but not impossible.
+                            membersToAdd.emplace(AZStd::move(memberName));
+                        }
+                    }
+                }
             }
 
             PrefabDomValueReference FindPrefabDomValue(PrefabDomValue& parentValue, const char* valueName)
@@ -337,6 +360,80 @@ namespace AzToolsFramework
                 applyPatchSettings.m_reporting = AZStd::move(issueReportingCallback);
                 return AZ::JsonSerialization::ApplyPatch(
                     prefabDomToApplyPatchesOn, allocator, patches, AZ::JsonMergeApproach::JsonPatch, applyPatchSettings);
+            }
+
+            //! Identifies the instance members to reload by parsing through the patches provided.
+            PatchesMetadata IdentifyModifiedInstanceMembers(const PrefabDom& patches)
+            {
+                PrefabDomUtils::PatchesMetadata patchesMetadata;
+                for (const PrefabDomValue& patchEntry : patches.GetArray())
+                {
+                    PrefabDomValue::ConstMemberIterator patchEntryIterator = patchEntry.FindMember("path");
+                    if (patchEntryIterator != patchEntry.MemberEnd())
+                    {
+                        AZStd::string_view patchPath = patchEntryIterator->value.GetString();
+
+                        if (patchPath == PathMatchingEntities) // Path is /Entities
+                        {
+                            patchesMetadata.clearAndLoadAllEntities = true;
+                        }
+                        else if (patchPath.starts_with(PathStartingWithEntities)) // Path begins with /Entities/
+                        {
+                            if (patchesMetadata.clearAndLoadAllEntities)
+                            {
+                                continue;
+                            }
+
+                            patchPath.remove_prefix(strlen(PathStartingWithEntities));
+                            AZStd::size_t pathSeparatorIndex = patchPath.find('/');
+                            if (pathSeparatorIndex != AZStd::string::npos) // Path begins with /Entities/{someString}/
+                            {
+                                patchesMetadata.entitiesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
+                            }
+                            else // Path is with /Entities/{someString}
+                            {
+                                Internal::IdentifyInstanceMembersToAddAndRemove(
+                                    patchEntry, patchesMetadata.entitiesToReload, patchesMetadata.entitiesToRemove, AZStd::move(patchPath));
+                            }
+                        }
+                        else if (patchPath == PathMatchingInstances) // Path is /Instances
+                        {
+                            patchesMetadata.clearAndLoadAllInstances = true;
+                        }
+                        else if (patchPath.starts_with(PathStartingWithInstances))// Path begins with /Entities/
+                        {
+                            if (patchesMetadata.clearAndLoadAllInstances)
+                            {
+                                continue;
+                            }
+
+                            patchPath.remove_prefix(strlen(PathStartingWithInstances));
+                            AZStd::size_t pathSeparatorIndex = patchPath.find('/');
+                            if (pathSeparatorIndex != AZStd::string::npos) // Path begins with /Instances/{someString}/
+                            {
+                                patchesMetadata.instancesToReload.emplace(patchPath.substr(0, pathSeparatorIndex));
+                            }
+                            else // Path is /Instances/{someString}
+                            {
+                                Internal::IdentifyInstanceMembersToAddAndRemove(
+                                    patchEntry, patchesMetadata.instancesToAdd, patchesMetadata.instancesToRemove, AZStd::move(patchPath));
+                            }
+                        }
+                        else if (patchPath.starts_with(PathMatchingContainerEntity)) // Path begins with /ContainerEntity
+                        {
+                            patchesMetadata.shouldReloadContainerEntity = true;
+                        }
+                        else
+                        {
+                            AZ_Warning(
+                                "Prefab", false,
+                                "A patch starting with the keyword '%s' is identified. This is currently not a supported path for "
+                                "patching a prefab.",
+                                patchPath);
+                        }
+                    }
+                }
+                return AZStd::move(patchesMetadata);
             }
 
             void PrintPrefabDomValue(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -178,6 +178,11 @@ namespace AzToolsFramework
                     return true;
                 }
 
+                //! Identifies instance members to be added or removed by inspecting the patch entry provided.
+                //! @param patchEntry The patch entry to inspect.
+                //! @param membersToAdd The set to add the instance member to if an addition operation is detected.
+                //! @param membersToRemove The set to add the instance member to if a remove operation is detected.
+                //! @param memberName The name of the instance member found in the patch.
                 static void IdentifyInstanceMembersToAddAndRemove(
                     const PrefabDomValue& patchEntry,
                     AZStd::unordered_set<AZStd::string>& membersToAdd,

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -31,6 +31,11 @@ namespace AzToolsFramework
             inline static const char* ComponentsName = "Components";
             inline static const char* EntityOrderName = "Child Entity Order";
             inline static const char* TypeName = "$type";
+            inline static const char* PathMatchingEntities = "/Entities";
+            inline static const char* PathMatchingInstances = "/Instances";
+            inline static const char* PathStartingWithEntities = "/Entities/";
+            inline static const char* PathStartingWithInstances = "/Instances/";
+            inline static const char* PathMatchingContainerEntity = "/ContainerEntity";
 
             /**
             * Find Prefab value from given parent value and target value's name.
@@ -55,6 +60,18 @@ namespace AzToolsFramework
                 StripLinkIds = 1 << 1
             };
             AZ_DEFINE_ENUM_BITWISE_OPERATORS(StoreFlags);
+
+            struct PatchesMetadata
+            {
+                AZStd::unordered_set<EntityAlias> entitiesToReload;
+                AZStd::unordered_set<EntityAlias> entitiesToRemove;
+                AZStd::unordered_set<InstanceAlias> instancesToRemove;
+                AZStd::unordered_set<InstanceAlias> instancesToAdd;
+                AZStd::unordered_set<InstanceAlias> instancesToReload;
+                bool shouldReloadContainerEntity = false;
+                bool clearAndLoadAllEntities = false;
+                bool clearAndLoadAllInstances = false;
+            };
 
             /**
             * Stores a valid Prefab Instance within a Prefab Dom. Useful for generating Templates.
@@ -164,6 +181,8 @@ namespace AzToolsFramework
                 PrefabDomValue& prefabDomToApplyPatchesOn,
                 PrefabDom::AllocatorType& allocator,
                 const PrefabDomValue& patches);
+
+            PatchesMetadata IdentifyModifiedInstanceMembers(const PrefabDom& patches);
 
             /**
              * Prints the contents of the given prefab DOM value to the debug output console in a readable format.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -21,21 +21,21 @@ namespace AzToolsFramework
         class Instance;
         namespace PrefabDomUtils
         {
-            inline static const char* InstancesName = "Instances";
-            inline static const char* PatchesName = "Patches";
-            inline static const char* SourceName = "Source";
-            inline static const char* LinkIdName = "LinkId";
-            inline static const char* EntityIdName = "Id";
-            inline static const char* EntitiesName = "Entities";
-            inline static const char* ContainerEntityName = "ContainerEntity";
-            inline static const char* ComponentsName = "Components";
-            inline static const char* EntityOrderName = "Child Entity Order";
-            inline static const char* TypeName = "$type";
-            inline static const char* PathMatchingEntities = "/Entities";
-            inline static const char* PathMatchingInstances = "/Instances";
-            inline static const char* PathStartingWithEntities = "/Entities/";
-            inline static const char* PathStartingWithInstances = "/Instances/";
-            inline static const char* PathMatchingContainerEntity = "/ContainerEntity";
+            inline static constexpr const char* InstancesName = "Instances";
+            inline static constexpr const char* PatchesName = "Patches";
+            inline static constexpr const char* SourceName = "Source";
+            inline static constexpr const char* LinkIdName = "LinkId";
+            inline static constexpr const char* EntityIdName = "Id";
+            inline static constexpr const char* EntitiesName = "Entities";
+            inline static constexpr const char* ContainerEntityName = "ContainerEntity";
+            inline static constexpr const char* ComponentsName = "Components";
+            inline static constexpr const char* EntityOrderName = "Child Entity Order";
+            inline static constexpr const char* TypeName = "$type";
+            inline static constexpr const char* PathMatchingEntities = "/Entities";
+            inline static constexpr const char* PathMatchingInstances = "/Instances";
+            inline static constexpr const char* PathStartingWithEntities = "/Entities/";
+            inline static constexpr const char* PathStartingWithInstances = "/Instances/";
+            inline static constexpr const char* PathMatchingContainerEntity = "/ContainerEntity";
 
             /**
             * Find Prefab value from given parent value and target value's name.
@@ -64,14 +64,14 @@ namespace AzToolsFramework
             //! The metadata about patches indicating information about the modified instance members.
             struct PatchesMetadata
             {
-                AZStd::unordered_set<EntityAlias> entitiesToReload;
-                AZStd::unordered_set<EntityAlias> entitiesToRemove;
-                AZStd::unordered_set<InstanceAlias> instancesToRemove;
-                AZStd::unordered_set<InstanceAlias> instancesToAdd;
-                AZStd::unordered_set<InstanceAlias> instancesToReload;
-                bool shouldReloadContainerEntity = false;
-                bool clearAndLoadAllEntities = false;
-                bool clearAndLoadAllInstances = false;
+                AZStd::unordered_set<EntityAlias> m_entitiesToReload;
+                AZStd::unordered_set<EntityAlias> m_entitiesToRemove;
+                AZStd::unordered_set<InstanceAlias> m_instancesToRemove;
+                AZStd::unordered_set<InstanceAlias> m_instancesToAdd;
+                AZStd::unordered_set<InstanceAlias> m_instancesToReload;
+                bool m_shouldReloadContainerEntity = false;
+                bool m_clearAndLoadAllEntities = false;
+                bool m_clearAndLoadAllInstances = false;
             };
 
             /**

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.h
@@ -61,6 +61,7 @@ namespace AzToolsFramework
             };
             AZ_DEFINE_ENUM_BITWISE_OPERATORS(StoreFlags);
 
+            //! The metadata about patches indicating information about the modified instance members.
             struct PatchesMetadata
             {
                 AZStd::unordered_set<EntityAlias> entitiesToReload;
@@ -182,6 +183,9 @@ namespace AzToolsFramework
                 PrefabDom::AllocatorType& allocator,
                 const PrefabDomValue& patches);
 
+            //! Identifies instance members modified by inspecting the patches provided.
+            //! @param patches The patches to inspect.
+            //! @return PatchesMetada The metadata object indicating which instance members get modified with the provided patches.
             PatchesMetadata IdentifyModifiedInstanceMembers(const PrefabDom& patches);
 
             /**

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -812,7 +812,7 @@ namespace AzToolsFramework
                     else
                     {
                         Internal_HandleContainerOverride(
-                            parentUndoBatch, entityId, patch, owningInstance->get().GetLinkId(), owningInstance->get().GetParentInstance());
+                            parentUndoBatch, entityId, patch, owningInstance->get().GetLinkId());
                     }
                 }
                 else

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.h
@@ -173,7 +173,7 @@ namespace AzToolsFramework
 
             static void Internal_HandleContainerOverride(
                 UndoSystem::URSequencePoint* undoBatch, AZ::EntityId entityId, const PrefabDom& patch,
-                const LinkId linkId, InstanceOptionalReference parentInstance = AZStd::nullopt);
+                const LinkId linkId);
             static void Internal_HandleEntityChange(
                 UndoSystem::URSequencePoint* undoBatch, AZ::EntityId entityId, PrefabDom& beforeState,
                 PrefabDom& afterState);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Instance/InstanceDeserializationTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Instance/InstanceDeserializationTests.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
+#pragma optimize("", off)
 #include <AzToolsFramework/ToolsComponents/TransformComponent.h>
 #include <AzToolsFramework/Prefab/PrefabDomUtils.h>
 #include <Prefab/PrefabTestFixture.h>
@@ -25,17 +25,18 @@ namespace UnitTest
     }
 
     AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> SetupPrefabInstances(
-        const AzToolsFramework::EntityList& entitiesToUseForCreation, PrefabSystemComponent* prefabSystemComponent)
+        const AzToolsFramework::EntityList& entitiesToUseForCreation,
+        AZStd::vector<AZStd::unique_ptr<Instance>>&& nestedInstances, PrefabSystemComponent* prefabSystemComponent)
     {
         AZStd::unique_ptr<AzToolsFramework::Prefab::Instance> createdPrefab =
-            prefabSystemComponent->CreatePrefab(entitiesToUseForCreation, {}, "test/path");
+            prefabSystemComponent->CreatePrefab(entitiesToUseForCreation, AZStd::move(nestedInstances), "test/path");
         EXPECT_NE(nullptr, createdPrefab);
 
         AZStd::unique_ptr<AzToolsFramework::Prefab::Instance> instantiatedPrefab =
             prefabSystemComponent->InstantiatePrefab(createdPrefab->GetTemplateId());
         EXPECT_NE(nullptr, instantiatedPrefab);
 
-        instantiatedPrefab->GetEntities(
+        instantiatedPrefab->GetAllEntitiesInHierarchy(
             [](const AZStd::unique_ptr<AZ::Entity>& entity)
             {
                 // Activate the entities so that we can later validate that entities stay activated throughout the deserialization.
@@ -47,6 +48,23 @@ namespace UnitTest
         return { AZStd::move(createdPrefab), AZStd::move(instantiatedPrefab) };
     }
 
+    void ValidateEntityState(const InstanceUniquePointer& instanceToLookUnder, AZStd::string_view entityName, AZ::Entity::State expectedEntityState)
+    {
+        bool isEntityFound = false;
+        instanceToLookUnder->GetEntities(
+            [&isEntityFound, &entityName, &expectedEntityState](const AZStd::unique_ptr<AZ::Entity>& entity)
+            {
+                if (entity->GetName() == entityName)
+                {
+                    EXPECT_EQ(entity->GetState(), expectedEntityState);
+                    isEntityFound = true;
+                }
+                return true;
+            });
+        EXPECT_TRUE(isEntityFound); 
+    }
+
+
     TEST_F(InstanceDeserializationTest, ReloadInstanceUponComponentUpdate)
     {
         AZ::Entity* entity1 = CreateEntity("Entity1",false);
@@ -57,7 +75,7 @@ namespace UnitTest
         AZ::Entity* entity2 = CreateEntity("Entity2", false);
 
         AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
-            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1, entity2}, m_prefabSystemComponent);
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1, entity2}, {}, m_prefabSystemComponent);
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
@@ -109,7 +127,7 @@ namespace UnitTest
         AZ::Entity* entity2 = CreateEntity("Entity2", false);
 
         AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
-            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1, entity2 }, m_prefabSystemComponent);
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1, entity2 }, {}, m_prefabSystemComponent);
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
@@ -161,7 +179,7 @@ namespace UnitTest
         AZ::Entity* entity2 = CreateEntity("Entity2", false);
 
         AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
-            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1, entity2 }, m_prefabSystemComponent);
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1, entity2 }, {}, m_prefabSystemComponent);
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
@@ -208,7 +226,7 @@ namespace UnitTest
         AZ::Entity* entity1 = CreateEntity("Entity1", false);
 
         AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
-            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1 }, m_prefabSystemComponent);
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1 }, {}, m_prefabSystemComponent);
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
@@ -238,10 +256,10 @@ namespace UnitTest
         EXPECT_TRUE(isEntity2Found);
     }
 
-    TEST_F(InstanceDeserializationTest, ReloadInstanceUponAddingEntityToEmptyInstance)
+    TEST_F(InstanceDeserializationTest, ReloadInstanceUponAddingTheFirstEntity)
     {
         AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
-            SetupPrefabInstances(AzToolsFramework::EntityList{}, m_prefabSystemComponent);
+            SetupPrefabInstances(AzToolsFramework::EntityList{}, {}, m_prefabSystemComponent);
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
@@ -267,7 +285,7 @@ namespace UnitTest
         AZ::Entity* entity2 = CreateEntity("Entity2", false);
 
         AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
-            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1, entity2 }, m_prefabSystemComponent);
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1, entity2 }, {}, m_prefabSystemComponent);
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
@@ -301,7 +319,7 @@ namespace UnitTest
         AZ::Entity* entity1 = CreateEntity("Entity1", false);
 
         AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
-            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1 }, m_prefabSystemComponent);
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1 }, {}, m_prefabSystemComponent);
         InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
         InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
 
@@ -323,4 +341,133 @@ namespace UnitTest
             });
         EXPECT_FALSE(isEntity1Found);
     }
+
+    TEST_F(InstanceDeserializationTest, ReloadInstanceUponAddingTheFirstNestedInstance)
+    {
+        AZ::Entity* entity1 = CreateEntity("Entity1", false);
+        AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1 }, {}, m_prefabSystemComponent);
+        InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
+        InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
+
+        AZStd::unique_ptr<AzToolsFramework::Prefab::Instance> nestedPrefab = m_prefabSystemComponent->CreatePrefab(
+            AzToolsFramework::EntityList{ CreateEntity("Entity1", false) }, {}, "test/nestedPrefabPath");
+
+        // Extract the template id from the instance and store it in a variable before moving the instance.
+        TemplateId nestedPrefabTemplateId = nestedPrefab->GetTemplateId();
+        createdPrefab->AddInstance(AZStd::move(nestedPrefab));
+        GenerateDomAndReloadInstantiatedPrefab(createdPrefab, instantiatedPrefab);
+
+        ValidateEntityState(instantiatedPrefab, "Entity1", AZ::Entity::State::Active);
+        EXPECT_EQ(instantiatedPrefab->GetNestedInstanceAliases(nestedPrefabTemplateId).size(), 1);
+    }
+
+    TEST_F(InstanceDeserializationTest, ReloadInstanceUponAddingNestedInstanceToExistingNestedInstances)
+    {
+        AZ::Entity* entity1 = CreateEntity("EntityUnderParentPrefab", false);
+        InstanceUniquePointer nestedInstanceToUseForCreation = m_prefabSystemComponent->CreatePrefab(
+            AzToolsFramework::EntityList{ CreateEntity("EntityUnderNestedPrefab", false) }, {}, "test/nestedPrefabPath");
+
+        // Extract the template id from the instance and store it in a variable before moving the instance.
+        TemplateId nestedPrefabTemplateId = nestedInstanceToUseForCreation->GetTemplateId();
+
+        AZStd::vector<InstanceUniquePointer> nestedInstances;
+        nestedInstances.emplace_back(AZStd::move(nestedInstanceToUseForCreation));
+        
+        AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances = SetupPrefabInstances(
+            AzToolsFramework::EntityList{ entity1 }, AZStd::move(nestedInstances),
+            m_prefabSystemComponent);
+        InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
+        InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
+
+        InstanceUniquePointer nestedInstanceToAdd = m_prefabSystemComponent->InstantiatePrefab(nestedPrefabTemplateId);
+        Instance& instanceAdded = createdPrefab->AddInstance(AZStd::move(nestedInstanceToAdd));
+        InstanceAlias aliasOfInstanceAdded = instanceAdded.GetInstanceAlias();
+
+        GenerateDomAndReloadInstantiatedPrefab(createdPrefab, instantiatedPrefab);
+
+        ValidateEntityState(instantiatedPrefab, "EntityUnderParentPrefab", AZ::Entity::State::Active);
+        EXPECT_EQ(instantiatedPrefab->GetNestedInstanceAliases(nestedPrefabTemplateId).size(), 2);
+        instantiatedPrefab->GetNestedInstances(
+            [&aliasOfInstanceAdded](AZStd::unique_ptr<Instance>& nestedInstance)
+            {
+                if (nestedInstance->GetInstanceAlias() == aliasOfInstanceAdded)
+                {
+                    ValidateEntityState(nestedInstance, "EntityUnderNestedPrefab", AZ::Entity::State::Constructed);
+                }
+                else
+                {
+                    ValidateEntityState(nestedInstance, "EntityUnderNestedPrefab", AZ::Entity::State::Active);
+                }
+                
+        });
+    }
+
+    TEST_F(InstanceDeserializationTest, ReloadInstanceUponDeletingTheOnlyNestedInstance)
+    {
+        AZ::Entity* entity1 = CreateEntity("EntityUnderParentPrefab", false);
+        InstanceUniquePointer nestedInstanceToUseForCreation = m_prefabSystemComponent->CreatePrefab(
+            AzToolsFramework::EntityList{ CreateEntity("EntityUnderNestedPrefab", false) }, {}, "test/nestedPrefabPath");
+
+        // Extract the template id from the instance and store it in a variable before moving the instance.
+        TemplateId nestedPrefabTemplateId = nestedInstanceToUseForCreation->GetTemplateId();
+
+        AZStd::vector<InstanceUniquePointer> nestedInstances;
+        nestedInstances.emplace_back(AZStd::move(nestedInstanceToUseForCreation));
+
+        AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1 }, AZStd::move(nestedInstances), m_prefabSystemComponent);
+        InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
+        InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
+
+        ASSERT_EQ(createdPrefab->GetNestedInstanceAliases(nestedPrefabTemplateId).size(), 1);
+        InstanceUniquePointer nestedInstanceToRemove =
+            createdPrefab->DetachNestedInstance(createdPrefab->GetNestedInstanceAliases(nestedPrefabTemplateId).front());
+        nestedInstanceToRemove.reset();
+
+        GenerateDomAndReloadInstantiatedPrefab(createdPrefab, instantiatedPrefab);
+
+        ValidateEntityState(instantiatedPrefab, "EntityUnderParentPrefab", AZ::Entity::State::Active);
+        EXPECT_EQ(instantiatedPrefab->GetNestedInstanceAliases(nestedPrefabTemplateId).size(), 0);
+    }
+
+    TEST_F(InstanceDeserializationTest, ReloadInstanceUponDeletingOneAmongManyNestedInstances)
+    {
+        AZ::Entity* entity1 = CreateEntity("EntityUnderParentPrefab", false);
+        InstanceUniquePointer nestedInstance1 = m_prefabSystemComponent->CreatePrefab(
+            AzToolsFramework::EntityList{ CreateEntity("EntityUnderNestedPrefab", false) }, {}, "test/nestedPrefabPath");
+
+        // Extract the template id from the instance and store it in a variable before moving the instance.
+        TemplateId nestedPrefabTemplateId = nestedInstance1->GetTemplateId();
+
+        InstanceUniquePointer nestedInstance2 = m_prefabSystemComponent->InstantiatePrefab(nestedPrefabTemplateId);
+
+        AZStd::vector<InstanceUniquePointer> nestedInstances;
+        nestedInstances.emplace_back(AZStd::move(nestedInstance1));
+        nestedInstances.emplace_back(AZStd::move(nestedInstance2));
+
+        AZStd::pair<InstanceUniquePointer, InstanceUniquePointer> prefabInstances =
+            SetupPrefabInstances(AzToolsFramework::EntityList{ entity1 }, AZStd::move(nestedInstances), m_prefabSystemComponent);
+        InstanceUniquePointer createdPrefab = AZStd::move(prefabInstances.first);
+        InstanceUniquePointer instantiatedPrefab = AZStd::move(prefabInstances.second);
+
+        AZStd::vector<InstanceAlias> nestedInstanceAliases = createdPrefab->GetNestedInstanceAliases(nestedPrefabTemplateId);
+        ASSERT_EQ(nestedInstanceAliases.size(), 2);
+        InstanceUniquePointer nestedInstanceToRemove = createdPrefab->DetachNestedInstance(nestedInstanceAliases.front());
+        nestedInstanceToRemove.reset();
+
+        GenerateDomAndReloadInstantiatedPrefab(createdPrefab, instantiatedPrefab);
+
+        ValidateEntityState(instantiatedPrefab, "EntityUnderParentPrefab", AZ::Entity::State::Active);
+        EXPECT_EQ(instantiatedPrefab->GetNestedInstanceAliases(nestedPrefabTemplateId).size(), 1);
+        instantiatedPrefab->GetNestedInstances(
+            [&nestedInstanceAliases](AZStd::unique_ptr<Instance>& nestedInstance)
+            {
+                if (nestedInstance->GetInstanceAlias() == nestedInstanceAliases.back())
+                {
+                    ValidateEntityState(nestedInstance, "EntityUnderNestedPrefab", AZ::Entity::State::Active);
+                }
+            });
+    }
 } // namespace UnitTest
+#pragma optimize("", on)


### PR DESCRIPTION
Major changes in this PR:
 
1. Identified nested instances to add, remove and reload by expanding the patch inspection logic during deserialization.
2. Selectively reloaded only modified nested prefabs using the data from previous step.

Minor changes in this PR:
1. Moved IdentifyInstanceMembersToReload to PrefabDomUtils to keep decouple patch inspection logic from deserialization and keep things simple
2. Created a helper function for ClearAndLoadInstances() and reused it for general loading and selective reloading
3. Created a PatchesMetadata struct to avoid creating multiple out parameters and to easily pass that metadata around.
4. Made a few changes to fix editor workflow errors around nested prefab creation and instantiation.

Testing:
1. Manually tested editor workflows around nested prefabs
2. Added unit tests for selective reloading of nested instance additions and removals
3. Benchmarks will follow soon in another PR.

