### PR TITLE
Fix asset Id of in-memory spawnable

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Spawnable/InMemorySpawnableAssetContainer.cpp
@@ -91,7 +91,7 @@ namespace AzFramework
 
             AZ::Data::AssetCatalogRequestBus::Broadcast(
                 &AZ::Data::AssetCatalogRequestBus::Events::RegisterAsset, assetInfo.m_assetId, assetInfo);
-            spawnableAssetData.m_assets.emplace_back(assetData, AZ::Data::AssetLoadBehavior::Default);
+            spawnableAssetData.m_assets.emplace_back(assetInfo.m_assetId, assetData, AZ::Data::AssetLoadBehavior::Default);
 
             // Ensure the product asset is registered with the AssetManager
             // Hold on to the returned asset to keep ref count alive until we assign it the latest data


### PR DESCRIPTION
Fix asset Id not being set for in-memory spawnables.
Prevent dependent assets from loading too early.

Signed-off-by: abrmich <abrmich@amazon.com>