### PR TITLE
Added new PhysX material asset where 1 asset is 1 material

### DIFF
--- a/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp
@@ -14,11 +14,16 @@ namespace PhysX
     {
         switch (pxMode)
         {
-        case physx::PxCombineMode::eAVERAGE: return CombineMode::Average;
-        case physx::PxCombineMode::eMULTIPLY: return CombineMode::Multiply;
-        case physx::PxCombineMode::eMAX: return CombineMode::Maximum;
-        case physx::PxCombineMode::eMIN: return CombineMode::Minimum;
-        default: return CombineMode::Average;
+        case physx::PxCombineMode::eAVERAGE:
+            return CombineMode::Average;
+        case physx::PxCombineMode::eMULTIPLY:
+            return CombineMode::Multiply;
+        case physx::PxCombineMode::eMAX:
+            return CombineMode::Maximum;
+        case physx::PxCombineMode::eMIN:
+            return CombineMode::Minimum;
+        default:
+            return CombineMode::Average;
         }
     }
 
@@ -26,11 +31,16 @@ namespace PhysX
     {
         switch (mode)
         {
-        case CombineMode::Average: return physx::PxCombineMode::eAVERAGE;
-        case CombineMode::Multiply: return physx::PxCombineMode::eMULTIPLY;
-        case CombineMode::Maximum: return physx::PxCombineMode::eMAX;
-        case CombineMode::Minimum: return physx::PxCombineMode::eMIN;
-        default: return physx::PxCombineMode::eAVERAGE;
+        case CombineMode::Average:
+            return physx::PxCombineMode::eAVERAGE;
+        case CombineMode::Multiply:
+            return physx::PxCombineMode::eMULTIPLY;
+        case CombineMode::Maximum:
+            return physx::PxCombineMode::eMAX;
+        case CombineMode::Minimum:
+            return physx::PxCombineMode::eMIN;
+        default:
+            return physx::PxCombineMode::eAVERAGE;
         }
     }
 
@@ -40,9 +50,7 @@ namespace PhysX
 
         m_pxMaterial = PxMaterialUniquePtr(
             PxGetPhysics().createMaterial(
-                defaultMaterialConf.m_staticFriction,
-                defaultMaterialConf.m_dynamicFriction,
-                defaultMaterialConf.m_restitution),
+                defaultMaterialConf.m_staticFriction, defaultMaterialConf.m_dynamicFriction, defaultMaterialConf.m_restitution),
             [](physx::PxMaterial* pxMaterial)
             {
                 pxMaterial->release();
@@ -67,9 +75,8 @@ namespace PhysX
 
     void Material2::SetDynamicFriction(float dynamicFriction)
     {
-        AZ_Warning("PhysX Material", dynamicFriction >= 0.0f,
-            "Dynamic friction value %f is out of range, 0 will be used.",
-            dynamicFriction);
+        AZ_Warning(
+            "PhysX Material", dynamicFriction >= 0.0f, "Dynamic friction value %f is out of range, 0 will be used.", dynamicFriction);
 
         m_pxMaterial->setDynamicFriction(AZ::GetMax(0.0f, dynamicFriction));
     }
@@ -81,9 +88,7 @@ namespace PhysX
 
     void Material2::SetStaticFriction(float staticFriction)
     {
-        AZ_Warning("PhysX Material", staticFriction >= 0.0f,
-            "Static friction value %f is out of range, 0 will be used.",
-            staticFriction);
+        AZ_Warning("PhysX Material", staticFriction >= 0.0f, "Static friction value %f is out of range, 0 will be used.", staticFriction);
 
         m_pxMaterial->setStaticFriction(AZ::GetMax(0.0f, staticFriction));
     }
@@ -95,8 +100,8 @@ namespace PhysX
 
     void Material2::SetRestitution(float restitution)
     {
-        AZ_Warning("PhysX Material", restitution >= 0.0f && restitution <= 1.0f,
-            "Restitution value %f will be clamped into range [0, 1]",
+        AZ_Warning(
+            "PhysX Material", restitution >= 0.0f && restitution <= 1.0f, "Restitution value %f will be clamped into range [0, 1]",
             restitution);
 
         m_pxMaterial->setRestitution(AZ::GetClamp(restitution, 0.0f, 1.0f));
@@ -129,12 +134,12 @@ namespace PhysX
 
     void Material2::SetDensity(float density)
     {
-        AZ_Warning("PhysX Material", density >= MaterialConfiguration::MinDensityLimit && density <= MaterialConfiguration::MaxDensityLimit,
-            "Density value %f will be clamped into range [%f, %f].",
-            density, MaterialConfiguration::MinDensityLimit, MaterialConfiguration::MaxDensityLimit);
+        AZ_Warning(
+            "PhysX Material", density >= MaterialConfiguration::MinDensityLimit && density <= MaterialConfiguration::MaxDensityLimit,
+            "Density value %f will be clamped into range [%f, %f].", density, MaterialConfiguration::MinDensityLimit,
+            MaterialConfiguration::MaxDensityLimit);
 
-        m_density = AZ::GetClamp(density,
-            MaterialConfiguration::MinDensityLimit, MaterialConfiguration::MaxDensityLimit);
+        m_density = AZ::GetClamp(density, MaterialConfiguration::MinDensityLimit, MaterialConfiguration::MaxDensityLimit);
     }
 
     const AZ::Color& Material2::GetDebugColor() const

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Material/PhysXMaterial.h>
+
+namespace PhysX
+{
+    static CombineMode FromPxCombineMode(physx::PxCombineMode::Enum pxMode)
+    {
+        switch (pxMode)
+        {
+        case physx::PxCombineMode::eAVERAGE: return CombineMode::Average;
+        case physx::PxCombineMode::eMULTIPLY: return CombineMode::Multiply;
+        case physx::PxCombineMode::eMAX: return CombineMode::Maximum;
+        case physx::PxCombineMode::eMIN: return CombineMode::Minimum;
+        default: return CombineMode::Average;
+        }
+    }
+
+    static physx::PxCombineMode::Enum ToPxCombineMode(CombineMode mode)
+    {
+        switch (mode)
+        {
+        case CombineMode::Average: return physx::PxCombineMode::eAVERAGE;
+        case CombineMode::Multiply: return physx::PxCombineMode::eMULTIPLY;
+        case CombineMode::Maximum: return physx::PxCombineMode::eMAX;
+        case CombineMode::Minimum: return physx::PxCombineMode::eMIN;
+        default: return physx::PxCombineMode::eAVERAGE;
+        }
+    }
+
+    Material2::Material2(const MaterialConfiguration& materialConfiguration)
+    {
+        const MaterialConfiguration defaultMaterialConf;
+
+        m_pxMaterial = PxMaterialUniquePtr(
+            PxGetPhysics().createMaterial(
+                defaultMaterialConf.m_staticFriction,
+                defaultMaterialConf.m_dynamicFriction,
+                defaultMaterialConf.m_restitution),
+            [](physx::PxMaterial* pxMaterial)
+            {
+                pxMaterial->release();
+                pxMaterial->userData = nullptr;
+            });
+        AZ_Assert(m_pxMaterial, "Failed to create physx material");
+        m_pxMaterial->userData = this;
+
+        SetStaticFriction(materialConfiguration.m_staticFriction);
+        SetDynamicFriction(materialConfiguration.m_dynamicFriction);
+        SetRestitution(materialConfiguration.m_restitution);
+        SetFrictionCombineMode(materialConfiguration.m_frictionCombine);
+        SetRestitutionCombineMode(materialConfiguration.m_restitutionCombine);
+        SetDensity(materialConfiguration.m_density);
+        SetDebugColor(materialConfiguration.m_debugColor);
+    }
+
+    float Material2::GetDynamicFriction() const
+    {
+        return m_pxMaterial->getDynamicFriction();
+    }
+
+    void Material2::SetDynamicFriction(float dynamicFriction)
+    {
+        AZ_Warning("PhysX Material", dynamicFriction >= 0.0f,
+            "Dynamic friction value %f is out of range, 0 will be used.",
+            dynamicFriction);
+
+        m_pxMaterial->setDynamicFriction(AZ::GetMax(0.0f, dynamicFriction));
+    }
+
+    float Material2::GetStaticFriction() const
+    {
+        return m_pxMaterial->getStaticFriction();
+    }
+
+    void Material2::SetStaticFriction(float staticFriction)
+    {
+        AZ_Warning("PhysX Material", staticFriction >= 0.0f,
+            "Static friction value %f is out of range, 0 will be used.",
+            staticFriction);
+
+        m_pxMaterial->setStaticFriction(AZ::GetMax(0.0f, staticFriction));
+    }
+
+    float Material2::GetRestitution() const
+    {
+        return m_pxMaterial->getRestitution();
+    }
+
+    void Material2::SetRestitution(float restitution)
+    {
+        AZ_Warning("PhysX Material", restitution >= 0.0f && restitution <= 1.0f,
+            "Restitution value %f will be clamped into range [0, 1]",
+            restitution);
+
+        m_pxMaterial->setRestitution(AZ::GetClamp(restitution, 0.0f, 1.0f));
+    }
+
+    CombineMode Material2::GetFrictionCombineMode() const
+    {
+        return FromPxCombineMode(m_pxMaterial->getFrictionCombineMode());
+    }
+
+    void Material2::SetFrictionCombineMode(CombineMode mode)
+    {
+        m_pxMaterial->setFrictionCombineMode(ToPxCombineMode(mode));
+    }
+
+    CombineMode Material2::GetRestitutionCombineMode() const
+    {
+        return FromPxCombineMode(m_pxMaterial->getRestitutionCombineMode());
+    }
+
+    void Material2::SetRestitutionCombineMode(CombineMode mode)
+    {
+        m_pxMaterial->setRestitutionCombineMode(ToPxCombineMode(mode));
+    }
+
+    float Material2::GetDensity() const
+    {
+        return m_density;
+    }
+
+    void Material2::SetDensity(float density)
+    {
+        AZ_Warning("PhysX Material", density >= MaterialConfiguration::MinDensityLimit && density <= MaterialConfiguration::MaxDensityLimit,
+            "Density value %f will be clamped into range [%f, %f].",
+            density, MaterialConfiguration::MinDensityLimit, MaterialConfiguration::MaxDensityLimit);
+
+        m_density = AZ::GetClamp(density,
+            MaterialConfiguration::MinDensityLimit, MaterialConfiguration::MaxDensityLimit);
+    }
+
+    const AZ::Color& Material2::GetDebugColor() const
+    {
+        return m_debugColor;
+    }
+
+    void Material2::SetDebugColor(const AZ::Color& debugColor)
+    {
+        m_debugColor = debugColor;
+    }
+
+    const void* Material2::GetNativePointer() const
+    {
+        return m_pxMaterial.get();
+    }
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterial.h
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterial.h
@@ -14,7 +14,7 @@
 
 namespace PhysX
 {
-    //! Runtime blast material, created from a MaterialConfiguration.
+    //! Runtime PhysX material, created from a MaterialConfiguration.
     // TODO: Material2 is temporary until old Material class is removed.
     class Material2
     {

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterial.h
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterial.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Material/PhysXMaterialConfiguration.h>
+
+#include <PxPhysicsAPI.h>
+
+namespace PhysX
+{
+    //! Runtime blast material, created from a MaterialConfiguration.
+    // TODO: Material2 is temporary until old Material class is removed.
+    class Material2
+    {
+    public:
+        Material2(const MaterialConfiguration& configuration);
+
+        float GetDynamicFriction() const;
+        void SetDynamicFriction(float dynamicFriction);
+
+        float GetStaticFriction() const;
+        void SetStaticFriction(float staticFriction);
+
+        float GetRestitution() const;
+        void SetRestitution(float restitution);
+
+        CombineMode GetFrictionCombineMode() const;
+        void SetFrictionCombineMode(CombineMode mode);
+
+        CombineMode GetRestitutionCombineMode() const;
+        void SetRestitutionCombineMode(CombineMode mode);
+
+        float GetDensity() const;
+        void SetDensity(float density);
+
+        const AZ::Color& GetDebugColor() const;
+        void SetDebugColor(const AZ::Color& debugColor);
+
+        const void* GetNativePointer() const;
+
+    private:
+        using PxMaterialUniquePtr = AZStd::unique_ptr<physx::PxMaterial, AZStd::function<void(physx::PxMaterial*)>>;
+
+        PxMaterialUniquePtr m_pxMaterial;
+        float m_density = 1000.0f;
+        AZ::Color m_debugColor = AZ::Colors::White;
+    };
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterialAsset.cpp
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterialAsset.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+
+#include <Material/PhysXMaterialAsset.h>
+
+namespace PhysX
+{
+    void MaterialAsset::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PhysX::MaterialAsset, AZ::Data::AssetData>()
+                ->Version(1)
+                ->Attribute(AZ::Edit::Attributes::EnableForAssetEditor, true)
+                ->Field("MaterialConfiguration", &MaterialAsset::m_materialConfiguration)
+                ;
+
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<PhysX::MaterialAsset>("", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default, &MaterialAsset::m_materialConfiguration, "PhysX Material",
+                        "PhysX material properties")
+                        ->Attribute(AZ::Edit::Attributes::ForceAutoExpand, true);
+            }
+        }
+    }
+
+    const MaterialConfiguration& MaterialAsset::GetMaterialConfiguration() const
+    {
+        return m_materialConfiguration;
+    }
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterialAsset.h
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterialAsset.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Asset/AssetCommon.h>
+
+#include <Material/PhysXMaterialConfiguration.h>
+
+namespace PhysX
+{
+    //! MaterialAsset defines a single material, which includes the configuration to create a Material instance to use at runtime.
+    class MaterialAsset
+        : public AZ::Data::AssetData
+    {
+    public:
+        AZ_CLASS_ALLOCATOR(PhysX::MaterialAsset, AZ::SystemAllocator, 0);
+        AZ_RTTI(PhysX::MaterialAsset, "{E4EF58EE-B1D1-46C8-BE48-BB62B8247386}", AZ::Data::AssetData);
+
+        MaterialAsset() = default;
+        virtual ~MaterialAsset() = default;
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        const MaterialConfiguration& GetMaterialConfiguration() const;
+
+    protected:
+        MaterialConfiguration m_materialConfiguration;
+    };
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterialConfiguration.cpp
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterialConfiguration.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/Serialization/EditContext.h>
+
+#include <AzFramework/Physics/NameConstants.h>
+
+#include <Material/PhysXMaterialConfiguration.h>
+
+namespace PhysX
+{
+    void MaterialConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<PhysX::MaterialConfiguration>()
+                ->Version(1)
+                ->Field("DynamicFriction", &MaterialConfiguration::m_dynamicFriction)
+                ->Field("StaticFriction", &MaterialConfiguration::m_staticFriction)
+                ->Field("Restitution", &MaterialConfiguration::m_restitution)
+                ->Field("FrictionCombine", &MaterialConfiguration::m_frictionCombine)
+                ->Field("RestitutionCombine", &MaterialConfiguration::m_restitutionCombine)
+                ->Field("Density", &MaterialConfiguration::m_density)
+                ->Field("DebugColor", &MaterialConfiguration::m_debugColor)
+                ;
+
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+
+                editContext->Class<PhysX::MaterialConfiguration>("", "")
+                    ->ClassElement(AZ::Edit::ClassElements::EditorData, "PhysX Material")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_staticFriction, "Static friction", "Friction coefficient when object is still")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_dynamicFriction, "Dynamic friction", "Friction coefficient when object is moving")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_restitution, "Restitution", "Restitution coefficient")
+                        ->Attribute(AZ::Edit::Attributes::Min, 0.f)
+                        ->Attribute(AZ::Edit::Attributes::Max, 1.f)
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &MaterialConfiguration::m_frictionCombine, "Friction combine", "How the friction is combined between colliding objects")
+                        ->EnumAttribute(CombineMode::Average, "Average")
+                        ->EnumAttribute(CombineMode::Minimum, "Minimum")
+                        ->EnumAttribute(CombineMode::Maximum, "Maximum")
+                        ->EnumAttribute(CombineMode::Multiply, "Multiply")
+                    ->DataElement(AZ::Edit::UIHandlers::ComboBox, &MaterialConfiguration::m_restitutionCombine, "Restitution combine", "How the restitution is combined between colliding objects")
+                        ->EnumAttribute(CombineMode::Average, "Average")
+                        ->EnumAttribute(CombineMode::Minimum, "Minimum")
+                        ->EnumAttribute(CombineMode::Maximum, "Maximum")
+                        ->EnumAttribute(CombineMode::Multiply, "Multiply")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &MaterialConfiguration::m_density, "Density", "Material density")
+                        ->Attribute(AZ::Edit::Attributes::Min, MaterialConfiguration::MinDensityLimit)
+                        ->Attribute(AZ::Edit::Attributes::Max, MaterialConfiguration::MaxDensityLimit)
+                        ->Attribute(AZ::Edit::Attributes::Suffix, " " + Physics::NameConstants::GetDensityUnit())
+                    ->DataElement(AZ::Edit::UIHandlers::Color, &MaterialConfiguration::m_debugColor, "Debug Color", "Debug color to use for this material")
+                    ;
+            }
+        }
+    }
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterialConfiguration.h
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterialConfiguration.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AzCore/std/string/string.h>
+#include <AzCore/Math/Color.h>
+
+namespace PhysX
+{
+    //! Enumeration that determines how two materials properties are combined when
+    //! processing collisions.
+    enum class CombineMode : AZ::u8
+    {
+        Average,
+        Minimum,
+        Maximum,
+        Multiply
+    };
+
+    //! Properties of a PhysX material.
+    struct MaterialConfiguration
+    {
+        AZ_TYPE_INFO(PhysX::MaterialConfiguration, "{675AF04D-CF51-479C-9D6A-4D7E264D1DBE}");
+
+        static void Reflect(AZ::ReflectContext* context);
+
+        static constexpr float MinDensityLimit = 0.01f; //!< Minimum possible value of density.
+        static constexpr float MaxDensityLimit = 100000.0f; //!< Maximum possible value of density.
+
+        float m_dynamicFriction = 0.5f;
+        float m_staticFriction = 0.5f;
+        float m_restitution = 0.5f;
+        float m_density = 1000.0f;
+
+        CombineMode m_restitutionCombine = CombineMode::Average;
+        CombineMode m_frictionCombine = CombineMode::Average;
+
+        AZ::Color m_debugColor = AZ::Colors::White;
+    };
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/SystemComponent.cpp
+++ b/Gems/PhysX/Code/Source/SystemComponent.cpp
@@ -20,6 +20,7 @@
 #include <Source/PhysXCharacters/API/CharacterUtils.h>
 #include <Source/PhysXCharacters/API/CharacterController.h>
 #include <Source/WindProvider.h>
+#include <Source/Material/PhysXMaterialAsset.h>
 
 #include <PhysX/Debug/PhysXDebugInterface.h>
 #include <System/PhysXSystem.h>
@@ -194,9 +195,14 @@ namespace PhysX
         m_defaultWorldComponent.Activate();
 
         // Assets related work
-        auto* materialAsset = aznew AzFramework::GenericAssetHandler<Physics::MaterialLibraryAsset>("Physics Material", "Physics", "physmaterial");
+        auto* materialAsset = aznew AzFramework::GenericAssetHandler<Physics::MaterialLibraryAsset>("Physics Material", "PhysX Material", "physmaterial");
         materialAsset->Register();
         m_assetHandlers.emplace_back(materialAsset);
+
+        // TODO: "materialAsset2" is temporary until the "materialAsset" is removed.
+        auto* materialAsset2 = aznew AzFramework::GenericAssetHandler<MaterialAsset>("PhysX Material", "PhysX Material", "physxmaterial");
+        materialAsset2->Register();
+        m_assetHandlers.emplace_back(materialAsset2);
 
         // Add asset types and extensions to AssetCatalog. Uses "AssetCatalogService".
         RegisterAsset<Pipeline::MeshAssetHandler, Pipeline::MeshAsset>(m_assetHandlers);

--- a/Gems/PhysX/Code/Source/Utils.cpp
+++ b/Gems/PhysX/Code/Source/Utils.cpp
@@ -40,6 +40,7 @@
 #include <Source/StaticRigidBodyComponent.h>
 #include <Source/RigidBodyStatic.h>
 #include <Source/Utils.h>
+#include <Source/Material/PhysXMaterialAsset.h>
 #include <PhysX/PhysXLocks.h>
 #include <PhysX/Joint/Configuration/PhysXJointConfiguration.h>
 #include <PhysX/MathConversion.h>
@@ -1652,6 +1653,9 @@ namespace PhysX
             FixedJointConfiguration::Reflect(context);
             BallJointConfiguration::Reflect(context);
             HingeJointConfiguration::Reflect(context);
+
+            MaterialConfiguration::Reflect(context);
+            MaterialAsset::Reflect(context);
         }
 
         void ForceRegionBusBehaviorHandler::Reflect(AZ::ReflectContext* context)

--- a/Gems/PhysX/Code/Tests/PhysXMaterialTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXMaterialTest.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzTest/AzTest.h>
+#include <AZTestShared/Math/MathTestHelpers.h>
+
+#include <Material/PhysXMaterial.h>
+
+namespace UnitTest
+{
+    static constexpr float Tolerance = 1e-4f;
+
+    TEST(PhysXMaterial, Material_GetSet_DynamicFriction_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_dynamicFriction = 68.6f;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetDynamicFriction(), 68.6f, Tolerance);
+
+        material.SetDynamicFriction(31.2f);
+        EXPECT_NEAR(material.GetDynamicFriction(), 31.2f, Tolerance);
+    }
+
+    TEST(PhysXMaterial, Material_Clamps_DynamicFriction_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_dynamicFriction = -7.0f;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetDynamicFriction(), 0.0f, Tolerance);
+
+        material.SetDynamicFriction(-61.0f);
+        EXPECT_NEAR(material.GetDynamicFriction(), 0.0f, Tolerance);
+    }
+
+    TEST(PhysXMaterial, Material_GetSet_StaticFriction_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_staticFriction = 68.6f;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetStaticFriction(), 68.6f, Tolerance);
+
+        material.SetStaticFriction(31.2f);
+        EXPECT_NEAR(material.GetStaticFriction(), 31.2f, Tolerance);
+    }
+
+    TEST(PhysXMaterial, Material_Clamps_StaticFriction_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_staticFriction = -7.0f;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetStaticFriction(), 0.0f, Tolerance);
+
+        material.SetStaticFriction(-61.0f);
+        EXPECT_NEAR(material.GetStaticFriction(), 0.0f, Tolerance);
+    }
+
+    TEST(PhysXMaterial, Material_GetSet_Restitution_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_restitution = 0.43f;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetRestitution(), 0.43f, Tolerance);
+
+        material.SetRestitution(0.78f);
+        EXPECT_NEAR(material.GetRestitution(), 0.78f, Tolerance);
+    }
+
+    TEST(PhysXMaterial, Material_Clamps_Restitution_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_restitution = -13.0f;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetRestitution(), 0.0f, Tolerance);
+
+        material.SetRestitution(0.0f);
+        EXPECT_NEAR(material.GetRestitution(), 0.0f, Tolerance);
+
+        material.SetRestitution(1.0f);
+        EXPECT_NEAR(material.GetRestitution(), 1.0f, Tolerance);
+
+        material.SetRestitution(61.0f);
+        EXPECT_NEAR(material.GetRestitution(), 1.0f, Tolerance);
+    }
+
+    TEST(PhysXMaterial, Material_GetSet_Density_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_density = 245.0f;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetDensity(), 245.0f, Tolerance);
+
+        material.SetDensity(43.1f);
+        EXPECT_NEAR(material.GetDensity(), 43.1f, Tolerance);
+    }
+
+    TEST(PhysXMaterial, Material_Clamps_Density_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_density = -13.0f;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_NEAR(material.GetDensity(), PhysX::MaterialConfiguration::MinDensityLimit, Tolerance);
+
+        material.SetDensity(0.0f);
+        EXPECT_NEAR(material.GetDensity(), PhysX::MaterialConfiguration::MinDensityLimit, Tolerance);
+
+        material.SetDensity(PhysX::MaterialConfiguration::MinDensityLimit);
+        EXPECT_NEAR(material.GetDensity(), PhysX::MaterialConfiguration::MinDensityLimit, Tolerance);
+
+        material.SetDensity(PhysX::MaterialConfiguration::MaxDensityLimit);
+        EXPECT_NEAR(material.GetDensity(), PhysX::MaterialConfiguration::MaxDensityLimit, Tolerance);
+
+        material.SetDensity(200000.0f);
+        EXPECT_NEAR(material.GetDensity(), PhysX::MaterialConfiguration::MaxDensityLimit, Tolerance);
+    }
+
+    TEST(PhysXMaterial, Material_GetSet_FrictionCombineMode_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_frictionCombine = PhysX::CombineMode::Maximum;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_EQ(material.GetFrictionCombineMode(), PhysX::CombineMode::Maximum);
+
+        material.SetFrictionCombineMode(PhysX::CombineMode::Minimum);
+        EXPECT_EQ(material.GetFrictionCombineMode(), PhysX::CombineMode::Minimum);
+    }
+
+    TEST(PhysXMaterial, Material_GetSet_RestitutionCombineMode_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_restitutionCombine = PhysX::CombineMode::Maximum;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_EQ(material.GetRestitutionCombineMode(), PhysX::CombineMode::Maximum);
+
+        material.SetRestitutionCombineMode(PhysX::CombineMode::Minimum);
+        EXPECT_EQ(material.GetRestitutionCombineMode(), PhysX::CombineMode::Minimum);
+    }
+
+    TEST(PhysXMaterial, Material_GetSet_DebugColor_Successfully)
+    {
+        PhysX::MaterialConfiguration materialConfiguration;
+        materialConfiguration.m_debugColor = AZ::Colors::Lavender;
+
+        PhysX::Material2 material(materialConfiguration);
+
+        EXPECT_THAT(material.GetDebugColor(), IsClose(AZ::Colors::Lavender));
+
+        material.SetDebugColor(AZ::Colors::Aquamarine);
+        EXPECT_THAT(material.GetDebugColor(), IsClose(AZ::Colors::Aquamarine));
+    }
+
+    TEST(PhysXMaterial, Material_ReturnsValid_NativePointer)
+    {
+        PhysX::Material2 material(PhysX::MaterialConfiguration{});
+
+        EXPECT_TRUE(material.GetNativePointer() != nullptr);
+    }
+} // namespace UnitTest

--- a/Gems/PhysX/Code/Tests/PhysXMaterialTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXMaterialTest.cpp
@@ -15,7 +15,7 @@ namespace UnitTest
 {
     static constexpr float Tolerance = 1e-4f;
 
-    TEST(PhysXMaterial, Material_GetSet_DynamicFriction_Successfully)
+    TEST(PhysXMaterial, Material_GetSet_DynamicFriction)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_dynamicFriction = 68.6f;
@@ -28,7 +28,7 @@ namespace UnitTest
         EXPECT_NEAR(material.GetDynamicFriction(), 31.2f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_Clamps_DynamicFriction_Successfully)
+    TEST(PhysXMaterial, Material_Clamps_DynamicFriction)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_dynamicFriction = -7.0f;
@@ -41,7 +41,7 @@ namespace UnitTest
         EXPECT_NEAR(material.GetDynamicFriction(), 0.0f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_StaticFriction_Successfully)
+    TEST(PhysXMaterial, Material_GetSet_StaticFriction)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_staticFriction = 68.6f;
@@ -54,7 +54,7 @@ namespace UnitTest
         EXPECT_NEAR(material.GetStaticFriction(), 31.2f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_Clamps_StaticFriction_Successfully)
+    TEST(PhysXMaterial, Material_Clamps_StaticFriction)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_staticFriction = -7.0f;
@@ -67,7 +67,7 @@ namespace UnitTest
         EXPECT_NEAR(material.GetStaticFriction(), 0.0f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_Restitution_Successfully)
+    TEST(PhysXMaterial, Material_GetSet_Restitution)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_restitution = 0.43f;
@@ -80,7 +80,7 @@ namespace UnitTest
         EXPECT_NEAR(material.GetRestitution(), 0.78f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_Clamps_Restitution_Successfully)
+    TEST(PhysXMaterial, Material_Clamps_Restitution)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_restitution = -13.0f;
@@ -99,7 +99,7 @@ namespace UnitTest
         EXPECT_NEAR(material.GetRestitution(), 1.0f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_Density_Successfully)
+    TEST(PhysXMaterial, Material_GetSet_Density)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_density = 245.0f;
@@ -112,7 +112,7 @@ namespace UnitTest
         EXPECT_NEAR(material.GetDensity(), 43.1f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_Clamps_Density_Successfully)
+    TEST(PhysXMaterial, Material_Clamps_Density)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_density = -13.0f;
@@ -134,7 +134,7 @@ namespace UnitTest
         EXPECT_NEAR(material.GetDensity(), PhysX::MaterialConfiguration::MaxDensityLimit, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_FrictionCombineMode_Successfully)
+    TEST(PhysXMaterial, Material_GetSet_FrictionCombineMode)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_frictionCombine = PhysX::CombineMode::Maximum;
@@ -147,7 +147,7 @@ namespace UnitTest
         EXPECT_EQ(material.GetFrictionCombineMode(), PhysX::CombineMode::Minimum);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_RestitutionCombineMode_Successfully)
+    TEST(PhysXMaterial, Material_GetSet_RestitutionCombineMode)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_restitutionCombine = PhysX::CombineMode::Maximum;
@@ -160,7 +160,7 @@ namespace UnitTest
         EXPECT_EQ(material.GetRestitutionCombineMode(), PhysX::CombineMode::Minimum);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_DebugColor_Successfully)
+    TEST(PhysXMaterial, Material_GetSet_DebugColor)
     {
         PhysX::MaterialConfiguration materialConfiguration;
         materialConfiguration.m_debugColor = AZ::Colors::Lavender;

--- a/Gems/PhysX/Code/physx_files.cmake
+++ b/Gems/PhysX/Code/physx_files.cmake
@@ -114,6 +114,12 @@ set(FILES
     Source/Joint/PhysXJointUtils.h
     Source/Joint/PhysXJointUtils.cpp
     Source/Joint/Configuration/PhysXJointConfiguration.cpp
+    Source/Material/PhysXMaterial.h
+    Source/Material/PhysXMaterial.cpp
+    Source/Material/PhysXMaterialAsset.h
+    Source/Material/PhysXMaterialAsset.cpp
+    Source/Material/PhysXMaterialConfiguration.h
+    Source/Material/PhysXMaterialConfiguration.cpp
     Source/Scene/PhysXScene.h
     Source/Scene/PhysXScene.cpp
     Source/Scene/PhysXSceneInterface.h

--- a/Gems/PhysX/Code/physx_tests_files.cmake
+++ b/Gems/PhysX/Code/physx_tests_files.cmake
@@ -18,6 +18,7 @@ set(FILES
     Tests/PhysXTestEnvironment.h
     Tests/PhysXTestEnvironment.cpp
     Tests/PhysXGenericTest.cpp
+    Tests/PhysXMaterialTest.cpp
     Tests/PhysXSpecificTest.cpp
     Tests/PhysXForceRegionTest.cpp
     Tests/PhysXCollisionFilteringTest.cpp

--- a/Gems/PhysX/Registry/AssetProcessorGemConfig.setreg
+++ b/Gems/PhysX/Registry/AssetProcessorGemConfig.setreg
@@ -6,6 +6,12 @@
                     "pattern": "(.*\\.physicsconfiguration|.*\\.physxconfiguration)",
                     "params": "copy"
                 },
+                "RC physxmaterial": {
+                    "glob": "*.physxmaterial",
+                    "params": "copy",
+                    "critical": true,
+                    "productAssetType": "{E4EF58EE-B1D1-46C8-BE48-BB62B8247386}"
+                },
                 "RC PhysX HeightField": {
                     "glob": "*.pxheightfield",
                     "params": "copy",


### PR DESCRIPTION
**This PR is part of the work to refactoring physx materials. It's NOT merging to development branch.**

The properties of the physx materials are the same, the difference is that the asset is now the material, not a material library, which simplifies the code and makes it work the same as render materials. 

- **MaterialConfiguration**: structure with physx properties.
- **MaterialAsset**: asset data that has a MaterialConfiguraiton. This asset will enable Asset Editor to create this assets.
- **Material**: runtime material with the physx internal classes, created from a MaterialConfiguration.

Asset Editor will create physx materials files (`.physxmaterial`) in the project's asset folder, then an Asset Processor rule copies the file to the cache folder, which makes it ready for O3DE to use. The old asset library extension is `.physmaterial`.

![image](https://user-images.githubusercontent.com/27999040/165533679-34778b5e-0e51-44c2-8180-66cd3dba39f9.png)

Unit tests added for physx materials:

````
[----------] 12 tests from PhysXMaterial
[ RUN      ] PhysXMaterial.Material_GetSet_DynamicFriction_Successfully
[       OK ] PhysXMaterial.Material_GetSet_DynamicFriction_Successfully (0 ms)
[ RUN      ] PhysXMaterial.Material_Clamps_DynamicFriction_Successfully
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(72): 'void __cdecl PhysX::Material2::SetDynamicFriction(float)'
PhysX Material: Dynamic friction value -7.000000 is out of range, 0 will be used.
PhysX Material: ==================================================================
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(72): 'void __cdecl PhysX::Material2::SetDynamicFriction(float)'
PhysX Material: Dynamic friction value -61.000000 is out of range, 0 will be used.
PhysX Material: ==================================================================
[       OK ] PhysXMaterial.Material_Clamps_DynamicFriction_Successfully (8 ms)
[ RUN      ] PhysXMaterial.Material_GetSet_StaticFriction_Successfully
[       OK ] PhysXMaterial.Material_GetSet_StaticFriction_Successfully (0 ms)
[ RUN      ] PhysXMaterial.Material_Clamps_StaticFriction_Successfully
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(86): 'void __cdecl PhysX::Material2::SetStaticFriction(float)'
PhysX Material: Static friction value -7.000000 is out of range, 0 will be used.
PhysX Material: ==================================================================
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(86): 'void __cdecl PhysX::Material2::SetStaticFriction(float)'
PhysX Material: Static friction value -61.000000 is out of range, 0 will be used.
PhysX Material: ==================================================================
[       OK ] PhysXMaterial.Material_Clamps_StaticFriction_Successfully (11 ms)
[ RUN      ] PhysXMaterial.Material_GetSet_Restitution_Successfully
[       OK ] PhysXMaterial.Material_GetSet_Restitution_Successfully (0 ms)
[ RUN      ] PhysXMaterial.Material_Clamps_Restitution_Successfully
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(100): 'void __cdecl PhysX::Material2::SetRestitution(float)'
PhysX Material: Restitution value -13.000000 will be clamped into range [0, 1]
PhysX Material: ==================================================================
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(100): 'void __cdecl PhysX::Material2::SetRestitution(float)'
PhysX Material: Restitution value 61.000000 will be clamped into range [0, 1]
PhysX Material: ==================================================================
[       OK ] PhysXMaterial.Material_Clamps_Restitution_Successfully (10 ms)
[ RUN      ] PhysXMaterial.Material_GetSet_Density_Successfully
[       OK ] PhysXMaterial.Material_GetSet_Density_Successfully (0 ms)
[ RUN      ] PhysXMaterial.Material_Clamps_Density_Successfully
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(134): 'void __cdecl PhysX::Material2::SetDensity(float)'
PhysX Material: Density value -13.000000 will be clamped into range [0.010000, 100000.000000].
PhysX Material: ==================================================================
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(134): 'void __cdecl PhysX::Material2::SetDensity(float)'
PhysX Material: Density value 0.000000 will be clamped into range [0.010000, 100000.000000].
PhysX Material: ==================================================================
PhysX Material:
==================================================================
PhysX Material: Trace::Warning
 E:/Amazon/GitHub/o3de/Gems/PhysX/Code/Source/Material/PhysXMaterial.cpp(134): 'void __cdecl PhysX::Material2::SetDensity(float)'
PhysX Material: Density value 200000.000000 will be clamped into range [0.010000, 100000.000000].
PhysX Material: ==================================================================
[       OK ] PhysXMaterial.Material_Clamps_Density_Successfully (13 ms)
[ RUN      ] PhysXMaterial.Material_GetSet_FrictionCombineMode_Successfully
[       OK ] PhysXMaterial.Material_GetSet_FrictionCombineMode_Successfully (0 ms)
[ RUN      ] PhysXMaterial.Material_GetSet_RestitutionCombineMode_Successfully
[       OK ] PhysXMaterial.Material_GetSet_RestitutionCombineMode_Successfully (0 ms)
[ RUN      ] PhysXMaterial.Material_GetSet_DebugColor_Successfully
[       OK ] PhysXMaterial.Material_GetSet_DebugColor_Successfully (0 ms)
[ RUN      ] PhysXMaterial.Material_ReturnsValid_NativePointer
[       OK ] PhysXMaterial.Material_ReturnsValid_NativePointer (0 ms)
[----------] 12 tests from PhysXMaterial (58 ms total)
````

Signed-off-by: moraaar <moraaar@amazon.com>