### PR TITLE
Clean up legacy generic function node system

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
@@ -1060,9 +1060,6 @@ protected:
 
         template<typename ResultType, typename t_Traits, typename>
         friend struct Internal::OutputSlotHelper;
-
-        template<size_t... inputDatumIndices>
-        friend struct SetDefaultValuesByIndex;
     };
 
     namespace Internal

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
@@ -11,7 +11,7 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/RTTI/TypeInfo.h>
-#include <AzCore/std/typetraits/function_traits.h>
+#include <AzCore/std/typetraits/add_pointer.h>
 #include <ScriptCanvas/Libraries/Libraries.h>
 #include <ScriptCanvas/Translation/TranslationContext.h>
 
@@ -131,8 +131,8 @@ namespace ScriptCanvas
         template<typename t_Library>
         static void Reflect(AZ::BehaviorContext* behaviorContext, const char* libraryName)
         {
-            auto reflection = behaviorContext->Class<t_Library>(libraryName)
-                ->Attribute(AZ::ScriptCanvasAttributes::VariableCreationForbidden, AZ::AttributeIsValid::IfPresent)
+            auto reflection = behaviorContext->Class<t_Library>(libraryName);
+            reflection->Attribute(AZ::ScriptCanvasAttributes::VariableCreationForbidden, AZ::AttributeIsValid::IfPresent)
                 ->Attribute(AZ::ScriptCanvasAttributes::Internal::ImplementedAsNodeGeneric, true);
             SCRIPT_CANVAS_CALL_ON_INDEX_SEQUENCE(reflection->Method(t_Node::GetNodeFunctionName(), t_Node::GetFunction())->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List | AZ::Script::Attributes::ExcludeFlags::Documentation));
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
@@ -11,10 +11,7 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/RTTI/RTTI.h>
 #include <AzCore/RTTI/TypeInfo.h>
-#include <AzCore/std/tuple.h>
-#include <AzCore/std/typetraits/add_pointer.h>
 #include <AzCore/std/typetraits/function_traits.h>
-#include <AzFramework/StringFunc/StringFunc.h>
 #include <ScriptCanvas/Libraries/Libraries.h>
 #include <ScriptCanvas/Translation/TranslationContext.h>
 
@@ -22,215 +19,28 @@
 #include "Attributes.h"
 
  /**
-  * NodeFunctionGeneric.h
-  *
-  * This file makes it really easy to take a single function and make into a ScriptCanvas node
-  * with all of the necessary plumbing, by using a macro, and adding the result to a node registry.
-  *
-  * Use SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE for a function of any arity that returns [0, N]
-  * arguments, wrapped in a tuple.
-  *
-  * The macros will turn the function name into a ScriptCanvas node with name of the function
-  * with "Node" appended to it.
-  *
-  * \note As much as possible, it best to wrap functions that use 'native' ScriptCanvas types,
-  * and to pass them in/out by value.
-
-  * You will need to add the nodes to the registry like any other node, and get a component description
-  * from it, in order to have it show up in the editor, etc.
-  *
-  * It is preferable to use this method for any node that provides ScriptCanvas-only functionality.
-  * If you are creating a node that represents functionality that would be useful in Lua, or any other
-  * client of BehaviorContext, it may be better to expose your functionality to BehaviorContext, unless
-  * performance in ScriptCanvas is an issue. This method will almost certainly provide faster run-time
-  * performance than a node that calls into BehaviorContext.
-  *
-  * A good faith effort to support reference return types has been made. Pointers and references, even in
-  * tuples, are supported. However, if your input or return values is T** or T*&, it won't work, and there
-  * are no plans to support them. If your tuple return value is made up of references remember to return it with
-  * std::forward_as_tuple, and not std::make_tuple.
-  *
-  * \see MathGenerics.h and Math.cpp for example usage of the macros and generic registrar defined below.
-  *
+  * Deprecated
   */
-
-  // this defines helps provide type safe static asserts in the results of the macros below
-#define SCRIPT_CANVAS_FUNCTION_VAR_ARGS(...) (AZStd::tuple_size<decltype(AZStd::make_tuple(__VA_ARGS__))>::value)
-
-namespace ScriptCanvas
-{
-    namespace Internal
-    {
-        template<class T, typename = AZStd::void_t<>>
-        struct extended_tuple_size : AZStd::integral_constant<size_t, 1> {};
-
-        template<class T>
-        struct extended_tuple_size<T, AZStd::enable_if_t<IsTupleLike<T>::value>> : AZStd::tuple_size<T> {};
-
-        template<>
-        struct extended_tuple_size<void, AZStd::void_t<>> : AZStd::integral_constant<size_t, 0> {};
-    }
-}
-
-#define SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE_WITH_DEFAULTS(NODE_NAME, DEFAULT_FUNC, CATEGORY, UUID, ISDEPRECATED, DESCRIPTION, ...)\
-    struct NODE_NAME##Traits\
-    {\
-        AZ_TYPE_INFO(NODE_NAME##Traits, UUID);\
-        using FunctionTraits = AZStd::function_traits< decltype(&NODE_NAME) >;\
-        using ResultType = FunctionTraits::result_type;\
-        static const size_t s_numArgs = FunctionTraits::arity;\
-        static const size_t s_numNames = SCRIPT_CANVAS_FUNCTION_VAR_ARGS(__VA_ARGS__);\
-        static const size_t s_numResults = ScriptCanvas::Internal::extended_tuple_size<ResultType>::value;\
-        \
-        static AZStd::string GetArgName(size_t i)\
-        {\
-            if constexpr (s_numArgs < 2)\
-            {\
-                return GetName(i);\
-            }\
-            else\
-            {\
-                AZStd::string_view argName = GetName(i);\
-                if (!argName.empty())\
-                {\
-                    return argName;\
-                }\
-                else\
-                {\
-                    return AZStd::string::format("Input [%zu]", i);\
-                }\
-            }\
-        }\
-        \
-        static AZStd::string GetResultName(size_t i)\
-        {\
-            AZStd::string_view resultName = GetName(i + s_numArgs);\
-            if (!resultName.empty())\
-            {\
-                return resultName;\
-            }\
-            else\
-            {\
-                if constexpr (s_numResults < 2)\
-                {\
-                    return "Result";\
-                }\
-                else\
-                {\
-                    return AZStd::string::format("Result [%zu]", i);\
-                }\
-            }\
-        }\
-        \
-        static const char* GetDependency() { return CATEGORY; }\
-        static const char* GetCategory() { if (IsDeprecated()) return "Deprecated"; else return CATEGORY; };\
-        static const char* GetDescription() { return DESCRIPTION; };\
-        static const char* GetNodeName() { return #NODE_NAME; };\
-        static bool IsDeprecated() { return ISDEPRECATED; };\
-        static const char* GetReplacementMethodName(){ return "None"; };\
-        \
-    private:\
-        static AZStd::string_view GetName(size_t i)\
-        {\
-            AZ_PUSH_DISABLE_WARNING(4296, "-Wunknown-warning-option")\
-            static_assert(s_numArgs <= s_numNames, "Number of arguments is greater than number of names in " #NODE_NAME );\
-            AZ_POP_DISABLE_WARNING\
-            /*static_assert(s_numResults <= s_numNames, "Number of results is greater than number of names in " #NODE_NAME );*/\
-            /*static_assert((s_numResults + s_numArgs) == s_numNames, "Argument name count + result name count != name count in " #NODE_NAME );*/\
-            static const AZStd::array<AZStd::string_view, s_numNames> s_names = {{ __VA_ARGS__ }};\
-            return i < s_names.size() ? s_names[i] : "";\
-        }\
-    };\
-    using NODE_NAME##Node = ScriptCanvas::NodeFunctionGenericMultiReturn<AZStd::add_pointer_t<decltype(NODE_NAME)>, NODE_NAME##Traits, &NODE_NAME, AZStd::add_pointer_t<decltype(DEFAULT_FUNC)>, &DEFAULT_FUNC>;
 
 #define SCRIPT_CANVAS_GENERIC_FUNCTION_REPLACEMENT(NODE_NAME, CATEGORY, UUID, METHOD_NAME)\
     struct NODE_NAME##Traits\
     {\
         AZ_TYPE_INFO(NODE_NAME##Traits, UUID);\
-        using FunctionTraits = AZStd::function_traits< decltype(&NODE_NAME) >;\
-        static const size_t s_numArgs = FunctionTraits::arity;\
-        static AZStd::string GetArgName([[maybe_unused]]size_t i) { return ""; };\
-        static AZStd::string GetResultName([[maybe_unused]]size_t i) { return ""; };\
         static const char* GetDependency() { return CATEGORY; }\
-        static const char* GetCategory() { return "Deprecated"; };\
-        static const char* GetDescription() { return "Deprecated Node"; };\
         static const char* GetNodeName() { return #NODE_NAME; };\
-        static bool IsDeprecated() { return true; };\
         static const char* GetReplacementMethodName() { return METHOD_NAME; };\
     };\
-    using NODE_NAME##Node = ScriptCanvas::NodeFunctionGenericMultiReturn<AZStd::add_pointer_t<decltype(NODE_NAME)>, NODE_NAME##Traits, &NODE_NAME, AZStd::add_pointer_t<decltype(ScriptCanvas::NoDefaultArguments)>, &ScriptCanvas::NoDefaultArguments>;
-
-// Following MACROS will be removed after all generic functions get migrated
-#define SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE(NODE_NAME, CATEGORY, UUID, DESCRIPTION, ...)\
-    SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE_WITH_DEFAULTS(NODE_NAME, ScriptCanvas::NoDefaultArguments, CATEGORY, UUID, false, DESCRIPTION, __VA_ARGS__)
-
-#define SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE_DEPRECATED(NODE_NAME, CATEGORY, UUID, DESCRIPTION, ...)\
-    SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE_WITH_DEFAULTS(NODE_NAME, ScriptCanvas::NoDefaultArguments, CATEGORY, UUID, true, DESCRIPTION, __VA_ARGS__)
-
-#define SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS(NODE_NAME, DEFAULT_FUNC, CATEGORY, UUID, DESCRIPTION, ...)\
-    SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE_WITH_DEFAULTS(NODE_NAME, DEFAULT_FUNC, CATEGORY, UUID, false, DESCRIPTION, __VA_ARGS__)
-
-#define SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_WITH_DEFAULTS_DEPRECATED(NODE_NAME, DEFAULT_FUNC, CATEGORY, UUID, DESCRIPTION, ...)\
-    SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE_WITH_DEFAULTS(NODE_NAME, DEFAULT_FUNC, CATEGORY, UUID, true, DESCRIPTION, __VA_ARGS__)
-
-#define SCRIPT_CANVAS_GENERIC_FUNCTION_NODE(NODE_NAME, CATEGORY, UUID, DESCRIPTION, ...)\
-    SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE_WITH_DEFAULTS(NODE_NAME, ScriptCanvas::NoDefaultArguments, CATEGORY, UUID, false, DESCRIPTION, __VA_ARGS__)
-
-#define SCRIPT_CANVAS_GENERIC_FUNCTION_NODE_DEPRECATED(NODE_NAME, CATEGORY, UUID, DESCRIPTION, ...)\
-    SCRIPT_CANVAS_GENERIC_FUNCTION_MULTI_RESULTS_NODE_WITH_DEFAULTS(NODE_NAME, ScriptCanvas::NoDefaultArguments, CATEGORY, UUID, true, DESCRIPTION, __VA_ARGS__)
+    using NODE_NAME##Node = ScriptCanvas::NodeFunctionGenericMultiReturn<AZStd::add_pointer_t<decltype(NODE_NAME)>, NODE_NAME##Traits, &NODE_NAME>;
 
 namespace ScriptCanvas
 {
-    template<size_t... inputDatumIndices>
-    struct SetDefaultValuesByIndex
-    {
-        template<typename... t_Args>
-        AZ_INLINE static void _(Node& node, t_Args&&... args)
-        {
-            Help(node, AZStd::make_index_sequence<sizeof...(t_Args)>(), AZStd::forward<t_Args>(args)...);
-        }
-
-    private:
-        template<AZStd::size_t... Is, typename... t_Args>
-        AZ_INLINE static void Help(Node& node, AZStd::index_sequence<Is...>, t_Args&&... args)
-        {
-            static int indices[] = { inputDatumIndices... };
-            static_assert(sizeof...(Is) == AZ_ARRAY_SIZE(indices), "size of default values doesn't match input datum indices for them");
-            [[maybe_unused]] std::initializer_list<int> dummy = { (MoreHelp(node, indices[Is], AZStd::forward<t_Args>(args)), 0)... };
-        }
-
-        template<typename ArgType>
-        AZ_INLINE static void MoreHelp(Node& node, size_t datumIndex, ArgType&& arg)
-        {
-            ModifiableDatumView datumView;
-            node.FindModifiableDatumViewByIndex(datumIndex, datumView);
-
-            datumView.template SetAs<AZStd::remove_cvref_t<ArgType>>(AZStd::forward<ArgType>(arg));
-        }
-    };
-
-    // a no-op for generic function nodes that have no overrides for default input
-    AZ_INLINE void NoDefaultArguments(Node&) {}
-
-    template<typename t_Func, typename t_Traits, t_Func function, typename t_DefaultFunc, t_DefaultFunc defaultsFunction>
-    class NodeFunctionGeneric
-        : public Node
-    {
-    public:
-        // This class has been deprecated for NodeFunctionGenericMultiReturn
-        NodeFunctionGeneric() = delete;
-        AZ_RTTI(((NodeFunctionGeneric<t_Func, t_Traits, function, t_DefaultFunc, defaultsFunction>), "{19E4AABE-1730-402C-A020-FC1006BC7F7B}", t_Func, t_Traits, t_DefaultFunc), Node);
-        AZ_COMPONENT_INTRUSIVE_DESCRIPTOR_TYPE(NodeFunctionGeneric);
-        AZ_COMPONENT_BASE(NodeFunctionGeneric, Node);
-    };
-
-    template<typename t_Func, typename t_Traits, t_Func function, typename t_DefaultFunc, t_DefaultFunc defaultsFunction>
+    template<typename t_Func, typename t_Traits, t_Func function>
     class NodeFunctionGenericMultiReturn
         : public Node
     {
     public:
         AZ_PUSH_DISABLE_WARNING(5046, "-Wunknown-warning-option") // 'function' : Symbol involving type with internal linkage not defined
-            AZ_RTTI(((NodeFunctionGenericMultiReturn<t_Func, t_Traits, function>), "{DC5B1799-6C5B-4190-8D90-EF0C2D1BCE4E}", t_Func, t_Traits), Node);
+        AZ_RTTI(((NodeFunctionGenericMultiReturn<t_Func, t_Traits, function>), "{DC5B1799-6C5B-4190-8D90-EF0C2D1BCE4E}", t_Func, t_Traits), Node);
         AZ_COMPONENT_INTRUSIVE_DESCRIPTOR_TYPE(NodeFunctionGenericMultiReturn);
         AZ_COMPONENT_BASE(NodeFunctionGenericMultiReturn, Node);
         AZ_POP_DISABLE_WARNING
@@ -251,31 +61,21 @@ namespace ScriptCanvas
             if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext))
             {
                 serializeContext->Class<NodeFunctionGenericMultiReturn, Node>()
-                    ->Version(1, &VersionConverter)
-                    ->Attribute(AZ::Script::Attributes::Deprecated, t_Traits::IsDeprecated())
+                    ->Version(1)
+                    ->Attribute(AZ::Script::Attributes::Deprecated, true)
                     ->Field("Initialized", &NodeFunctionGenericMultiReturn::m_initialized)
                     ;
 
                 if (AZ::EditContext* editContext = serializeContext->GetEditContext())
                 {
-                    editContext->Class<NodeFunctionGenericMultiReturn>(t_Traits::GetNodeName(), t_Traits::GetDescription())
-                        ->ClassElement(AZ::Edit::ClassElements::EditorData, t_Traits::GetDescription())
-                        ->Attribute(AZ::Script::Attributes::Deprecated, t_Traits::IsDeprecated())
-                        ->Attribute(ScriptCanvas::Attributes::Node::TitlePaletteOverride, t_Traits::IsDeprecated() ? "DeprecatedNodeTitlePalette" : "")
-                        ->Attribute(AZ::Edit::Attributes::Category, t_Traits::GetCategory())
+                    editContext->Class<NodeFunctionGenericMultiReturn>(t_Traits::GetNodeName(), "Deprecated Generic Function Node")
+                        ->ClassElement(AZ::Edit::ClassElements::EditorData, "Deprecated Generic Function Node")
+                        ->Attribute(AZ::Script::Attributes::Deprecated, true)
+                        ->Attribute(ScriptCanvas::Attributes::Node::TitlePaletteOverride, "DeprecatedNodeTitlePalette")
+                        ->Attribute(AZ::Edit::Attributes::Category, "Deprecated")
                         ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                         ;
                 }
-
-                // NodeFunctionGeneric class has been deprecated in terms of the this class
-                serializeContext->ClassDeprecate("NodeFunctionGeneric", azrtti_typeid<NodeFunctionGeneric<t_Func, t_Traits, function, t_DefaultFunc, defaultsFunction>>(), &ConvertOldNodeGeneric);
-                // Need to calculate the Typeid for the old NodeFunctionGeneric class as if it contains no templated types which are pointers
-                AZ::Uuid genericTypeIdPointerRemoved = AZ::Uuid{ "{19E4AABE-1730-402C-A020-FC1006BC7F7B}" } + AZ::Internal::AggregateTypes<t_Func, t_Traits, t_DefaultFunc>::template Uuid<AZ::PointerRemovedTypeIdTag>();
-                serializeContext->ClassDeprecate("NodeFunctionGenericTemplate", genericTypeIdPointerRemoved, &ConvertOldNodeGeneric);
-                // NodeFunctionGenericMultiReturn class used to use the same typeid for pointer and not-pointer types for the function parameters
-                // i.e, void Func(AZ::Entity*) and void Func2(AZ::Entity&) are the same typeid
-                AZ::Uuid genericMultiReturnV1TypeId = AZ::Uuid{ "{DC5B1799-6C5B-4190-8D90-EF0C2D1BCE4E}" } + AZ::Internal::AggregateTypes<t_Func, t_Traits>::template Uuid<AZ::PointerRemovedTypeIdTag>();
-                serializeContext->ClassDeprecate("NodeFunctionGenericMultiReturnV1", genericMultiReturnV1TypeId, &ConvertOldNodeGeneric);
             }
         }
 
@@ -299,7 +99,7 @@ namespace ScriptCanvas
 
         bool IsDeprecated() const override
         {
-            return t_Traits::IsDeprecated();
+            return true;
         }
 
         ScriptCanvas::NodeReplacementConfiguration GetReplacementNodeConfiguration() const override
@@ -312,59 +112,7 @@ namespace ScriptCanvas
             return replacementNode;
         }
 
-    protected:
-
-        template<typename ArgType, size_t Index>
-        void CreateDataSlot(const ConnectionType& connectionType)
-        {
-            DataSlotConfiguration slotConfiguration;
-
-            slotConfiguration.m_name = t_Traits::GetArgName(Index);
-            slotConfiguration.ConfigureDatum(AZStd::move(Datum(Data::FromAZType(Data::Traits<ArgType>::GetAZType()), Datum::eOriginality::Copy)));
-
-            slotConfiguration.SetConnectionType(connectionType);
-            AZ_VerifyError("ScriptCanvas", AddSlot(slotConfiguration).IsValid(), "NodeFunctionGenericMultiReturn failed to add a required data slot");
-        }
-
-        template<typename... t_Args, AZStd::size_t... Is>
-        void AddInputDatumSlotHelper(AZStd::Internal::pack_traits_arg_sequence<t_Args...>, AZStd::index_sequence<Is...>)
-        {
-            static_assert(sizeof...(t_Args) == sizeof...(Is), "Argument size mismatch in NodeFunctionGenericMultiReturn");
-            static_assert(sizeof...(t_Args) == t_Traits::s_numArgs, "Number of arguments does not match number of argument names in NodeFunctionGenericMultiReturn");
-
-            SCRIPT_CANVAS_CALL_ON_INDEX_SEQUENCE(
-                (CreateDataSlot<t_Args, Is>(ConnectionType::Input))
-            );
-        }
-
-        void ConfigureSlots() override
-        {
-            {
-                ExecutionSlotConfiguration slotConfiguration("In", ConnectionType::Input);
-                AZ_VerifyError("ScriptCanvas", AddSlot(slotConfiguration).IsValid(), "NodeFunctionGenericMultiReturn failed to add a required Execution In slot");
-            }
-
-            {
-                ExecutionSlotConfiguration slotConfiguration("Out", ConnectionType::Output);
-                AZ_VerifyError("ScriptCanvas", AddSlot(slotConfiguration).IsValid(), "NodeFunctionGenericMultiReturn failed to add a required Execution Out slot");
-            }
-
-            AddInputDatumSlotHelper(typename AZStd::function_traits<t_Func>::arg_sequence{}, AZStd::make_index_sequence<AZStd::function_traits<t_Func>::arity>{});
-
-            if (!m_initialized)
-            {
-                m_initialized = true;
-                defaultsFunction(*this);
-            }
-
-            MultipleOutputInvoker<t_Func, function, t_Traits>::Add(*this);
-        }
-
-        static bool VersionConverter(AZ::SerializeContext& serializeContext, AZ::SerializeContext::DataElementNode& rootElement);
-        static bool ConvertOldNodeGeneric(AZ::SerializeContext& serializeContext, AZ::SerializeContext::DataElementNode& rootElement);
-
     private:
-
         bool m_initialized = false;
     };
 
@@ -380,58 +128,13 @@ namespace ScriptCanvas
             SCRIPT_CANVAS_CALL_ON_INDEX_SEQUENCE(descriptors.push_back(t_Node::CreateDescriptor()));
         }
 
-        template<typename t_NodeGroup>
-        static void AddToRegistry(NodeRegistry& nodeRegistry)
-        {
-            auto& nodes = nodeRegistry.m_nodeMap[azrtti_typeid<t_NodeGroup>()];
-            SCRIPT_CANVAS_CALL_ON_INDEX_SEQUENCE(nodes.push_back({ azrtti_typeid<t_Node>(), AZ::AzTypeInfo<t_Node>::Name() }));
-        }
-
         template<typename t_Library>
         static void Reflect(AZ::BehaviorContext* behaviorContext, const char* libraryName)
         {
-            auto reflection = behaviorContext->Class<t_Library>(libraryName);
-            reflection->Attribute(AZ::ScriptCanvasAttributes::VariableCreationForbidden, AZ::AttributeIsValid::IfPresent)->Attribute(AZ::ScriptCanvasAttributes::Internal::ImplementedAsNodeGeneric, true);
+            auto reflection = behaviorContext->Class<t_Library>(libraryName)
+                ->Attribute(AZ::ScriptCanvasAttributes::VariableCreationForbidden, AZ::AttributeIsValid::IfPresent)
+                ->Attribute(AZ::ScriptCanvasAttributes::Internal::ImplementedAsNodeGeneric, true);
             SCRIPT_CANVAS_CALL_ON_INDEX_SEQUENCE(reflection->Method(t_Node::GetNodeFunctionName(), t_Node::GetFunction())->Attribute(AZ::Script::Attributes::ExcludeFrom, AZ::Script::Attributes::ExcludeFlags::List | AZ::Script::Attributes::ExcludeFlags::Documentation));
         }
     };
-
-    template<typename t_Func, typename t_Traits, t_Func function, typename t_DefaultFunc, t_DefaultFunc defaultsFunction>
-    bool NodeFunctionGenericMultiReturn<t_Func, t_Traits, function, t_DefaultFunc, defaultsFunction>::ConvertOldNodeGeneric(AZ::SerializeContext& serializeContext, AZ::SerializeContext::DataElementNode& rootElement)
-    {
-        int nodeElementIndex = rootElement.FindElement(AZ_CRC("BaseClass1", 0xd4925735));
-        if (nodeElementIndex == -1)
-        {
-            AZ_Error("Script Canvas", false, "Unable to find base class node element on deprecated class %s", rootElement.GetNameString());
-            return false;
-        }
-
-        // The DataElementNode is being copied purposefully in this statement to clone the data
-        AZ::SerializeContext::DataElementNode baseNodeElement = rootElement.GetSubElement(nodeElementIndex);
-        if (!rootElement.Convert(serializeContext, azrtti_typeid<NodeFunctionGenericMultiReturn>()))
-        {
-            AZ_Error("Script Canvas", false, "Unable to convert deprecated class %s to class %s", rootElement.GetNameString(), RTTI_TypeName());
-            return false;
-        }
-
-        if (rootElement.AddElement(baseNodeElement) == -1)
-        {
-            AZ_Error("Script Canvas", false, "Unable to add base class node element to %s", RTTI_TypeName());
-            return false;
-        }
-
-        return true;
-    }
-
-    template<typename t_Func, typename t_Traits, t_Func function, typename t_DefaultFunc, t_DefaultFunc defaultsFunction>
-    bool NodeFunctionGenericMultiReturn<t_Func, t_Traits, function, t_DefaultFunc, defaultsFunction>::VersionConverter(AZ::SerializeContext& serializeContext, AZ::SerializeContext::DataElementNode& rootElement)
-    {
-        if (rootElement.GetVersion() < 1)
-        {
-            rootElement.AddElementWithData(serializeContext, "Initialized", true);
-        }
-
-        return true;
-    }
-
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Deprecated/EntityNodes.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Deprecated/EntityNodes.h
@@ -26,9 +26,6 @@ namespace ScriptCanvas
         using namespace Data;
         static constexpr const char* k_categoryName = "Entity/Entity";
 
-        template<int t_Index>
-        AZ_INLINE void DefaultScale(Node& node) { SetDefaultValuesByIndex<t_Index>::_(node, Data::One()); }
-
         AZ_INLINE Vector3Type GetEntityRight(AZ::EntityId entityId, NumberType scale)
         {
             AZ::Transform worldTransform = {};


### PR DESCRIPTION
## Details
Clean up the legacy code and keep required code only to support migration

## Measurement Stats of Building ScriptCanvas Target
Following stats are collection from profile unity build
### Build Time Matrix
config | .lib | .dll 
:------:|:---:|:---:
development branch| 00:02:06.85 | 00:00:10.95
autogen system + trimmed legacy system | 00:02:06.96 (+0.11s) | 00:00:10.89 (-0.06s)
autogen system only | 00:02:06.69 (-0.16s) | 00:00:10.77 (-0.18s)
### File Size Matrix
config | .lib | .dll 
:------:|:---:|:---:
development branch| 703,190 KB | 47,642 KB
autogen system + trimmed legacy system | 709,574 KB | 46,213 KB
autogen system only | 607,392 KB | 40,633 KB

### Diff Analysis
Using [SizeBench](https://devblogs.microsoft.com/performance-diagnostics/sizebench-a-new-tool-for-analyzing-windows-binary-size/) for .lib and .dll diff analysis
#### **autogen system + trimmed legacy system** VS **development branch**
Binary Sections Diff
size on disk diff | size in memory diff | name | description
:---------------:|:--------------------:|:-----:|:------------:
-635.0 KB|-636.0 KB|.text|Code
-708.5 KB|-708.0 KB|.rdata|Read-only data
-68.0 KB|-92.0 KB|.data|Read/write data
-9.5 KB|-8.0 KB|.pdata|Procedure data
-8.0 KB|-8.0 KB|.reloc|Relocation data

Static Libs Diff
size on disk diff | name
:---------------:|:------:
-1.4 MB|ScriptCanvas.Static

#### **autogen system only** VS **development branch**
Binary Sections Diff
size on disk diff | size in memory diff | name | description
:---------------:|:--------------------:|:-----:|:------------:
-3.8 MB|-3.8 MB|.text|Code
-2.4 MB|-2.4 MB|.rdata|Read-only data
-392.0 KB|-504.0 KB|.data|Read/write data
-179.5 KB|-180.0 KB|.pdata|Procedure data
-128.5 KB|-132.0 KB|.reloc|Relocation data

Static Libs Diff
size on disk diff | name
:---------------:|:------:
-39.4 MB|ScriptCanvas.Static


Signed-off-by: onecent1101 <liug@amazon.com>