### PR TITLE
Fix symbol stripping issue

### DIFF
--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -97,6 +97,7 @@ ly_add_target(
             Gem::ScriptCanvasDebugger
             Gem::ScriptCanvas.Extensions
     AUTOGEN_RULES
+        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Header.jinja,$path/$fileprefix.generated.h
         *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,$path/$fileprefix.generated.cpp
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Header.jinja,$path/$fileprefix.generated.h
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Source.jinja,$path/$fileprefix.generated.cpp

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -16,6 +16,11 @@ namespace AZ
     class ReflectContext;
 }
 
+//! Macros to self-register AutoGen functions into ScriptCanvas
+//! Which takes the same library name as provided in .ScriptCanvasFunction.xml
+#define REGISTER_SCRIPTCANVAS_FUNCTION(LIBRARY)\
+    static ScriptCanvas##LIBRARY s_ScriptCanvas##LIBRARY;
+
 namespace ScriptCanvas
 {
     class IScriptCanvasFunctionRegistry

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
@@ -26,6 +26,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {{- macros.Required('Include', Library, Library) -}}
 {{- macros.Required('Name', Library, Library) -}}
 
+{% set sanitizedName = macros.CleanName(Library.attrib['Name']) %}
 {% set className = macros.CleanName('ScriptCanvas' + Library.attrib['Name']) %}
 {% set namespaceList = [] %}
 {% set sanitizedNamespaceName = 'GlobalMethod' %}
@@ -40,25 +41,26 @@ namespace {{namespace}}
 {
 {% endfor %}
 
-    class {{className}}
-        : public ScriptCanvas::IScriptCanvasFunctionRegistry
-    {
-    public:
-        {{className}}();
+class {{className}}
+    : public ScriptCanvas::IScriptCanvasFunctionRegistry
+{
+public:
+    {{className}}();
 
-        virtual ~{{className}}();
+    virtual ~{{className}}();
  
-        void Reflect(AZ::ReflectContext* context) override;
-    };
+    void Reflect(AZ::ReflectContext* context) override;
+};
 
 {% for namespace in namespaceList %}
 }
 {% endfor %}
 
-#define REGISTER_{{sanitizedNamespaceName|upper}}\
 {% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
+#define REGISTER_{{sanitizedNamespaceName|upper}}\
     static {{Library.attrib['Namespace']}}::{{className}} s_{{className}};
 {% else %}
+#define REGISTER_{{sanitizedName|upper}}\
     static {{className}} s_{{className}};
 {% endif %}
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
@@ -1,0 +1,68 @@
+{#
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+#}
+
+{% import 'ScriptCanvas_Macros.jinja' as macros %}
+
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// This code was produced with AzAutoGen, any modifications made will not be preserved.
+// If you need to modify this code see:
+//
+// Gems\ScriptCanvas\Code\Include\ScriptCanvas\AutoGen\ScriptCanvasFunction_Source.jinja
+//
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <AzCore/RTTI/BehaviorContext.h>
+#include <ScriptCanvasAutoGenRegistry.h>
+
+{% for ScriptCanvas in dataFiles %}
+{% for Library in ScriptCanvas%}
+
+{{- macros.Required('Include', Library, Library) -}}
+{{- macros.Required('Name', Library, Library) -}}
+
+{% set className = macros.CleanName('ScriptCanvas' + Library.attrib['Name']) %}
+{% set namespaceList = [] %}
+{% set sanitizedNamespaceName = 'GlobalMethod' %}
+{% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
+{% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
+{% set sanitizedNamespaceName = macros.CleanName(Library.attrib['Namespace'].replace('::', '_')) %}
+{% endif %}
+{% set categoryName = Library.attrib['Category'] %}
+
+{% for namespace in namespaceList %}
+namespace {{namespace}}
+{
+{% endfor %}
+
+    class {{className}}
+        : public ScriptCanvas::IScriptCanvasFunctionRegistry
+    {
+    public:
+        {{className}}();
+
+        virtual ~{{className}}();
+ 
+        void Reflect(AZ::ReflectContext* context) override;
+    };
+
+{% for namespace in namespaceList %}
+}
+{% endfor %}
+
+#define REGISTER_{{sanitizedNamespaceName|upper}}\
+{% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
+    static {{Library.attrib['Namespace']}}::{{className}} s_{{className}};
+{% else %}
+    static {{className}} s_{{className}};
+{% endif %}
+
+{{ macros.ReportErrors() }}
+
+{% endfor %}
+{% endfor %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
@@ -26,15 +26,11 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {{- macros.Required('Include', Library, Library) -}}
 {{- macros.Required('Name', Library, Library) -}}
 
-{% set sanitizedName = macros.CleanName(Library.attrib['Name']) %}
 {% set className = macros.CleanName('ScriptCanvas' + Library.attrib['Name']) %}
 {% set namespaceList = [] %}
-{% set sanitizedNamespaceName = 'GlobalMethod' %}
 {% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
 {% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
-{% set sanitizedNamespaceName = macros.CleanName(Library.attrib['Namespace'].replace('::', '_')) %}
 {% endif %}
-{% set categoryName = Library.attrib['Category'] %}
 
 {% for namespace in namespaceList %}
 namespace {{namespace}}
@@ -55,14 +51,6 @@ public:
 {% for namespace in namespaceList %}
 }
 {% endfor %}
-
-{% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
-#define REGISTER_{{sanitizedNamespaceName|upper}}\
-    static {{Library.attrib['Namespace']}}::{{className}} s_{{className}};
-{% else %}
-#define REGISTER_{{sanitizedName|upper}}\
-    static {{className}} s_{{className}};
-{% endif %}
 
 {{ macros.ReportErrors() }}
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -76,55 +76,55 @@ namespace {{namespace}}
 {
 {% endfor %}
 
-	{{className}}::{{className}}()
-	{
-		ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{sanitizedNamespaceName}}_{{className}}", this);
-	}
+{{className}}::{{className}}()
+{
+    ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{sanitizedNamespaceName}}_{{className}}", this);
+}
 
-	{{className}}::~{{className}}()
-	{
-		ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction("{{sanitizedNamespaceName}}_{{className}}");
-	}
+{{className}}::~{{className}}()
+{
+    ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction("{{sanitizedNamespaceName}}_{{className}}");
+}
 
-	void {{className}}::Reflect(AZ::ReflectContext* context)
-	{
-		if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
-		{
+void {{className}}::Reflect(AZ::ReflectContext* context)
+{
+    if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+    {
 {% for function in Library.findall('Function') %}
-			{
+        {
 {{ macros.Required('Name', function, Library) }}
 
 {%- set hasbranch = CheckFunctionBranchResult(function) -%}
 {% if hasbranch|booleanTrue == true %}
 {% set branchfunction = function.attrib['Branch'] %}
-				AZ::BranchOnResultInfo branchResultInfo;
+            AZ::BranchOnResultInfo branchResultInfo;
 {% if branchfunction is defined and branchfunction and not branchfunction == "Boolean" %}
 {% set sanitizedBranchFunctionName = macros.CleanName(branchfunction).replace('::', '_') %}
-				branchResultInfo.m_nonBooleanResultCheckName = "{{sanitizedNamespaceName}}_{{sanitizedBranchFunctionName}}";
+            branchResultInfo.m_nonBooleanResultCheckName = "{{sanitizedNamespaceName}}_{{sanitizedBranchFunctionName}}";
 {% endif -%}
 {% set branchwithvalue = function.attrib['BranchWithValue'] %}
 {%- if branchwithvalue is defined and branchwithvalue.lower() == "true" %}
-				branchResultInfo.m_returnResultInBranches = true;
+            branchResultInfo.m_returnResultInBranches = true;
 {% endif -%}
 {{SetBranchExecution(function)}}
 {%- endif -%}
 
 {% set functionName = macros.CleanName(function.attrib['Name']) %}
 {% set sanitizedFunctionName = macros.CleanName(function.attrib['Name']).replace('::', '_') %}
-				behaviorContext->Method("{{sanitizedNamespaceName}}_{{sanitizedFunctionName}}", &{{functionName}},
+            behaviorContext->Method("{{sanitizedNamespaceName}}_{{sanitizedFunctionName}}", &{{functionName}},
 {{macros.GenerateFunctionMetaData(function)}})
-					->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
 {% if categoryName %}
-					->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
+                ->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
 {% endif %}
 {% if hasbranch|booleanTrue == true %}
-					->Attribute(AZ::ScriptCanvasAttributes::BranchOnResult, branchResultInfo)
+                ->Attribute(AZ::ScriptCanvasAttributes::BranchOnResult, branchResultInfo)
 {% endif %}
-				;
-			}
+            ;
+        }
 {% endfor %}
-		}
-	}
+    }
+}
 
 {% for namespace in namespaceList %}
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -76,62 +76,55 @@ namespace {{namespace}}
 {
 {% endfor %}
 
-    class {{className}}
-        : public ScriptCanvas::IScriptCanvasFunctionRegistry
-    {
-    public:
-        {{className}}()
-        {
-            ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{sanitizedNamespaceName}}_{{className}}", this);
-        }
+	{{className}}::{{className}}()
+	{
+		ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{sanitizedNamespaceName}}_{{className}}", this);
+	}
 
-        virtual ~{{className}}()
-        {
-            ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction("{{sanitizedNamespaceName}}_{{className}}");
-        }
- 
-        void Reflect(AZ::ReflectContext* context) override
-        {
-            if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
-            {
+	{{className}}::~{{className}}()
+	{
+		ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction("{{sanitizedNamespaceName}}_{{className}}");
+	}
+
+	void {{className}}::Reflect(AZ::ReflectContext* context)
+	{
+		if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+		{
 {% for function in Library.findall('Function') %}
-                {
+			{
 {{ macros.Required('Name', function, Library) }}
 
 {%- set hasbranch = CheckFunctionBranchResult(function) -%}
 {% if hasbranch|booleanTrue == true %}
 {% set branchfunction = function.attrib['Branch'] %}
-                    AZ::BranchOnResultInfo branchResultInfo;
+				AZ::BranchOnResultInfo branchResultInfo;
 {% if branchfunction is defined and branchfunction and not branchfunction == "Boolean" %}
 {% set sanitizedBranchFunctionName = macros.CleanName(branchfunction).replace('::', '_') %}
-                    branchResultInfo.m_nonBooleanResultCheckName = "{{sanitizedNamespaceName}}_{{sanitizedBranchFunctionName}}";
+				branchResultInfo.m_nonBooleanResultCheckName = "{{sanitizedNamespaceName}}_{{sanitizedBranchFunctionName}}";
 {% endif -%}
 {% set branchwithvalue = function.attrib['BranchWithValue'] %}
 {%- if branchwithvalue is defined and branchwithvalue.lower() == "true" %}
-                    branchResultInfo.m_returnResultInBranches = true;
+				branchResultInfo.m_returnResultInBranches = true;
 {% endif -%}
 {{SetBranchExecution(function)}}
 {%- endif -%}
 
 {% set functionName = macros.CleanName(function.attrib['Name']) %}
 {% set sanitizedFunctionName = macros.CleanName(function.attrib['Name']).replace('::', '_') %}
-                    behaviorContext->Method("{{sanitizedNamespaceName}}_{{sanitizedFunctionName}}", &{{functionName}},
+				behaviorContext->Method("{{sanitizedNamespaceName}}_{{sanitizedFunctionName}}", &{{functionName}},
 {{macros.GenerateFunctionMetaData(function)}})
-                        ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+					->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
 {% if categoryName %}
-                        ->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
+					->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
 {% endif %}
 {% if hasbranch|booleanTrue == true %}
-                        ->Attribute(AZ::ScriptCanvasAttributes::BranchOnResult, branchResultInfo)
+					->Attribute(AZ::ScriptCanvasAttributes::BranchOnResult, branchResultInfo)
 {% endif %}
-                    ;
-                }
+				;
+			}
 {% endfor %}
-            }
-        }
-    };
-
-    static {{className}} s_{{className}};
+		}
+	}
 
 {% for namespace in namespaceList %}
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.cpp
@@ -11,6 +11,8 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TransformBus.h>
 
+REGISTER_SCRIPTCANVAS_ENTITYFUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace EntityFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.cpp
@@ -11,12 +11,12 @@
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TransformBus.h>
 
-REGISTER_SCRIPTCANVAS_ENTITYFUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace EntityFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(EntityFunctions);
+
         AZ::Vector3 GetEntityRight(AZ::EntityId entityId, double scale)
         {
             AZ::Transform worldTransform = {};

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Vector3.h>
+#include <Include/ScriptCanvas/Libraries/Entity/EntityFunctions.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.cpp
@@ -8,12 +8,12 @@
 
 #include "AABB.h"
 
-REGISTER_SCRIPTCANVAS_AABBFUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace AABBFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(AABBFunctions);
+
         AZ::Aabb AddAABB(AZ::Aabb a, const AZ::Aabb& b)
         {
             a.AddAabb(b);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.cpp
@@ -8,6 +8,8 @@
 
 #include "AABB.h"
 
+REGISTER_SCRIPTCANVAS_AABBFUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace AABBFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.h
@@ -13,6 +13,7 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/tuple.h>
+#include <Include/ScriptCanvas/Libraries/Math/AABB.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.cpp
@@ -10,12 +10,12 @@
 
 #include <AzCore/Math/Crc.h>
 
-REGISTER_SCRIPTCANVAS_CRCFUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace CRCFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(CRCFunctions);
+
         Data::CRCType FromString(Data::StringType value)
         {
             return AZ::Crc32(value.data());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.cpp
@@ -10,6 +10,8 @@
 
 #include <AzCore/Math/Crc.h>
 
+REGISTER_SCRIPTCANVAS_CRCFUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace CRCFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/CRC.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.cpp
@@ -11,12 +11,12 @@
 #include <AzCore/Math/Color.h>
 #include <ScriptCanvas/Libraries/Math/MathNodeUtilities.h>
 
-REGISTER_SCRIPTCANVAS_COLORFUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace ColorFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(ColorFunctions);
+
         using namespace Data;
 
         NumberType Dot(ColorType a, ColorType b)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.cpp
@@ -11,6 +11,8 @@
 #include <AzCore/Math/Color.h>
 #include <ScriptCanvas/Libraries/Math/MathNodeUtilities.h>
 
+REGISTER_SCRIPTCANVAS_COLORFUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace ColorFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Color.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.cpp
@@ -12,6 +12,9 @@
 #include <AzCore/Math/Vector4.h>
 #include <ScriptCanvas/Libraries/Math/MathNodeUtilities.h>
 
+REGISTER_SCRIPTCANVAS_MATHFUNCTIONS;
+REGISTER_SCRIPTCANVAS_MATHRANDOMS;
+
 namespace ScriptCanvas
 {
     namespace MathFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.cpp
@@ -12,13 +12,12 @@
 #include <AzCore/Math/Vector4.h>
 #include <ScriptCanvas/Libraries/Math/MathNodeUtilities.h>
 
-REGISTER_SCRIPTCANVAS_MATHFUNCTIONS;
-REGISTER_SCRIPTCANVAS_MATHRANDOMS;
-
 namespace ScriptCanvas
 {
     namespace MathFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(MathFunctions);
+
         Data::NumberType MultiplyAndAdd(Data::NumberType multiplicand, Data::NumberType multiplier, Data::NumberType addend)
         {
             // result = src0 * src1 + src2
@@ -33,6 +32,8 @@ namespace ScriptCanvas
 
     namespace MathRandoms
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(MathRandoms);
+
         Data::ColorType RandomColor(Data::ColorType minValue, Data::ColorType maxValue)
         {
             return Data::ColorType(MathNodeUtilities::GetRandomReal<float>(minValue.GetR(), maxValue.GetR()),

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/MathFunctions.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.cpp
@@ -8,12 +8,12 @@
 
 #include "Matrix3x3.h"
 
-REGISTER_SCRIPTCANVAS_MATRIX3X3FUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace Matrix3x3Functions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(Matrix3x3Functions);
+
         Data::Matrix3x3Type FromColumns(
             const Data::Vector3Type& col0, const Data::Vector3Type& col1, const Data::Vector3Type& col2)
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.cpp
@@ -8,6 +8,8 @@
 
 #include "Matrix3x3.h"
 
+REGISTER_SCRIPTCANVAS_MATRIX3X3FUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace Matrix3x3Functions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Matrix3x3.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.cpp
@@ -8,6 +8,8 @@
 
 #include "Matrix4x4.h"
 
+REGISTER_SCRIPTCANVAS_MATRIX4X4FUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace Matrix4x4Functions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.cpp
@@ -8,12 +8,12 @@
 
 #include "Matrix4x4.h"
 
-REGISTER_SCRIPTCANVAS_MATRIX4X4FUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace Matrix4x4Functions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(Matrix4x4Functions);
+
         Data::Matrix4x4Type FromColumns(
             const Data::Vector4Type& col0, const Data::Vector4Type& col1, const Data::Vector4Type& col2, const Data::Vector4Type& col3)
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Matrix4x4.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.cpp
@@ -8,12 +8,12 @@
 
 #include "OBB.h"
 
-REGISTER_SCRIPTCANVAS_OBBFUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace OBBFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(OBBFunctions);
+
         using namespace Data;
 
         OBBType FromAabb(const AABBType& source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.cpp
@@ -8,6 +8,8 @@
 
 #include "OBB.h"
 
+REGISTER_SCRIPTCANVAS_OBBFUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace OBBFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/OBB.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.cpp
@@ -8,12 +8,12 @@
 
 #include "Plane.h"
 
-REGISTER_SCRIPTCANVAS_PLANEFUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace PlaneFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(PlaneFunctions);
+
         using namespace Data;
 
         NumberType DistanceToPoint(PlaneType source, Vector3Type point)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.cpp
@@ -8,6 +8,8 @@
 
 #include "Plane.h"
 
+REGISTER_SCRIPTCANVAS_PLANEFUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace PlaneFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Plane.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
@@ -8,6 +8,8 @@
 
 #include "Quaternion.h"
 
+REGISTER_SCRIPTCANVAS_QUATERNIONFUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace QuaternionFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
@@ -8,12 +8,12 @@
 
 #include "Quaternion.h"
 
-REGISTER_SCRIPTCANVAS_QUATERNIONFUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace QuaternionFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(QuaternionFunctions);
+
         using namespace Data;
 
         QuaternionType Conjugate(QuaternionType source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Quaternion.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.cpp
@@ -8,6 +8,8 @@
 
 #include "Transform.h"
 
+REGISTER_SCRIPTCANVAS_TRANSFORMFUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace TransformFunctions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.cpp
@@ -8,12 +8,12 @@
 
 #include "Transform.h"
 
-REGISTER_SCRIPTCANVAS_TRANSFORMFUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace TransformFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(TransformFunctions);
+
         using namespace Data;
 
         TransformType FromMatrix3x3(Matrix3x3Type source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Transform.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
@@ -8,6 +8,8 @@
 
 #include "Vector2.h"
 
+REGISTER_SCRIPTCANVAS_VECTOR2FUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace Vector2Functions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
@@ -8,12 +8,12 @@
 
 #include "Vector2.h"
 
-REGISTER_SCRIPTCANVAS_VECTOR2FUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace Vector2Functions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(Vector2Functions);
+
         using namespace Data;
 
         Vector2Type Absolute(const Vector2Type source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Vector2.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
@@ -8,12 +8,12 @@
 
 #include "Vector3.h"
 
-REGISTER_SCRIPTCANVAS_VECTOR3FUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace Vector3Functions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(Vector3Functions);
+
         using namespace Data;
 
         Vector3Type Absolute(const Vector3Type source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
@@ -8,6 +8,8 @@
 
 #include "Vector3.h"
 
+REGISTER_SCRIPTCANVAS_VECTOR3FUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace Vector3Functions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Vector3.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.cpp
@@ -8,12 +8,12 @@
 
 #include "Vector4.h"
 
-REGISTER_SCRIPTCANVAS_VECTOR4FUNCTIONS;
-
 namespace ScriptCanvas
 {
     namespace Vector4Functions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(Vector4Functions);
+
         using namespace Data;
 
         Vector4Type Absolute(const Vector4Type source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.cpp
@@ -8,6 +8,8 @@
 
 #include "Vector4.h"
 
+REGISTER_SCRIPTCANVAS_VECTOR4FUNCTIONS;
+
 namespace ScriptCanvas
 {
     namespace Vector4Functions

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
+#include <Include/ScriptCanvas/Libraries/Math/Vector4.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.cpp
@@ -15,6 +15,8 @@
 
 #define LUA_BACKEND
 
+REGISTER_SCRIPTCANVAS_STRINGFUNCTIONS;
+
 namespace ScriptCanvas
 {
     static const size_t k_LuaNpos = UINT_MAX;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.cpp
@@ -15,14 +15,14 @@
 
 #define LUA_BACKEND
 
-REGISTER_SCRIPTCANVAS_STRINGFUNCTIONS;
-
 namespace ScriptCanvas
 {
     static const size_t k_LuaNpos = UINT_MAX;
 
     namespace StringFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(StringFunctions);
+
         AZStd::string ToLower(AZStd::string sourceString)
         {
             AZStd::to_lower(sourceString.begin(), sourceString.end());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.h
@@ -10,6 +10,7 @@
 
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
+#include <Include/ScriptCanvas/Libraries/String/StringFunctions.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_headers.cmake
@@ -67,6 +67,7 @@ set(FILES
     Include/ScriptCanvas/PerformanceTracker.h
     Include/ScriptCanvas/AutoGen/ScriptCanvas_Macros.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvas_Nodeable_Macros.jinja
+    Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Header.jinja
     Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Source.jinja

--- a/Gems/ScriptCanvasPhysics/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvasPhysics/Code/CMakeLists.txt
@@ -20,6 +20,7 @@ ly_add_target(
         PUBLIC
             Gem::ScriptCanvas.Extensions
     AUTOGEN_RULES
+        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Header.jinja,$path/$fileprefix.generated.h
         *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,$path/$fileprefix.generated.cpp
 )
 

--- a/Gems/ScriptCanvasPhysics/Code/Source/World.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Source/World.cpp
@@ -21,6 +21,8 @@ namespace ScriptCanvasPhysics
 {
     namespace WorldFunctions
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(WorldFunctions);
+
         Result RayCastWorldSpaceWithGroup(
             const AZ::Vector3& start,
             const AZ::Vector3& direction,

--- a/Gems/ScriptCanvasPhysics/Code/Source/World.h
+++ b/Gems/ScriptCanvasPhysics/Code/Source/World.h
@@ -17,6 +17,7 @@
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/string/string.h>
+#include <Source/World.generated.h>
 
 namespace ScriptCanvasPhysics
 {

--- a/Gems/ScriptCanvasPhysics/Code/scriptcanvas_physics_files.cmake
+++ b/Gems/ScriptCanvasPhysics/Code/scriptcanvas_physics_files.cmake
@@ -9,6 +9,7 @@
 get_property(scriptcanvas_gem_root GLOBAL PROPERTY "@GEMROOT:ScriptCanvas@")
 
 set(FILES
+    ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
     ${scriptcanvas_gem_root}/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
     Source/ScriptCanvasPhysicsSystemComponent.cpp
     Source/ScriptCanvasPhysicsSystemComponent.h


### PR DESCRIPTION
## Details
As AutoGen function is using static initialization to register specified function metadata into AutoGenRegistry singleton object.
And originally, the static object is written into xxxx.generated.cpp file, but compiler starts stripping and optimizing out those code when having more and more autogen files get added.

The fix is to split old xxxx.generated.cpp file into xxxx.generated.cpp and xxxx.generated.h files
So user needs to include xxxx.generated.h in source function header file, and explicitly use macros REGISTER_XXX_XXX in source function cpp file (or other explicitly cmake included cpp file) to avoid code getting stripped.

## For example
EntityFunctions.h
```
#include <AzCore/Component/EntityId.h>
#include <AzCore/Math/Vector3.h>
#include <Include/ScriptCanvas/Libraries/Entity/EntityFunctions.generated.h>

namespace ScriptCanvas
{
    namespace EntityFunctions
...
```

EntityFunctions.cpp
```
#include "EntityFunctions.h"
#include <AzCore/Component/ComponentApplicationBus.h>
#include <AzCore/Component/Entity.h>
#include <AzCore/Component/TransformBus.h>

REGISTER_SCRIPTCANVAS_ENTITYFUNCTIONS;

namespace ScriptCanvas
{
    namespace EntityFunctions
...
```

Signed-off-by: onecent1101 <liug@amazon.com>