### PR TITLE
Improve symbol stripping fix

### DIFF
--- a/Gems/ScriptCanvas/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvas/Code/CMakeLists.txt
@@ -97,8 +97,8 @@ ly_add_target(
             Gem::ScriptCanvasDebugger
             Gem::ScriptCanvas.Extensions
     AUTOGEN_RULES
-        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Header.jinja,$path/$fileprefix.generated.h
-        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,$path/$fileprefix.generated.cpp
+        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Header.jinja,AutoGenFunctionRegistry.generated.h
+        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,AutoGenFunctionRegistry.generated.cpp
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Header.jinja,$path/$fileprefix.generated.h
         *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Source.jinja,$path/$fileprefix.generated.cpp
         *.ScriptCanvasNodeable.xml,ScriptCanvasNodeable_Header.jinja,$path/$fileprefix.generated.h

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -16,10 +16,12 @@ namespace AZ
     class ReflectContext;
 }
 
+#define CONCAT_IMPL(x, y) x##y
+#define UNIQUE_NAME(x, y) CONCAT_IMPL(x, y)
+
 //! Macros to self-register AutoGen functions into ScriptCanvas
-//! Which takes the same library name as provided in .ScriptCanvasFunction.xml
-#define REGISTER_SCRIPTCANVAS_FUNCTION(LIBRARY)\
-    static ScriptCanvas##LIBRARY s_ScriptCanvas##LIBRARY;
+//! Which takes the same library (library namespace + library name) as provided in .ScriptCanvasFunction.xml
+#define REGISTER_SCRIPTCANVAS_FUNCTION(LIBRARY) static LIBRARY UNIQUE_NAME(s_functionLibrary, __COUNTER__);
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -16,12 +16,9 @@ namespace AZ
     class ReflectContext;
 }
 
-#define CONCAT_IMPL(x, y) x##y
-#define UNIQUE_NAME(x, y) CONCAT_IMPL(x, y)
-
-//! Macros to self-register AutoGen functions into ScriptCanvas
-//! Which takes the same library (library namespace + library name) as provided in .ScriptCanvasFunction.xml
-#define REGISTER_SCRIPTCANVAS_FUNCTION(LIBRARY) static LIBRARY UNIQUE_NAME(s_functionLibrary, __COUNTER__);
+//! Macros to self-register AutoGen node into ScriptCanvas
+#define REGISTER_SCRIPTCANVAS_AUTOGEN(LIBRARY)\
+    static ScriptCanvas::##LIBRARY##FunctionRegistry s_AutoGenFunctionRegistry;
 
 namespace ScriptCanvas
 {
@@ -42,13 +39,16 @@ namespace ScriptCanvas
 
         static AutoGenRegistry* GetInstance();
 
-        // Reflect all autogen functions
+        //! Reflect all AutoGen functions
         static void Reflect(AZ::ReflectContext* context);
 
-        //! Reflect specified autogen function by given name
+        //! Reflect specified AutoGen function by given name
         static void ReflectFunction(AZ::ReflectContext* context, const char* functionName);
 
+        //! Register function registry with its name
         void RegisterFunction(const char* functionName, IScriptCanvasFunctionRegistry* registry);
+
+        //! Unregister function registry by using its name
         void UnregisterFunction(const char* functionName);
 
         std::unordered_map<std::string, IScriptCanvasFunctionRegistry*> m_functions;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h
@@ -18,7 +18,7 @@ namespace AZ
 
 //! Macros to self-register AutoGen node into ScriptCanvas
 #define REGISTER_SCRIPTCANVAS_AUTOGEN(LIBRARY)\
-    static ScriptCanvas::##LIBRARY##FunctionRegistry s_AutoGenFunctionRegistry;
+    static ScriptCanvas::LIBRARY##FunctionRegistry s_AutoGenFunctionRegistry;
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction.xsd
@@ -93,11 +93,6 @@
                                 <xs:documentation>The header file contains function declarations.</xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="Name" type="NonEmptyString" use="required">
-                            <xs:annotation>
-                                <xs:documentation>The name of library.</xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
                         <xs:attribute name="Namespace" type="NonEmptyString" use="required">
                             <xs:annotation>
                                 <xs:documentation>The namespace of functions, it has to be unique and same as function declaration.</xs:documentation>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
@@ -10,7 +10,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 // This code was produced with AzAutoGen, any modifications made will not be preserved.
 // If you need to modify this code see:
 //
-// Gems\ScriptCanvas\Code\Include\ScriptCanvas\AutoGen\ScriptCanvasFunction_Source.jinja
+// Gems\ScriptCanvas\Code\Include\ScriptCanvas\AutoGen\ScriptCanvasFunction_Header.jinja
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -27,14 +27,14 @@ namespace AZ
 
 namespace ScriptCanvas
 {
-    //! {{azcgTargetName}}FunctionRegistry
+    //! {{autogenTargetName}}FunctionRegistry
     //! AutoGen registry to register function required metadata into system
-    class {{azcgTargetName}}FunctionRegistry
+    class {{autogenTargetName}}FunctionRegistry
         : public IScriptCanvasFunctionRegistry
     {
     public:
-        {{azcgTargetName}}FunctionRegistry();
-        virtual ~{{azcgTargetName}}FunctionRegistry();
+        {{autogenTargetName}}FunctionRegistry();
+        virtual ~{{autogenTargetName}}FunctionRegistry();
  
         //! Reflect function metadata into BehaviorContext
         void Reflect(AZ::ReflectContext* context) override;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
@@ -5,9 +5,6 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 #}
 
-{% import 'ScriptCanvas_Macros.jinja' as macros %}
-
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 // This code was produced with AzAutoGen, any modifications made will not be preserved.
@@ -17,44 +14,32 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 //
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include <AzCore/RTTI/BehaviorContext.h>
+{% import 'ScriptCanvas_Macros.jinja' as macros %}
+
+#pragma once
+
 #include <ScriptCanvasAutoGenRegistry.h>
 
-{% for ScriptCanvas in dataFiles %}
-{% for Library in ScriptCanvas%}
-
-{{- macros.Required('Include', Library, Library) -}}
-{{- macros.Required('Name', Library, Library) -}}
-
-{% set className = macros.CleanName(Library.attrib['Name']) %}
-{% set namespaceList = [] %}
-{% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
-{% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
-{% endif %}
-
-{% for namespace in namespaceList %}
-namespace {{namespace}}
+namespace AZ
 {
-{% endfor %}
-
-class {{className}}
-    : public ScriptCanvas::IScriptCanvasFunctionRegistry
-{
-public:
-    {{className}}();
-
-    virtual ~{{className}}();
- 
-    void Reflect(AZ::ReflectContext* context) override;
-
-    static const char* GetRegistryName();
-};
-
-{% for namespace in namespaceList %}
+    class ReflectContext;
 }
-{% endfor %}
 
-{{ macros.ReportErrors() }}
+namespace ScriptCanvas
+{
+    //! {{azcgTargetName}}FunctionRegistry
+    //! AutoGen registry to register function required metadata into system
+    class {{azcgTargetName}}FunctionRegistry
+        : public IScriptCanvasFunctionRegistry
+    {
+    public:
+        {{azcgTargetName}}FunctionRegistry();
+        virtual ~{{azcgTargetName}}FunctionRegistry();
+ 
+        //! Reflect function metadata into BehaviorContext
+        void Reflect(AZ::ReflectContext* context) override;
 
-{% endfor %}
-{% endfor %}
+        //! Get AutoGen registry name
+        static const char* GetRegistryName();
+    };
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Header.jinja
@@ -26,7 +26,7 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {{- macros.Required('Include', Library, Library) -}}
 {{- macros.Required('Name', Library, Library) -}}
 
-{% set className = macros.CleanName('ScriptCanvas' + Library.attrib['Name']) %}
+{% set className = macros.CleanName(Library.attrib['Name']) %}
 {% set namespaceList = [] %}
 {% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
 {% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
@@ -46,6 +46,8 @@ public:
     virtual ~{{className}}();
  
     void Reflect(AZ::ReflectContext* context) override;
+
+    static const char* GetRegistryName();
 };
 
 {% for namespace in namespaceList %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -52,7 +52,6 @@ false
 {%- endmacro -%}
 
 #include "{{filename}}.h"
-#include <AzCore/Math/Uuid.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <ScriptCanvasAutoGenRegistry.h>
 {% for ScriptCanvas in dataFiles %}
@@ -67,21 +66,21 @@ false
 
 namespace ScriptCanvas
 {
-    {{azcgTargetName}}FunctionRegistry::{{azcgTargetName}}FunctionRegistry()
+    {{autogenTargetName}}FunctionRegistry::{{autogenTargetName}}FunctionRegistry()
     {
         ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction(GetRegistryName(), this);
     }
 
-    {{azcgTargetName}}FunctionRegistry::~{{azcgTargetName}}FunctionRegistry()
+    {{autogenTargetName}}FunctionRegistry::~{{autogenTargetName}}FunctionRegistry()
     {
         ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction(GetRegistryName());
     }
 
-    const char* {{azcgTargetName}}FunctionRegistry::GetRegistryName() {
-        return "{{azcgTargetName}}";
+    const char* {{autogenTargetName}}FunctionRegistry::GetRegistryName() {
+        return "{{autogenTargetName}}";
     }
 
-    void {{azcgTargetName}}FunctionRegistry::Reflect(AZ::ReflectContext* context)
+    void {{autogenTargetName}}FunctionRegistry::Reflect(AZ::ReflectContext* context)
     {
         if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -62,7 +62,7 @@ false
 
 #include "{{ Library.attrib['Include'] }}"
 
-{% set className = macros.CleanName('ScriptCanvas' + Library.attrib['Name']) %}
+{% set className = macros.CleanName(Library.attrib['Name']) %}
 {% set namespaceList = [] %}
 {% set sanitizedNamespaceName = 'GlobalMethod' %}
 {% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
@@ -78,12 +78,12 @@ namespace {{namespace}}
 
 {{className}}::{{className}}()
 {
-    ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction("{{sanitizedNamespaceName}}_{{className}}", this);
+    ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction(GetRegistryName(), this);
 }
 
 {{className}}::~{{className}}()
 {
-    ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction("{{sanitizedNamespaceName}}_{{className}}");
+    ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction(GetRegistryName());
 }
 
 void {{className}}::Reflect(AZ::ReflectContext* context)
@@ -124,6 +124,11 @@ void {{className}}::Reflect(AZ::ReflectContext* context)
         }
 {% endfor %}
     }
+}
+
+const char* {{className}}::GetRegistryName()
+{
+    return "{{sanitizedNamespaceName}}_{{className}}";
 }
 
 {% for namespace in namespaceList %}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasFunction_Source.jinja
@@ -5,6 +5,15 @@ For complete copyright and license terms please see the LICENSE at the root of t
 SPDX-License-Identifier: Apache-2.0 OR MIT
 #}
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// This code was produced with AzAutoGen, any modifications made will not be preserved.
+// If you need to modify this code see:
+//
+// Gems\ScriptCanvas\Code\Include\ScriptCanvas\AutoGen\ScriptCanvasFunction_Source.jinja
+//
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 {% import 'ScriptCanvas_Macros.jinja' as macros %}
 
 {%- macro CheckFunctionBranchResult(function) -%}
@@ -42,100 +51,89 @@ false
 {% endif -%}
 {%- endmacro -%}
 
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// This code was produced with AzAutoGen, any modifications made will not be preserved.
-// If you need to modify this code see:
-//
-// Gems\ScriptCanvas\Code\Include\ScriptCanvas\AutoGen\ScriptCanvasFunction_Source.jinja
-//
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
+#include "{{filename}}.h"
+#include <AzCore/Math/Uuid.h>
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <ScriptCanvasAutoGenRegistry.h>
-
 {% for ScriptCanvas in dataFiles %}
 {% for Library in ScriptCanvas%}
-
-{{- macros.Required('Include', Library, Library) -}}
-{{- macros.Required('Name', Library, Library) -}}
+{{ macros.Required('Include', Library, Library) -}}
 
 #include "{{ Library.attrib['Include'] }}"
 
-{% set className = macros.CleanName(Library.attrib['Name']) %}
-{% set namespaceList = [] %}
+{{- macros.ReportErrors() }}
+{% endfor %}
+{% endfor %}
+
+namespace ScriptCanvas
+{
+    {{azcgTargetName}}FunctionRegistry::{{azcgTargetName}}FunctionRegistry()
+    {
+        ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction(GetRegistryName(), this);
+    }
+
+    {{azcgTargetName}}FunctionRegistry::~{{azcgTargetName}}FunctionRegistry()
+    {
+        ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction(GetRegistryName());
+    }
+
+    const char* {{azcgTargetName}}FunctionRegistry::GetRegistryName() {
+        return "{{azcgTargetName}}";
+    }
+
+    void {{azcgTargetName}}FunctionRegistry::Reflect(AZ::ReflectContext* context)
+    {
+        if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
+        {
+{% for ScriptCanvas in dataFiles %}
+{% for Library in ScriptCanvas -%}
+
+{% set namespaceName = '' %}
 {% set sanitizedNamespaceName = 'GlobalMethod' %}
 {% if Library.attrib['Namespace'] is defined and Library.attrib['Namespace'] %}
-{% set namespaceList = macros.CleanName(Library.attrib['Namespace']).split('::') %}
+{% set namespaceName = Library.attrib['Namespace'] + '::' %}
 {% set sanitizedNamespaceName = macros.CleanName(Library.attrib['Namespace'].replace('::', '_')) %}
 {% endif %}
 {% set categoryName = Library.attrib['Category'] %}
-
-{% for namespace in namespaceList %}
-namespace {{namespace}}
-{
-{% endfor %}
-
-{{className}}::{{className}}()
-{
-    ScriptCanvas::AutoGenRegistry::GetInstance()->RegisterFunction(GetRegistryName(), this);
-}
-
-{{className}}::~{{className}}()
-{
-    ScriptCanvas::AutoGenRegistry::GetInstance()->UnregisterFunction(GetRegistryName());
-}
-
-void {{className}}::Reflect(AZ::ReflectContext* context)
-{
-    if (AZ::BehaviorContext* behaviorContext = azrtti_cast<AZ::BehaviorContext*>(context))
-    {
+            // Reflect {{namespaceName}} functions
 {% for function in Library.findall('Function') %}
-        {
+            {
 {{ macros.Required('Name', function, Library) }}
 
 {%- set hasbranch = CheckFunctionBranchResult(function) -%}
 {% if hasbranch|booleanTrue == true %}
 {% set branchfunction = function.attrib['Branch'] %}
-            AZ::BranchOnResultInfo branchResultInfo;
+                AZ::BranchOnResultInfo branchResultInfo;
 {% if branchfunction is defined and branchfunction and not branchfunction == "Boolean" %}
 {% set sanitizedBranchFunctionName = macros.CleanName(branchfunction).replace('::', '_') %}
-            branchResultInfo.m_nonBooleanResultCheckName = "{{sanitizedNamespaceName}}_{{sanitizedBranchFunctionName}}";
+                branchResultInfo.m_nonBooleanResultCheckName = "{{sanitizedNamespaceName}}_{{sanitizedBranchFunctionName}}";
 {% endif -%}
 {% set branchwithvalue = function.attrib['BranchWithValue'] %}
 {%- if branchwithvalue is defined and branchwithvalue.lower() == "true" %}
-            branchResultInfo.m_returnResultInBranches = true;
+                branchResultInfo.m_returnResultInBranches = true;
 {% endif -%}
 {{SetBranchExecution(function)}}
 {%- endif -%}
 
 {% set functionName = macros.CleanName(function.attrib['Name']) %}
 {% set sanitizedFunctionName = macros.CleanName(function.attrib['Name']).replace('::', '_') %}
-            behaviorContext->Method("{{sanitizedNamespaceName}}_{{sanitizedFunctionName}}", &{{functionName}},
+                behaviorContext->Method("{{sanitizedNamespaceName}}_{{sanitizedFunctionName}}", &{{namespaceName}}{{functionName}},
 {{macros.GenerateFunctionMetaData(function)}})
-                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
+                    ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Common)
 {% if categoryName %}
-                ->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
+                    ->Attribute(AZ::Script::Attributes::Category, "{{categoryName}}")
 {% endif %}
 {% if hasbranch|booleanTrue == true %}
-                ->Attribute(AZ::ScriptCanvasAttributes::BranchOnResult, branchResultInfo)
+                    ->Attribute(AZ::ScriptCanvasAttributes::BranchOnResult, branchResultInfo)
 {% endif %}
-            ;
-        }
-{% endfor %}
-    }
-}
-
-const char* {{className}}::GetRegistryName()
-{
-    return "{{sanitizedNamespaceName}}_{{className}}";
-}
-
-{% for namespace in namespaceList %}
-}
-{% endfor %}
+                ;
+            }
+{% endfor -%}
 
 {{ macros.ReportErrors() }}
 
+{%- endfor %}
 {% endfor %}
-{% endfor %}
+        }
+    }
+}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.ScriptCanvasFunction.xml
@@ -3,7 +3,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Entity/EntityFunctions.h"
-        Name="EntityFunctions"
         Namespace="ScriptCanvas::EntityFunctions"
         Category="Entity/Entity">
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.cpp
@@ -15,8 +15,6 @@ namespace ScriptCanvas
 {
     namespace EntityFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(EntityFunctions);
-
         AZ::Vector3 GetEntityRight(AZ::EntityId entityId, double scale)
         {
             AZ::Transform worldTransform = {};

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Entity/EntityFunctions.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Math/Vector3.h>
-#include <Include/ScriptCanvas/Libraries/Entity/EntityFunctions.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.cpp
@@ -14,21 +14,6 @@
 #include <Libraries/Logic/Logic.h>
 #include <Libraries/Spawning/Spawning.h>
 #include <Libraries/UnitTesting/UnitTestingLibrary.h>
-#include <ScriptCanvas/Libraries/Entity/EntityFunctions.h>
-#include <ScriptCanvas/Libraries/Math/AABB.h>
-#include <ScriptCanvas/Libraries/Math/CRC.h>
-#include <ScriptCanvas/Libraries/Math/Color.h>
-#include <ScriptCanvas/Libraries/Math/MathFunctions.h>
-#include <ScriptCanvas/Libraries/Math/Matrix3x3.h>
-#include <ScriptCanvas/Libraries/Math/Matrix4x4.h>
-#include <ScriptCanvas/Libraries/Math/OBB.h>
-#include <ScriptCanvas/Libraries/Math/Plane.h>
-#include <ScriptCanvas/Libraries/Math/Quaternion.h>
-#include <ScriptCanvas/Libraries/Math/Transform.h>
-#include <ScriptCanvas/Libraries/Math/Vector2.h>
-#include <ScriptCanvas/Libraries/Math/Vector3.h>
-#include <ScriptCanvas/Libraries/Math/Vector4.h>
-#include <ScriptCanvas/Libraries/String/StringFunctions.h>
 
 namespace ScriptCanvas
 {
@@ -36,23 +21,6 @@ namespace ScriptCanvas
 
     void InitNodeRegistry()
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::EntityFunctions::EntityFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::AABBFunctions::AABBFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::ColorFunctions::ColorFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::CRCFunctions::CRCFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::MathFunctions::MathFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::MathRandoms::MathRandoms);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Matrix3x3Functions::Matrix3x3Functions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Matrix4x4Functions::Matrix4x4Functions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::OBBFunctions::OBBFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::PlaneFunctions::PlaneFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::QuaternionFunctions::QuaternionFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::TransformFunctions::TransformFunctions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Vector2Functions::Vector2Functions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Vector3Functions::Vector3Functions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Vector4Functions::Vector4Functions);
-        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::StringFunctions::StringFunctions);
-
         g_nodeRegistry = AZ::Environment::CreateVariable<NodeRegistry>(s_nodeRegistryName);
         using namespace Library;
         Core::InitNodeRegistry(*g_nodeRegistry);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.cpp
@@ -14,6 +14,21 @@
 #include <Libraries/Logic/Logic.h>
 #include <Libraries/Spawning/Spawning.h>
 #include <Libraries/UnitTesting/UnitTestingLibrary.h>
+#include <ScriptCanvas/Libraries/Entity/EntityFunctions.h>
+#include <ScriptCanvas/Libraries/Math/AABB.h>
+#include <ScriptCanvas/Libraries/Math/CRC.h>
+#include <ScriptCanvas/Libraries/Math/Color.h>
+#include <ScriptCanvas/Libraries/Math/MathFunctions.h>
+#include <ScriptCanvas/Libraries/Math/Matrix3x3.h>
+#include <ScriptCanvas/Libraries/Math/Matrix4x4.h>
+#include <ScriptCanvas/Libraries/Math/OBB.h>
+#include <ScriptCanvas/Libraries/Math/Plane.h>
+#include <ScriptCanvas/Libraries/Math/Quaternion.h>
+#include <ScriptCanvas/Libraries/Math/Transform.h>
+#include <ScriptCanvas/Libraries/Math/Vector2.h>
+#include <ScriptCanvas/Libraries/Math/Vector3.h>
+#include <ScriptCanvas/Libraries/Math/Vector4.h>
+#include <ScriptCanvas/Libraries/String/StringFunctions.h>
 
 namespace ScriptCanvas
 {
@@ -21,6 +36,23 @@ namespace ScriptCanvas
 
     void InitNodeRegistry()
     {
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::EntityFunctions::EntityFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::AABBFunctions::AABBFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::ColorFunctions::ColorFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::CRCFunctions::CRCFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::MathFunctions::MathFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::MathRandoms::MathRandoms);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Matrix3x3Functions::Matrix3x3Functions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Matrix4x4Functions::Matrix4x4Functions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::OBBFunctions::OBBFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::PlaneFunctions::PlaneFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::QuaternionFunctions::QuaternionFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::TransformFunctions::TransformFunctions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Vector2Functions::Vector2Functions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Vector3Functions::Vector3Functions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::Vector4Functions::Vector4Functions);
+        REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvas::StringFunctions::StringFunctions);
+
         g_nodeRegistry = AZ::Environment::CreateVariable<NodeRegistry>(s_nodeRegistryName);
         using namespace Library;
         Core::InitNodeRegistry(*g_nodeRegistry);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/AABB.h"
-        Name="AABBFunctions"
         Namespace="ScriptCanvas::AABBFunctions"
         Category="Math/AABB">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace AABBFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(AABBFunctions);
-
         AZ::Aabb AddAABB(AZ::Aabb a, const AZ::Aabb& b)
         {
             a.AddAabb(b);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/AABB.h
@@ -13,7 +13,6 @@
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/tuple.h>
-#include <Include/ScriptCanvas/Libraries/Math/AABB.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/CRC.h"
-        Name="CRCFunctions"
         Namespace="ScriptCanvas::CRCFunctions"
         Category="Math/Crc32">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.cpp
@@ -14,8 +14,6 @@ namespace ScriptCanvas
 {
     namespace CRCFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(CRCFunctions);
-
         Data::CRCType FromString(Data::StringType value)
         {
             return AZ::Crc32(value.data());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/CRC.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/CRC.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Color.h"
-        Name="ColorFunctions"
         Namespace="ScriptCanvas::ColorFunctions"
         Category="Math/Color">
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.cpp
@@ -15,8 +15,6 @@ namespace ScriptCanvas
 {
     namespace ColorFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(ColorFunctions);
-
         using namespace Data;
 
         NumberType Dot(ColorType a, ColorType b)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Color.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Color.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/MathFunctions.h"
-        Name="MathFunctions"
         Namespace="ScriptCanvas::MathFunctions"
         Category="Math">
         
@@ -19,7 +18,6 @@
 
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/MathFunctions.h"
-        Name="MathRandoms"
         Namespace="ScriptCanvas::MathRandoms"
         Category="Math/Random">
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.cpp
@@ -16,8 +16,6 @@ namespace ScriptCanvas
 {
     namespace MathFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(MathFunctions);
-
         Data::NumberType MultiplyAndAdd(Data::NumberType multiplicand, Data::NumberType multiplier, Data::NumberType addend)
         {
             // result = src0 * src1 + src2
@@ -32,8 +30,6 @@ namespace ScriptCanvas
 
     namespace MathRandoms
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(MathRandoms);
-
         Data::ColorType RandomColor(Data::ColorType minValue, Data::ColorType maxValue)
         {
             return Data::ColorType(MathNodeUtilities::GetRandomReal<float>(minValue.GetR(), maxValue.GetR()),

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathFunctions.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/MathFunctions.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Matrix3x3.h"
-        Name="Matrix3x3Functions"
         Namespace="ScriptCanvas::Matrix3x3Functions"
         Category="Math/Matrix3x3">
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace Matrix3x3Functions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(Matrix3x3Functions);
-
         Data::Matrix3x3Type FromColumns(
             const Data::Vector3Type& col0, const Data::Vector3Type& col1, const Data::Vector3Type& col2)
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix3x3.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Matrix3x3.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Matrix4x4.h"
-        Name="Matrix4x4Functions"
         Namespace="ScriptCanvas::Matrix4x4Functions"
         Category="Math/Matrix4x4">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace Matrix4x4Functions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(Matrix4x4Functions);
-
         Data::Matrix4x4Type FromColumns(
             const Data::Vector4Type& col0, const Data::Vector4Type& col1, const Data::Vector4Type& col2, const Data::Vector4Type& col3)
         {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Matrix4x4.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Matrix4x4.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/OBB.h"
-        Name="OBBFunctions"
         Namespace="ScriptCanvas::OBBFunctions"
         Category="Math/OBB">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace OBBFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(OBBFunctions);
-
         using namespace Data;
 
         OBBType FromAabb(const AABBType& source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/OBB.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/OBB.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Plane.h"
-        Name="PlaneFunctions"
         Namespace="ScriptCanvas::PlaneFunctions"
         Category="Math/Plane">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace PlaneFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(PlaneFunctions);
-
         using namespace Data;
 
         NumberType DistanceToPoint(PlaneType source, Vector3Type point)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Plane.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Plane.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Quaternion.h"
-        Name="QuaternionFunctions"
         Namespace="ScriptCanvas::QuaternionFunctions"
         Category="Math/Quaternion">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace QuaternionFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(QuaternionFunctions);
-
         using namespace Data;
 
         QuaternionType Conjugate(QuaternionType source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Quaternion.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Quaternion.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Transform.h"
-        Name="TransformFunctions"
         Namespace="ScriptCanvas::TransformFunctions"
         Category="Math/Transform">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace TransformFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(TransformFunctions);
-
         using namespace Data;
 
         TransformType FromMatrix3x3(Matrix3x3Type source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Transform.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Transform.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Vector2.h"
-        Name="Vector2Functions"
         Namespace="ScriptCanvas::Vector2Functions"
         Category="Math/Vector2">
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace Vector2Functions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(Vector2Functions);
-
         using namespace Data;
 
         Vector2Type Absolute(const Vector2Type source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector2.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Vector2.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Vector3.h"
-        Name="Vector3Functions"
         Namespace="ScriptCanvas::Vector3Functions"
         Category="Math/Vector3">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace Vector3Functions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(Vector3Functions);
-
         using namespace Data;
 
         Vector3Type Absolute(const Vector3Type source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector3.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Vector3.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.ScriptCanvasFunction.xml
@@ -2,7 +2,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/Math/Vector4.h"
-        Name="Vector4Functions"
         Namespace="ScriptCanvas::Vector4Functions"
         Category="Math/Vector4">
         

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvas
 {
     namespace Vector4Functions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(Vector4Functions);
-
         using namespace Data;
 
         Vector4Type Absolute(const Vector4Type source)

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/Vector4.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Include/ScriptCanvas/Libraries/Math/Vector4.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.ScriptCanvasFunction.xml
@@ -3,7 +3,6 @@
 <ScriptCanvas>
     <Library
         Include="Include/ScriptCanvas/Libraries/String/StringFunctions.h"
-        Name="StringFunctions"
         Namespace="ScriptCanvas::StringFunctions"
         Category="String">
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.cpp
@@ -21,8 +21,6 @@ namespace ScriptCanvas
 
     namespace StringFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(StringFunctions);
-
         AZStd::string ToLower(AZStd::string sourceString)
         {
             AZStd::to_lower(sourceString.begin(), sourceString.end());

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/StringFunctions.h
@@ -10,7 +10,6 @@
 
 #include <AzCore/std/containers/vector.h>
 #include <AzCore/std/string/string.h>
-#include <Include/ScriptCanvas/Libraries/String/StringFunctions.generated.h>
 
 namespace ScriptCanvas
 {

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -14,7 +14,6 @@
 #include <AzCore/Serialization/Utils.h>
 #include <Libraries/Libraries.h>
 #include <ScriptCanvas/Asset/RuntimeAsset.h>
-#include <ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h>
 #include <ScriptCanvas/Core/Contract.h>
 #include <ScriptCanvas/Core/Graph.h>
 #include <ScriptCanvas/Core/Node.h>
@@ -32,6 +31,10 @@
 #if defined(SC_EXECUTION_TRACE_ENABLED)
 #include <ScriptCanvas/Asset/ExecutionLogAsset.h>
 #endif
+
+#include <AutoGenFunctionRegistry.generated.h>
+
+REGISTER_SCRIPTCANVAS_AUTOGEN(ScriptCanvasStatic);
 
 namespace ScriptCanvasSystemComponentCpp
 {

--- a/Gems/ScriptCanvasPhysics/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvasPhysics/Code/CMakeLists.txt
@@ -20,8 +20,8 @@ ly_add_target(
         PUBLIC
             Gem::ScriptCanvas.Extensions
     AUTOGEN_RULES
-        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Header.jinja,$path/$fileprefix.generated.h
-        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,$path/$fileprefix.generated.cpp
+        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Header.jinja,AutoGenFunctionRegistry.generated.h
+        *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,AutoGenFunctionRegistry.generated.cpp
 )
 
 ly_add_target(

--- a/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsModule.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsModule.cpp
@@ -9,6 +9,7 @@
 #include "ScriptCanvasPhysicsSystemComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
+#include "World.h"
 
 namespace ScriptCanvasPhysics
 {
@@ -22,6 +23,8 @@ namespace ScriptCanvasPhysics
         ScriptCanvasPhysicsModule()
             : AZ::Module()
         {
+            REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvasPhysics::WorldFunctions::WorldFunctions);
+
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             m_descriptors.insert(m_descriptors.end(), {
                 ScriptCanvasPhysicsSystemComponent::CreateDescriptor(),

--- a/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsModule.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsModule.cpp
@@ -9,7 +9,6 @@
 #include "ScriptCanvasPhysicsSystemComponent.h"
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
-#include "World.h"
 
 namespace ScriptCanvasPhysics
 {
@@ -23,8 +22,6 @@ namespace ScriptCanvasPhysics
         ScriptCanvasPhysicsModule()
             : AZ::Module()
         {
-            REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvasPhysics::WorldFunctions::WorldFunctions);
-
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             m_descriptors.insert(m_descriptors.end(), {
                 ScriptCanvasPhysicsSystemComponent::CreateDescriptor(),

--- a/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsSystemComponent.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Source/ScriptCanvasPhysicsSystemComponent.cpp
@@ -11,7 +11,9 @@
 #include <AzCore/RTTI/BehaviorContext.h>
 
 #include "ScriptCanvasPhysicsSystemComponent.h"
-#include <ScriptCanvasAutoGenRegistry.h>
+#include <AutoGenFunctionRegistry.generated.h>
+
+REGISTER_SCRIPTCANVAS_AUTOGEN(ScriptCanvasPhysicsStatic);
 
 namespace ScriptCanvasPhysics
 {

--- a/Gems/ScriptCanvasPhysics/Code/Source/World.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvasPhysics/Code/Source/World.ScriptCanvasFunction.xml
@@ -3,7 +3,6 @@
 <ScriptCanvas>
     <Library
         Include="World.h"
-        Name="WorldFunctions"
         Namespace="ScriptCanvasPhysics::WorldFunctions"
         Category="PhysX/World">
 

--- a/Gems/ScriptCanvasPhysics/Code/Source/World.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Source/World.cpp
@@ -21,8 +21,6 @@ namespace ScriptCanvasPhysics
 {
     namespace WorldFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(WorldFunctions);
-
         Result RayCastWorldSpaceWithGroup(
             const AZ::Vector3& start,
             const AZ::Vector3& direction,

--- a/Gems/ScriptCanvasPhysics/Code/Source/World.h
+++ b/Gems/ScriptCanvasPhysics/Code/Source/World.h
@@ -17,7 +17,6 @@
 #include <AzCore/Math/Vector2.h>
 #include <AzCore/Math/Vector3.h>
 #include <AzCore/std/string/string.h>
-#include <Source/World.generated.h>
 
 namespace ScriptCanvasPhysics
 {

--- a/Gems/ScriptCanvasTesting/Code/CMakeLists.txt
+++ b/Gems/ScriptCanvasTesting/Code/CMakeLists.txt
@@ -39,8 +39,8 @@ ly_add_target(
             AZ::AzToolsFramework
             AZ::AssetBuilderSDK
         AUTOGEN_RULES
-            *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Header.jinja,$path/$fileprefix.generated.h
-            *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,$path/$fileprefix.generated.cpp
+            *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Header.jinja,TestAutoGenFunctionRegistry.generated.h
+            *.ScriptCanvasFunction.xml,ScriptCanvasFunction_Source.jinja,TestAutoGenFunctionRegistry.generated.cpp
             *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Header.jinja,$path/$fileprefix.generated.h
             *.ScriptCanvasGrammar.xml,ScriptCanvasGrammar_Source.jinja,$path/$fileprefix.generated.cpp
             *.ScriptCanvasNodeable.xml,ScriptCanvasNodeable_Header.jinja,$path/$fileprefix.generated.h

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
@@ -20,11 +20,11 @@
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzTest/AzTest.h>
 
+#include <TestAutoGenFunctionRegistry.generated.h>
 #include <Nodes/BehaviorContextObjectTestNode.h>
 #include <Nodes/Nodeables/SharedDataSlotExample.h>
 #include <Nodes/Nodeables/ValuePointerReferenceExample.h>
 #include <Nodes/TestAutoGenFunctions.h>
-#include <ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h>
 #include <ScriptCanvas/Core/Graph.h>
 #include <ScriptCanvas/Core/SlotConfigurationDefaults.h>
 #include <ScriptCanvas/ScriptCanvasGem.h>
@@ -130,9 +130,9 @@ namespace ScriptCanvasTests
             TestNodeableObject::Reflect(m_behaviorContext);
             ScriptUnitTestEventHandler::Reflect(m_serializeContext);
             ScriptUnitTestEventHandler::Reflect(m_behaviorContext);
-            REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvasTesting::TestAutoGenFunctions::TestAutoGenFunctions);
+            REGISTER_SCRIPTCANVAS_AUTOGEN(ScriptCanvasTestingEditorStatic);
             ScriptCanvas::AutoGenRegistry::ReflectFunction(
-                m_behaviorContext, ScriptCanvasTesting::TestAutoGenFunctions::TestAutoGenFunctions::GetRegistryName());
+                m_behaviorContext, ScriptCanvas::ScriptCanvasTestingEditorStaticFunctionRegistry::GetRegistryName());
         }
 
         static void TearDownTestCase()

--- a/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Framework/ScriptCanvasTestFixture.h
@@ -39,14 +39,6 @@
 #define SC_EXPECT_DOUBLE_EQ(candidate, reference) EXPECT_NEAR(candidate, reference, 0.001)
 #define SC_EXPECT_FLOAT_EQ(candidate, reference) EXPECT_NEAR(candidate, reference, 0.001f)
 
-namespace ScriptCanvasTesting
-{
-    namespace TestAutoGenFunctions
-    {
-        REGISTER_SCRIPTCANVAS_FUNCTION(TestAutoGenFunctions);
-    }
-}
-
 namespace ScriptCanvasTests
 {
 
@@ -138,8 +130,9 @@ namespace ScriptCanvasTests
             TestNodeableObject::Reflect(m_behaviorContext);
             ScriptUnitTestEventHandler::Reflect(m_serializeContext);
             ScriptUnitTestEventHandler::Reflect(m_behaviorContext);
+            REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvasTesting::TestAutoGenFunctions::TestAutoGenFunctions);
             ScriptCanvas::AutoGenRegistry::ReflectFunction(
-                m_behaviorContext, "ScriptCanvasTesting_TestAutoGenFunctions_ScriptCanvasTestAutoGenFunctions");
+                m_behaviorContext, ScriptCanvasTesting::TestAutoGenFunctions::TestAutoGenFunctions::GetRegistryName());
         }
 
         static void TearDownTestCase()

--- a/Gems/ScriptCanvasTesting/Code/Source/Nodes/TestAutoGenFunctions.ScriptCanvasFunction.xml
+++ b/Gems/ScriptCanvasTesting/Code/Source/Nodes/TestAutoGenFunctions.ScriptCanvasFunction.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScriptCanvas>
     <Library Include="Source/Nodes/TestAutoGenFunctions.h"
-		Name="TestAutoGenFunctions"
 		Namespace="ScriptCanvasTesting::TestAutoGenFunctions"
         Category="Tests">
 		

--- a/Gems/ScriptCanvasTesting/Code/Source/Nodes/TestAutoGenFunctions.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/Nodes/TestAutoGenFunctions.cpp
@@ -12,8 +12,6 @@ namespace ScriptCanvasTesting
 {
     namespace TestAutoGenFunctions
     {
-        REGISTER_SCRIPTCANVAS_FUNCTION(TestAutoGenFunctions);
-
         float NoArgsReturn()
         {
             return 0.0f;

--- a/Gems/ScriptCanvasTesting/Code/Source/Nodes/TestAutoGenFunctions.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Nodes/TestAutoGenFunctions.h
@@ -11,7 +11,6 @@
 #include <AzCore/std/string/string.h>
 #include <AzCore/std/tuple.h>
 #include <ScriptCanvas/Data/NumericData.h>
-#include <Source/Nodes/TestAutoGenFunctions.generated.h>
 
 namespace ScriptCanvasTesting
 {

--- a/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingEditorModule.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingEditorModule.cpp
@@ -12,6 +12,7 @@
 #include <ScriptCanvasTestingSystemComponent.h>
 #include <Editor/Framework/ScriptCanvasTraceUtilities.h>
 #include <Source/Nodes/Nodeables/NodeableTestingLibrary.h>
+#include <Source/Nodes/TestAutoGenFunctions.h>
 
 namespace ScriptCanvasTesting
 {
@@ -26,6 +27,8 @@ namespace ScriptCanvasTesting
 
         ScriptCanvasTestingModule()
         {
+            REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvasTesting::TestAutoGenFunctions::TestAutoGenFunctions);
+
             m_descriptors.insert(m_descriptors.end(), {
                 ScriptCanvasTestingSystemComponent::CreateDescriptor(),
                 TraceMessageComponent::CreateDescriptor(),

--- a/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingEditorModule.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingEditorModule.cpp
@@ -12,7 +12,6 @@
 #include <ScriptCanvasTestingSystemComponent.h>
 #include <Editor/Framework/ScriptCanvasTraceUtilities.h>
 #include <Source/Nodes/Nodeables/NodeableTestingLibrary.h>
-#include <Source/Nodes/TestAutoGenFunctions.h>
 
 namespace ScriptCanvasTesting
 {
@@ -27,8 +26,6 @@ namespace ScriptCanvasTesting
 
         ScriptCanvasTestingModule()
         {
-            REGISTER_SCRIPTCANVAS_FUNCTION(ScriptCanvasTesting::TestAutoGenFunctions::TestAutoGenFunctions);
-
             m_descriptors.insert(m_descriptors.end(), {
                 ScriptCanvasTestingSystemComponent::CreateDescriptor(),
                 TraceMessageComponent::CreateDescriptor(),

--- a/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingSystemComponent.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingSystemComponent.cpp
@@ -15,6 +15,7 @@
 #include "Nodes/BehaviorContextObjectTestNode.h"
 
 #include <Source/Nodes/Nodeables/NodeableTestingLibrary.h>
+#include <Source/Nodes/TestAutoGenFunctions.h>
 #include <ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h>
 
 namespace ScriptCanvasTesting
@@ -42,7 +43,7 @@ namespace ScriptCanvasTesting
         ScriptCanvasTestingNodes::BehaviorContextObjectTest::Reflect(context);
         ScriptCanvasTesting::Reflect(context);
         // Reflect testing only autogen function
-        ScriptCanvas::AutoGenRegistry::ReflectFunction(context, "ScriptCanvasTesting_TestAutoGenFunctions_ScriptCanvasTestAutoGenFunctions");
+        ScriptCanvas::AutoGenRegistry::ReflectFunction(context, TestAutoGenFunctions::TestAutoGenFunctions::GetRegistryName());
     }
 
     void ScriptCanvasTestingSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)

--- a/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingSystemComponent.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/ScriptCanvasTestingSystemComponent.cpp
@@ -15,8 +15,9 @@
 #include "Nodes/BehaviorContextObjectTestNode.h"
 
 #include <Source/Nodes/Nodeables/NodeableTestingLibrary.h>
-#include <Source/Nodes/TestAutoGenFunctions.h>
-#include <ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.h>
+#include <TestAutoGenFunctionRegistry.generated.h>
+
+REGISTER_SCRIPTCANVAS_AUTOGEN(ScriptCanvasTestingEditorStatic);
 
 namespace ScriptCanvasTesting
 {
@@ -43,7 +44,8 @@ namespace ScriptCanvasTesting
         ScriptCanvasTestingNodes::BehaviorContextObjectTest::Reflect(context);
         ScriptCanvasTesting::Reflect(context);
         // Reflect testing only autogen function
-        ScriptCanvas::AutoGenRegistry::ReflectFunction(context, TestAutoGenFunctions::TestAutoGenFunctions::GetRegistryName());
+        ScriptCanvas::AutoGenRegistry::ReflectFunction(
+            context, ScriptCanvas::ScriptCanvasTestingEditorStaticFunctionRegistry::GetRegistryName());
     }
 
     void ScriptCanvasTestingSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)

--- a/cmake/AzAutoGen.py
+++ b/cmake/AzAutoGen.py
@@ -23,11 +23,21 @@ from xml.sax.saxutils import escape, unescape, quoteattr
 # Maximum number of errors before bailing on AutoGen
 MAX_ERRORS = 100
 errorCount = 0
-AUTOGEN_TARGET_NAME = ""
 
-def SanitizeAutoGenTargetName():
-    global AUTOGEN_TARGET_NAME
-    return AUTOGEN_TARGET_NAME.replace('.', '').replace('::', '')
+class AutoGenConfig:
+    def __init__(self, targetName, cacheDir, outputDir, projectDir, inputFiles, expansionRules, dryrun, verbose, pythonPaths):
+        self.targetName = targetName
+        self.cacheDir = cacheDir
+        self.outputDir = outputDir
+        self.projectDir = projectDir
+        self.inputFiles = inputFiles
+        self.expansionRules = expansionRules
+        self.dryrun = dryrun
+        self.verbose = verbose
+        self.pythonPaths = pythonPaths
+
+def SanitizeTargetName(targetName):
+    return targetName.replace('.', '').replace('::', '')
 
 def ParseInputFile(inputFilePath):
     result = []
@@ -93,8 +103,8 @@ def ComputeOutputPath(inputFiles, projectDir, outputDir):
     inputRelativePath = os.path.relpath(commonInputPath, commonPath) # Computes the relative path for the project source directory (Code/Framework/AzCore/AutoGen/)
     return os.path.join(outputDir, inputRelativePath) # Returns a suitable output directory (//depot/dev/Generated/Code/Framework/AzCore/AutoGen/)
 
-def ProcessTemplateConversion(dataInputSet, dataInputFiles, templateFile, outputFile, templateCache, dryrun, verbose):
-    if dryrun or not dataInputFiles:
+def ProcessTemplateConversion(autogenConfig, dataInputSet, dataInputFiles, templateFile, outputFile, templateCache):
+    if autogenConfig.dryrun or not dataInputFiles:
         return
     try:
         outputFile = os.path.abspath(outputFile)
@@ -170,7 +180,7 @@ def ProcessTemplateConversion(dataInputSet, dataInputFiles, templateFile, output
         templateJinja  = templateEnv.get_template(os.path.basename(templateFile))
         templateVars   = \
             { \
-                "autogenTargetName": SanitizeAutoGenTargetName(), \
+                "autogenTargetName": autogenConfig.targetName, \
                 "dataFiles"        : treeRoots, \
                 "dataFileNames"    : dataInputFiles, \
                 "templateName"     : templateFile, \
@@ -232,7 +242,7 @@ def ProcessTemplateConversion(dataInputSet, dataInputFiles, templateFile, output
             with open(outputFile, 'r+') as currentFile:
                 currentFileStringData = currentFile.read()
                 if currentFileStringData == compareFD.getvalue():
-                    if verbose == True:
+                    if autogenConfig.verbose == True:
                         print('Generated file %s is unchanged, skipping' % (outputFile))                    
                 else:
                     currentFile.truncate()
@@ -251,7 +261,7 @@ def ProcessTemplateConversion(dataInputSet, dataInputFiles, templateFile, output
         raise
     compareFD.close()
 
-def ProcessExpansionRule(sourceFiles, templateFiles, templateCache, outputDir, projectDir, expansionRule, dryrun, verbose, dataInputSet, outputFiles):
+def ProcessExpansionRule(autogenConfig, sourceFiles, templateFiles, templateCache, expansionRule, dataInputSet, outputFiles):
     try:
         # should be of the format inputFile(s),templateFile,outputFile, where inputFile and outputFile are subject to wildcarding and substitutions
         expansionRuleSet = expansionRule.split(",")
@@ -277,16 +287,16 @@ def ProcessExpansionRule(sourceFiles, templateFiles, templateCache, outputDir, p
         #       generate a single output file containing all matching data file's
         #    endif
         # endif
-        testSingle = os.path.join(projectDir, inputFiles)
+        testSingle = os.path.join(autogenConfig.projectDir, inputFiles)
         if os.path.isfile(testSingle):
             # If we specified an *explicit* file to be processed (no wildcards for the data input file foo.json not *.foo.json), this is the branch that handles this case
             # This is explicitly one-to-one mapping
             dataInputFiles = [os.path.abspath(testSingle)]
-            outputFileAbsolute = outputFile.replace("$path", ComputeOutputPath(dataInputFiles, projectDir, outputDir))
+            outputFileAbsolute = outputFile.replace("$path", ComputeOutputPath(dataInputFiles, autogenConfig.projectDir, autogenConfig.outputDir))
             outputFileAbsolute = outputFileAbsolute.replace("$fileprefix", os.path.splitext(os.path.basename(testSingle))[0].split(".")[0])
             outputFileAbsolute = outputFileAbsolute.replace("$file", os.path.splitext(os.path.basename(testSingle))[0])
             outputFileAbsolute = SanitizePath(outputFileAbsolute)
-            ProcessTemplateConversion(dataInputSet, dataInputFiles, templateFile, outputFileAbsolute, templateCache, dryrun, verbose)
+            ProcessTemplateConversion(autogenConfig, dataInputSet, dataInputFiles, templateFile, outputFileAbsolute, templateCache)
             outputFiles.append(outputFileAbsolute)
         else:
             # We've wildcarded the data input field, so we may have to handle one-to-one mapping of data files to output, or many-to-one mapping of data files to output
@@ -294,22 +304,22 @@ def ProcessExpansionRule(sourceFiles, templateFiles, templateCache, outputDir, p
                 # Due to the wildcards in the output file, we've determined we'll do a one-to-one mapping of data files to output
                 for filename in fnmatch.filter(sourceFiles, inputFiles):
                     dataInputFiles = [os.path.abspath(filename)]
-                    outputFileAbsolute = outputFile.replace("$path", ComputeOutputPath(dataInputFiles, projectDir, outputDir))
+                    outputFileAbsolute = outputFile.replace("$path", ComputeOutputPath(dataInputFiles, autogenConfig.projectDir, autogenConfig.outputDir))
                     outputFileAbsolute = outputFileAbsolute.replace("$fileprefix", os.path.splitext(os.path.basename(filename))[0].split(".")[0])
                     outputFileAbsolute = outputFileAbsolute.replace("$file", os.path.splitext(os.path.basename(filename))[0])
                     outputFileAbsolute = SanitizePath(outputFileAbsolute)
-                    ProcessTemplateConversion(dataInputSet, dataInputFiles, templateFile, outputFileAbsolute, templateCache, dryrun, verbose)
+                    ProcessTemplateConversion(autogenConfig, dataInputSet, dataInputFiles, templateFile, outputFileAbsolute, templateCache)
                     outputFiles.append(outputFileAbsolute)
             else:
                 # Process all matches in one batch
                 # Due to the lack of wildcards in the output file, we've determined we'll glob all matching input files into the template conversion 
                 dataInputFiles = [os.path.abspath(file) for file in fnmatch.filter(sourceFiles, inputFiles)]
                 if "$path" in outputFile:
-                    outputFileAbsolute = outputFile.replace("$path", ComputeOutputPath(dataInputFiles, projectDir, outputDir))
+                    outputFileAbsolute = outputFile.replace("$path", ComputeOutputPath(dataInputFiles, autogenConfig.projectDir, autogenConfig.outputDir))
                 else: # if no relative $path, put one batch file under outputDir
-                    outputFileAbsolute = os.path.join(outputDir, outputFile)
+                    outputFileAbsolute = os.path.join(autogenConfig.outputDir, outputFile)
                 outputFileAbsolute = SanitizePath(outputFileAbsolute)
-                ProcessTemplateConversion(dataInputSet, dataInputFiles, templateFile, outputFileAbsolute, templateCache, dryrun, verbose)
+                ProcessTemplateConversion(autogenConfig, dataInputSet, dataInputFiles, templateFile, outputFileAbsolute, templateCache)
                 outputFiles.append(outputFileAbsolute)
     except IOError as e:
         PrintError('%s : error I/O(%s) accessing %s : %s' % (expansionRule, e.errno, e.filename, e.strerror))
@@ -318,15 +328,14 @@ def ProcessExpansionRule(sourceFiles, templateFiles, templateCache, outputDir, p
         PrintUnhandledExcptionInfo()
         raise
 
-def ExecuteExpansionRules(cacheDir, outputDir, projectDir, inputFiles, expansionRules, dryrun, verbose, dataInputSet, outputFiles):
+def ExecuteExpansionRules(autogenConfig, dataInputSet, outputFiles):
     # Get Globals
-    global MAX_ERRORS
-    global errorCount
+    global MAX_ERRORS, errorCount
     currentPath = os.getcwd()
     startTime = time.time()
     # Ensure jinja2 template cache dir actually exists...
     try:
-        os.makedirs(cacheDir)
+        os.makedirs(autogenConfig.cacheDir)
     except OSError as e:
         if e.errno == errno.EEXIST:
             pass
@@ -334,15 +343,15 @@ def ExecuteExpansionRules(cacheDir, outputDir, projectDir, inputFiles, expansion
             raise
     sourceFiles = []
     templateFiles = []
-    for inputFile in inputFiles:
+    for inputFile in autogenConfig.inputFiles:
         if inputFile.endswith(".xml") or inputFile.endswith(".json"):
-            sourceFiles.append(os.path.join(projectDir, inputFile))
+            sourceFiles.append(os.path.join(autogenConfig.projectDir, inputFile))
         elif inputFile.endswith(".jinja"):
-            templateFiles.append(os.path.join(projectDir, inputFile))
-    templateCache = jinja2.FileSystemBytecodeCache(cacheDir)
-    for expansionRule in expansionRules:
-        ProcessExpansionRule(sourceFiles, templateFiles, templateCache, outputDir, projectDir, expansionRule, dryrun, verbose, dataInputSet, outputFiles)
-    if not dryrun:
+            templateFiles.append(os.path.join(autogenConfig.projectDir, inputFile))
+    templateCache = jinja2.FileSystemBytecodeCache(autogenConfig.cacheDir)
+    for expansionRule in autogenConfig.expansionRules:
+        ProcessExpansionRule(autogenConfig, sourceFiles, templateFiles, templateCache, expansionRule, dataInputSet, outputFiles)
+    if not autogenConfig.dryrun:
         elapsedTime = time.time() - startTime
         millis = int(round(elapsedTime * 10))
         m, s = divmod(elapsedTime, 60)
@@ -366,21 +375,18 @@ if __name__ == '__main__':
     parser.add_argument("-p", "--pythonPaths", action='append', nargs='+', default=[""], help="set of additional python paths to use for module imports")
     
     args = parser.parse_args()
-    AUTOGEN_TARGET_NAME = args.targetName
-    pythonPaths = args.pythonPaths
-    cacheDir  = args.cacheDir
-    outputDir = args.outputDir
-    projectDir = args.projectDir
-    inputFiles = ParseInputFile(args.inputFilePath.strip())
-    expansionRules = args.expansionRules.split(";")
-    dryrun = args.dryrun
-    verbose = args.verbose
-    cacheDir = os.path.abspath(SanitizePath(cacheDir))
-    outputDir = os.path.abspath(SanitizePath(outputDir))
-    projectDir = os.path.abspath(SanitizePath(projectDir))
+    autogenConfig = AutoGenConfig(SanitizeTargetName(args.targetName),
+                                  os.path.abspath(SanitizePath(args.cacheDir)),
+                                  os.path.abspath(SanitizePath(args.outputDir)),
+                                  os.path.abspath(SanitizePath(args.projectDir)),
+                                  ParseInputFile(args.inputFilePath.strip()),
+                                  args.expansionRules.split(";"),
+                                  args.dryrun,
+                                  args.verbose,
+                                  args.pythonPaths)
 
     # Import 3rd party modules
-    for pythonPath in pythonPaths:
+    for pythonPath in autogenConfig.pythonPaths:
         sys.path.append(pythonPath)
     import jinja2
     #from lxml import etree
@@ -389,8 +395,8 @@ if __name__ == '__main__':
 
     dataInputSet = {}
     outputFiles  = []
-    autoGenResult = ExecuteExpansionRules(cacheDir, outputDir, projectDir, inputFiles, expansionRules, dryrun, verbose, dataInputSet, outputFiles)
-    if dryrun:
+    autoGenResult = ExecuteExpansionRules(autogenConfig, dataInputSet, outputFiles)
+    if autogenConfig.dryrun:
         print("%s" % ';'.join(outputFiles))
     if autoGenResult:
         sys.exit(0)

--- a/cmake/AzAutoGen.py
+++ b/cmake/AzAutoGen.py
@@ -27,7 +27,7 @@ AZCG_TARGET_NAME = ""
 
 def SanitizeAZCGTargetName():
     global AZCG_TARGET_NAME
-    return AZCG_TARGET_NAME.replace('.', '').replace('::', '.')
+    return AZCG_TARGET_NAME.replace('.', '').replace('::', '')
 
 def ParseInputFile(inputFilePath):
     result = []

--- a/cmake/AzAutoGen.py
+++ b/cmake/AzAutoGen.py
@@ -23,11 +23,11 @@ from xml.sax.saxutils import escape, unescape, quoteattr
 # Maximum number of errors before bailing on AutoGen
 MAX_ERRORS = 100
 errorCount = 0
-AZCG_TARGET_NAME = ""
+AUTOGEN_TARGET_NAME = ""
 
-def SanitizeAZCGTargetName():
-    global AZCG_TARGET_NAME
-    return AZCG_TARGET_NAME.replace('.', '').replace('::', '')
+def SanitizeAutoGenTargetName():
+    global AUTOGEN_TARGET_NAME
+    return AUTOGEN_TARGET_NAME.replace('.', '').replace('::', '')
 
 def ParseInputFile(inputFilePath):
     result = []
@@ -170,12 +170,12 @@ def ProcessTemplateConversion(dataInputSet, dataInputFiles, templateFile, output
         templateJinja  = templateEnv.get_template(os.path.basename(templateFile))
         templateVars   = \
             { \
-                "azcgTargetName": SanitizeAZCGTargetName(), \
-                "dataFiles"     : treeRoots, \
-                "dataFileNames" : dataInputFiles, \
-                "templateName"  : templateFile, \
-                "outputFile"    : outputFile, \
-                "filename"      : os.path.splitext(os.path.basename(outputFile))[0], \
+                "autogenTargetName": SanitizeAutoGenTargetName(), \
+                "dataFiles"        : treeRoots, \
+                "dataFileNames"    : dataInputFiles, \
+                "templateName"     : templateFile, \
+                "outputFile"       : outputFile, \
+                "filename"         : os.path.splitext(os.path.basename(outputFile))[0], \
             }
         try:
             outputExtension = os.path.splitext(outputFile)[1]
@@ -355,7 +355,7 @@ def ExecuteExpansionRules(cacheDir, outputDir, projectDir, inputFiles, expansion
 if __name__ == '__main__':
     # setup our command syntax
     parser = argparse.ArgumentParser()
-    parser.add_argument("targetName", help="azcg target name")
+    parser.add_argument("targetName", help="AzAutoGen build target name")
     parser.add_argument("cacheDir", help="location to store jinja template cache files")
     parser.add_argument("outputDir", help="location to output generated files")
     parser.add_argument("projectDir", help="location to build directory against")
@@ -366,7 +366,7 @@ if __name__ == '__main__':
     parser.add_argument("-p", "--pythonPaths", action='append', nargs='+', default=[""], help="set of additional python paths to use for module imports")
     
     args = parser.parse_args()
-    AZCG_TARGET_NAME = args.targetName
+    AUTOGEN_TARGET_NAME = args.targetName
     pythonPaths = args.pythonPaths
     cacheDir  = args.cacheDir
     outputDir = args.outputDir

--- a/cmake/LyAutoGen.cmake
+++ b/cmake/LyAutoGen.cmake
@@ -33,7 +33,7 @@ function(ly_add_autogen)
             target_include_directories(${ly_add_autogen_NAME} PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/Azcg/Generated")
         endif()
         execute_process(
-            COMMAND ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py" "${CMAKE_BINARY_DIR}/Azcg/TemplateCache/" "${CMAKE_CURRENT_BINARY_DIR}/Azcg/Generated/" "${CMAKE_CURRENT_SOURCE_DIR}" "${input_files_path}" "${ly_add_autogen_AUTOGEN_RULES}" "-n"
+            COMMAND ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py" "${ly_add_autogen_NAME}" "${CMAKE_BINARY_DIR}/Azcg/TemplateCache/" "${CMAKE_CURRENT_BINARY_DIR}/Azcg/Generated/" "${CMAKE_CURRENT_SOURCE_DIR}" "${input_files_path}" "${ly_add_autogen_AUTOGEN_RULES}" "-n"
             OUTPUT_VARIABLE AUTOGEN_OUTPUTS
         )
         string(STRIP "${AUTOGEN_OUTPUTS}" AUTOGEN_OUTPUTS)
@@ -42,7 +42,7 @@ function(ly_add_autogen)
         add_custom_command(
             OUTPUT ${AUTOGEN_OUTPUTS}
             DEPENDS ${AZCG_DEPENDENCIES}
-            COMMAND ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py" "${CMAKE_BINARY_DIR}/Azcg/TemplateCache/" "${CMAKE_CURRENT_BINARY_DIR}/Azcg/Generated/" "${CMAKE_CURRENT_SOURCE_DIR}" "${input_files_path}" "${ly_add_autogen_AUTOGEN_RULES}"
+            COMMAND ${LY_PYTHON_CMD} "${LY_ROOT_FOLDER}/cmake/AzAutoGen.py" "${ly_add_autogen_NAME}" "${CMAKE_BINARY_DIR}/Azcg/TemplateCache/" "${CMAKE_CURRENT_BINARY_DIR}/Azcg/Generated/" "${CMAKE_CURRENT_SOURCE_DIR}" "${input_files_path}" "${ly_add_autogen_AUTOGEN_RULES}"
             COMMENT "Running AutoGen for ${ly_add_autogen_NAME}"
             VERBATIM
         )


### PR DESCRIPTION
## Details
1. Improve the function registration macros which can be used directly anywhere (avoid have to use with namespace)
2. Previous plan is to let user register functions in function cpp file, but it doesn't really work. (Function is not explicitly used in any code, compiler is not guaranteed to include function symbols) **Current working solution**: user has to register functions in gem module file, gem system component file, or any class used directly/indirectly in gem module or system component.

**UPDATE**
Combined autogen files into single one, which expects to have only one function registry file generated per build target if using autogen

For example,
REGISTER_SCRIPTCANVAS_AUTOGEN(ScriptCanvasStatic), REGISTER_SCRIPTCANVAS_AUTOGEN(ScriptCanvasPhysicsStatic) and REGISTER_SCRIPTCANVAS_AUTOGEN(ScriptCanvasTestingEditorStatic)
Which takes a sanitized build target name (we can easily integrate this with gem&project template later to make onboard process easier)

Extra changes&fix:
1. Pass build target name into AutoGen jinja environment variable so we can use it in jinja template
2. For many to one batch autogen use case, previously the file is not generated under Azcg\Generated folder.

Signed-off-by: onecent1101 <liug@amazon.com>