### PR TITLE
Fix automated tests broken due to selective deserialization branch

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded.py
@@ -88,7 +88,6 @@ def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
         # 4. Set Quality Level property to Low
         diffuse_global_illumination_component.set_component_property_value(
             AtomComponentProperties.diffuse_global_illumination('Quality Level'), GLOBAL_ILLUMINATION_QUALITY['Low'])
-
         quality = diffuse_global_illumination_component.get_component_property_value(
             AtomComponentProperties.diffuse_global_illumination('Quality Level'))
         Report.result(Tests.diffuse_global_illumination_quality, quality == GLOBAL_ILLUMINATION_QUALITY['Low'])

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded.py
@@ -66,6 +66,7 @@ def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
         # 1. Add Diffuse Global Illumination level component to the level entity.
         diffuse_global_illumination_component = EditorLevelEntity.add_component(
             AtomComponentProperties.diffuse_global_illumination())
+        general.idle_wait_frames(1)
         Report.critical_result(
             Tests.diffuse_global_illumination_component,
             EditorLevelEntity.has_component(AtomComponentProperties.diffuse_global_illumination()))
@@ -87,6 +88,7 @@ def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
         # 4. Set Quality Level property to Low
         diffuse_global_illumination_component.set_component_property_value(
             AtomComponentProperties.diffuse_global_illumination('Quality Level'), GLOBAL_ILLUMINATION_QUALITY['Low'])
+
         quality = diffuse_global_illumination_component.get_component_property_value(
             AtomComponentProperties.diffuse_global_illumination('Quality Level'))
         Report.result(Tests.diffuse_global_illumination_quality, quality == GLOBAL_ILLUMINATION_QUALITY['Low'])

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DiffuseGlobalIlluminationAdded.py
@@ -53,6 +53,7 @@ def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
     import azlmbr.legacy.general as general
 
     from editor_python_test_tools.editor_entity_utils import EditorLevelEntity
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
     from Atom.atom_utils.atom_constants import AtomComponentProperties, GLOBAL_ILLUMINATION_QUALITY
 
@@ -66,7 +67,7 @@ def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
         # 1. Add Diffuse Global Illumination level component to the level entity.
         diffuse_global_illumination_component = EditorLevelEntity.add_component(
             AtomComponentProperties.diffuse_global_illumination())
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.critical_result(
             Tests.diffuse_global_illumination_component,
             EditorLevelEntity.has_component(AtomComponentProperties.diffuse_global_illumination()))
@@ -74,14 +75,14 @@ def AtomEditorComponentsLevel_DiffuseGlobalIllumination_AddedToEntity():
         # 2. UNDO the level component addition.
         # -> UNDO component addition.
         general.undo()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.result(Tests.creation_undo,
                       not EditorLevelEntity.has_component(AtomComponentProperties.diffuse_global_illumination()))
 
         # 3. REDO the level component addition.
         # -> REDO component addition.
         general.redo()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.result(Tests.creation_redo,
                       EditorLevelEntity.has_component(AtomComponentProperties.diffuse_global_illumination()))
 

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
@@ -134,6 +134,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
         # Test steps begin.
         # 1. Add Display Mapper level component to the level entity.
         display_mapper_component = EditorLevelEntity.add_component(AtomComponentProperties.display_mapper())
+        general.idle_wait_frames(1)
         Report.critical_result(
             Tests.display_mapper_component,
             EditorLevelEntity.has_component(AtomComponentProperties.display_mapper()))

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
@@ -122,7 +122,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
     from azlmbr.math import Math_IsClose
     from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorLevelEntity
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
     from Atom.atom_utils.atom_constants import AtomComponentProperties, DISPLAY_MAPPER_PRESET, DISPLAY_MAPPER_OPERATION_TYPE
 
@@ -135,7 +135,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
         # Test steps begin.
         # 1. Add Display Mapper level component to the level entity.
         display_mapper_component = EditorLevelEntity.add_component(AtomComponentProperties.display_mapper())
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
         Report.critical_result(
             Tests.display_mapper_component,
             EditorLevelEntity.has_component(AtomComponentProperties.display_mapper()))
@@ -143,13 +143,13 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
         # 2. UNDO the level component addition.
         # -> UNDO component addition.
         general.undo()
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
         Report.result(Tests.creation_undo, not EditorLevelEntity.has_component(AtomComponentProperties.display_mapper()))
 
         # 3. REDO the level component addition.
         # -> REDO component addition.
         general.redo()
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
         Report.result(Tests.creation_redo, EditorLevelEntity.has_component(AtomComponentProperties.display_mapper()))
 
         # 4. Set LDR color Grading LUT asset.

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponentsLevel_DisplayMapperAdded.py
@@ -122,6 +122,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
     from azlmbr.math import Math_IsClose
     from editor_python_test_tools.asset_utils import Asset
     from editor_python_test_tools.editor_entity_utils import EditorLevelEntity
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
     from Atom.atom_utils.atom_constants import AtomComponentProperties, DISPLAY_MAPPER_PRESET, DISPLAY_MAPPER_OPERATION_TYPE
 
@@ -134,7 +135,7 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
         # Test steps begin.
         # 1. Add Display Mapper level component to the level entity.
         display_mapper_component = EditorLevelEntity.add_component(AtomComponentProperties.display_mapper())
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.critical_result(
             Tests.display_mapper_component,
             EditorLevelEntity.has_component(AtomComponentProperties.display_mapper()))
@@ -142,13 +143,13 @@ def AtomEditorComponentsLevel_DisplayMapper_AddedToEntity():
         # 2. UNDO the level component addition.
         # -> UNDO component addition.
         general.undo()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.result(Tests.creation_undo, not EditorLevelEntity.has_component(AtomComponentProperties.display_mapper()))
 
         # 3. REDO the level component addition.
         # -> REDO component addition.
         general.redo()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.result(Tests.creation_redo, EditorLevelEntity.has_component(AtomComponentProperties.display_mapper()))
 
         # 4. Set LDR color Grading LUT asset.

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
@@ -865,6 +865,7 @@ def AtomEditorComponents_Bloom_AddedToEntity():
 
         # 43. Delete Bloom entity.
         bloom_entity.delete()
+        general.idle_wait_frames(1)
         Report.result(Tests.entity_deleted, not bloom_entity.exists())
 
         # 44. UNDO deletion.

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_BloomAdded.py
@@ -296,6 +296,7 @@ def AtomEditorComponents_Bloom_AddedToEntity():
     import azlmbr.math as math
 
     from editor_python_test_tools.editor_entity_utils import EditorEntity
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report, Tracer, TestHelper
     from Atom.atom_utils.atom_constants import AtomComponentProperties
 
@@ -865,17 +866,17 @@ def AtomEditorComponents_Bloom_AddedToEntity():
 
         # 43. Delete Bloom entity.
         bloom_entity.delete()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.result(Tests.entity_deleted, not bloom_entity.exists())
 
         # 44. UNDO deletion.
         general.undo()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.result(Tests.deletion_undo, bloom_entity.exists())
 
         # 45. REDO deletion.
         general.redo()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         Report.result(Tests.deletion_redo, not bloom_entity.exists())
 
         # 46. Look for errors and asserts.

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
@@ -247,7 +247,6 @@ def AtomEditorComponents_Material_AddedToEntity():
 
         # 15. Enable the use of LOD materials
         material_component.set_component_property_value(AtomComponentProperties.material('Enable LOD Materials'), True)
-        general.idle_wait_frames(1)
         Report.result(
             Tests.enable_lod_materials,
             material_component.get_component_property_value(
@@ -256,7 +255,7 @@ def AtomEditorComponents_Material_AddedToEntity():
         # 16. Wait for LOD Materials to indicate count 5 terminate early if container fails to reflect correct count
         Report.critical_result(Tests.lod_material_count, TestHelper.wait_for_condition(
             lambda: (material_component.get_container_count(
-                AtomComponentProperties.material('LOD Materials')) == 5), timeout_in_seconds=5))
+                AtomComponentProperties.material('LOD Materials')) == 5), timeout_in_seconds=10))
 
         # 17. Get the slot zero list from LOD Material
         item = material_component.get_container_item(

--- a/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
+++ b/AutomatedTesting/Gem/PythonTests/Atom/tests/hydra_AtomEditorComponents_MaterialAdded.py
@@ -255,7 +255,7 @@ def AtomEditorComponents_Material_AddedToEntity():
         # 16. Wait for LOD Materials to indicate count 5 terminate early if container fails to reflect correct count
         Report.critical_result(Tests.lod_material_count, TestHelper.wait_for_condition(
             lambda: (material_component.get_container_count(
-                AtomComponentProperties.material('LOD Materials')) == 5), timeout_in_seconds=10))
+                AtomComponentProperties.material('LOD Materials')) == 5), timeout_in_seconds=5))
 
         # 17. Get the slot zero list from LOD Material
         item = material_component.get_container_item(

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
@@ -20,6 +20,7 @@ import azlmbr.legacy.general as general
 
 # Helper file Imports
 from editor_python_test_tools.utils import Report
+from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
 
 
 class EditorEntityType(Enum):
@@ -243,7 +244,7 @@ class EditorComponent:
         assert (
             outcome.IsSuccess()
         ), f"Failure: Could not set value to '{self.get_component_name()}' : '{component_property_path}'"
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         self.get_property_tree(True)
 
     def is_enabled(self):
@@ -446,7 +447,7 @@ class EditorEntity:
         :return: Component object of newly added component.
         """
         component = self.add_components([component_name])[0]
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         return component
 
     def add_components(self, component_names: list) -> List[EditorComponent]:
@@ -578,7 +579,7 @@ class EditorEntity:
         :return: None
         """
         editor.ToolsApplicationRequestBus(bus.Broadcast, "DeleteEntityById", self.id)
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
 
     def set_visibility_state(self, is_visible: bool) -> None:
         """

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
@@ -243,6 +243,8 @@ class EditorComponent:
         assert (
             outcome.IsSuccess()
         ), f"Failure: Could not set value to '{self.get_component_name()}' : '{component_property_path}'"
+        general.idle_wait_frames(1)
+        self.get_property_tree(True)
 
     def is_enabled(self):
         """
@@ -444,6 +446,7 @@ class EditorEntity:
         :return: Component object of newly added component.
         """
         component = self.add_components([component_name])[0]
+        general.idle_wait_frames(1)
         return component
 
     def add_components(self, component_names: list) -> List[EditorComponent]:
@@ -575,6 +578,7 @@ class EditorEntity:
         :return: None
         """
         editor.ToolsApplicationRequestBus(bus.Broadcast, "DeleteEntityById", self.id)
+        general.idle_wait_frames(1)
 
     def set_visibility_state(self, is_visible: bool) -> None:
         """

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
@@ -20,7 +20,6 @@ import azlmbr.legacy.general as general
 
 # Helper file Imports
 from editor_python_test_tools.utils import Report
-from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
 
 
 class EditorEntityType(Enum):
@@ -244,7 +243,7 @@ class EditorComponent:
         assert (
             outcome.IsSuccess()
         ), f"Failure: Could not set value to '{self.get_component_name()}' : '{component_property_path}'"
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
         self.get_property_tree(True)
 
     def is_enabled(self):
@@ -447,7 +446,7 @@ class EditorEntity:
         :return: Component object of newly added component.
         """
         component = self.add_components([component_name])[0]
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
         return component
 
     def add_components(self, component_names: list) -> List[EditorComponent]:
@@ -579,7 +578,7 @@ class EditorEntity:
         :return: None
         """
         editor.ToolsApplicationRequestBus(bus.Broadcast, "DeleteEntityById", self.id)
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
 
     def set_visibility_state(self, is_visible: bool) -> None:
         """
@@ -775,3 +774,5 @@ class EditorLevelEntity:
         """
         type_ids = EditorComponent.get_type_ids([component_name], EditorEntityType.LEVEL)
         return editor.EditorLevelComponentAPIBus(bus.Broadcast, "CountComponentsOfType", type_ids[0])
+
+import editor_python_test_tools.prefab_utils as PrefabUtils

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/hydra_editor_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/hydra_editor_utils.py
@@ -316,6 +316,8 @@ class Entity:
 
         editor.EditorComponentAPIBus(bus.Broadcast, "SetComponentProperty", component, path, value)
 
+        general.idle_wait_frames(1)
+
         new_value = get_component_property_value(self.components[component_index], path)
 
         if new_value is not None:

--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/hydra_editor_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/hydra_editor_utils.py
@@ -316,8 +316,6 @@ class Entity:
 
         editor.EditorComponentAPIBus(bus.Broadcast, "SetComponentProperty", component, path, value)
 
-        general.idle_wait_frames(1)
-
         new_value = get_component_property_value(self.components[component_index], path)
 
         if new_value is not None:

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/Physics_UndoRedoWorksOnEntityWithPhysComponents.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/Physics_UndoRedoWorksOnEntityWithPhysComponents.py
@@ -44,6 +44,7 @@ def Physics_UndoRedoWorksOnEntityWithPhysComponents():
     """
     import os
     import sys
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Tracer
@@ -66,19 +67,19 @@ def Physics_UndoRedoWorksOnEntityWithPhysComponents():
         # 3) Delete entity
         general.select_objects([entity_name])
         general.delete_selected()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.entity_deleted, not entity_id.IsValid())
 
         # 4) Undo deletion
         general.undo()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.deletion_undone, entity_id.IsValid())
 
         # 5) Redo deletion
         general.redo()
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.deletion_redone, not entity_id.IsValid())
 

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/Physics_UndoRedoWorksOnEntityWithPhysComponents.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/Physics_UndoRedoWorksOnEntityWithPhysComponents.py
@@ -66,6 +66,7 @@ def Physics_UndoRedoWorksOnEntityWithPhysComponents():
         # 3) Delete entity
         general.select_objects([entity_name])
         general.delete_selected()
+        general.idle_wait_frames(1)
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.entity_deleted, not entity_id.IsValid())
 

--- a/AutomatedTesting/Gem/PythonTests/Physics/tests/Physics_UndoRedoWorksOnEntityWithPhysComponents.py
+++ b/AutomatedTesting/Gem/PythonTests/Physics/tests/Physics_UndoRedoWorksOnEntityWithPhysComponents.py
@@ -44,7 +44,8 @@ def Physics_UndoRedoWorksOnEntityWithPhysComponents():
     """
     import os
     import sys
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Tracer
@@ -67,19 +68,19 @@ def Physics_UndoRedoWorksOnEntityWithPhysComponents():
         # 3) Delete entity
         general.select_objects([entity_name])
         general.delete_selected()
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.entity_deleted, not entity_id.IsValid())
 
         # 4) Undo deletion
         general.undo()
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.deletion_undone, entity_id.IsValid())
 
         # 5) Redo deletion
         general.redo()
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
         entity_id = general.find_editor_entity(entity_name)
         Report.result(Tests.deletion_redone, not entity_id.IsValid())
 

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
@@ -48,6 +48,7 @@ def Terrain_SupportsPhysics():
     :return: None
     """
 
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Report, Tracer
     import editor_python_test_tools.hydra_editor_utils as hydra
@@ -118,7 +119,7 @@ def Terrain_SupportsPhysics():
 
         # 9) Disable and Enable the Terrain Gradient List so that it is recognised
         editor.EditorComponentAPIBus(bus.Broadcast, 'EnableComponents', [terrain_spawner_entity.components[2]])
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
 
         general.enter_game_mode()
 

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
@@ -48,7 +48,7 @@ def Terrain_SupportsPhysics():
     :return: None
     """
 
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Report, Tracer
     import editor_python_test_tools.hydra_editor_utils as hydra
@@ -119,7 +119,7 @@ def Terrain_SupportsPhysics():
 
         # 9) Disable and Enable the Terrain Gradient List so that it is recognised
         editor.EditorComponentAPIBus(bus.Broadcast, 'EnableComponents', [terrain_spawner_entity.components[2]])
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
 
         general.enter_game_mode()
 

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_SupportsPhysics.py
@@ -118,6 +118,7 @@ def Terrain_SupportsPhysics():
 
         # 9) Disable and Enable the Terrain Gradient List so that it is recognised
         editor.EditorComponentAPIBus(bus.Broadcast, 'EnableComponents', [terrain_spawner_entity.components[2]])
+        general.idle_wait_frames(1)
 
         general.enter_game_mode()
 

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_World_ConfigurationWorks.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_World_ConfigurationWorks.py
@@ -117,6 +117,7 @@ def Terrain_World_ConfigurationWorks():
         height_provider_entity.get_set_test(2, "Configuration|Frequency", frequency)
         frequencyVal = hydra.get_component_property_value(height_provider_entity.components[2], "Configuration|Frequency")
         Report.result(Tests.frequency_changed, math.isclose(frequency, frequencyVal, abs_tol = 0.00001))
+        general.idle_wait_frames(1)
 
         # 9) Set the Gradient List to height_provider_entity
         propertyTree = hydra.get_property_tree(terrain_spawner_entity.components[2])

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_World_ConfigurationWorks.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_World_ConfigurationWorks.py
@@ -48,7 +48,7 @@ def Terrain_World_ConfigurationWorks():
      13) Check height value is the expected one when query resolution is changed
     """
 
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Report, Tracer
     import editor_python_test_tools.hydra_editor_utils as hydra
@@ -118,7 +118,7 @@ def Terrain_World_ConfigurationWorks():
         height_provider_entity.get_set_test(2, "Configuration|Frequency", frequency)
         frequencyVal = hydra.get_component_property_value(height_provider_entity.components[2], "Configuration|Frequency")
         Report.result(Tests.frequency_changed, math.isclose(frequency, frequencyVal, abs_tol = 0.00001))
-        WaitForPrefabPropagation()
+        PrefabUtils.wait_for_propagation()
 
         # 9) Set the Gradient List to height_provider_entity
         propertyTree = hydra.get_property_tree(terrain_spawner_entity.components[2])

--- a/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_World_ConfigurationWorks.py
+++ b/AutomatedTesting/Gem/PythonTests/Terrain/EditorScripts/Terrain_World_ConfigurationWorks.py
@@ -48,6 +48,7 @@ def Terrain_World_ConfigurationWorks():
      13) Check height value is the expected one when query resolution is changed
     """
 
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import TestHelper as helper
     from editor_python_test_tools.utils import Report, Tracer
     import editor_python_test_tools.hydra_editor_utils as hydra
@@ -117,7 +118,7 @@ def Terrain_World_ConfigurationWorks():
         height_provider_entity.get_set_test(2, "Configuration|Frequency", frequency)
         frequencyVal = hydra.get_component_property_value(height_provider_entity.components[2], "Configuration|Frequency")
         Report.result(Tests.frequency_changed, math.isclose(frequency, frequencyVal, abs_tol = 0.00001))
-        general.idle_wait_frames(1)
+        WaitForPrefabPropagation()
 
         # 9) Set the Gradient List to height_provider_entity
         propertyTree = hydra.get_property_tree(terrain_spawner_entity.components[2])

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
@@ -139,9 +139,7 @@ def BasicEditorWorkflows_LevelEntityComponentCRUD():
         # Update the component
         dimensions_to_set = math.Vector3(16.0, 16.0, 16.0)
         child_entity.get_set_test(0, "Box Shape|Box Configuration|Dimensions", dimensions_to_set)
-        box_shape_dimensions = hydra.get_component_property_value(child_entity.components[0],
-                                                                  "Box Shape|Box Configuration|Dimensions")
-        Report.result(Tests.component_updated, box_shape_dimensions == dimensions_to_set)
+
 
         # Remove the component
         child_entity.remove_component("Box Shape")

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/BasicEditorWorkflows_LevelEntityComponentCRUD.py
@@ -139,6 +139,9 @@ def BasicEditorWorkflows_LevelEntityComponentCRUD():
         # Update the component
         dimensions_to_set = math.Vector3(16.0, 16.0, 16.0)
         child_entity.get_set_test(0, "Box Shape|Box Configuration|Dimensions", dimensions_to_set)
+        box_shape_dimensions = hydra.get_component_property_value(child_entity.components[0],
+                                                                  "Box Shape|Box Configuration|Dimensions")
+        Report.result(Tests.component_updated, box_shape_dimensions == dimensions_to_set)
 
 
         # Remove the component

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshBlocker_InstancesBlockedByMesh.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshBlocker_InstancesBlockedByMesh.py
@@ -77,6 +77,7 @@ def MeshBlocker_InstancesBlockedByMesh():
         bus.Broadcast, "GetAssetIdByPath", os.path.join("objects", "_primitives", "_box_1x1.azmodel"), math.Uuid(),
         False)
     blocker_entity.get_set_test(1, "Controller|Configuration|Mesh Asset", cubeId)
+    general.idle_wait_frames(1)
     components.TransformBus(bus.Event, "SetLocalUniformScale", blocker_entity.id, 2.0)
 
     # Verify spawned instance counts are accurate after addition of Blocker Entity

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshBlocker_InstancesBlockedByMesh.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshBlocker_InstancesBlockedByMesh.py
@@ -46,6 +46,7 @@ def MeshBlocker_InstancesBlockedByMesh():
 
     import editor_python_test_tools.hydra_editor_utils as hydra
     from largeworlds.large_worlds_utils import editor_dynveg_test_helper as dynveg
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
 
@@ -77,7 +78,7 @@ def MeshBlocker_InstancesBlockedByMesh():
         bus.Broadcast, "GetAssetIdByPath", os.path.join("objects", "_primitives", "_box_1x1.azmodel"), math.Uuid(),
         False)
     blocker_entity.get_set_test(1, "Controller|Configuration|Mesh Asset", cubeId)
-    general.idle_wait_frames(1)
+    WaitForPrefabPropagation()
     components.TransformBus(bus.Event, "SetLocalUniformScale", blocker_entity.id, 2.0)
 
     # Verify spawned instance counts are accurate after addition of Blocker Entity

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshBlocker_InstancesBlockedByMesh.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshBlocker_InstancesBlockedByMesh.py
@@ -46,7 +46,7 @@ def MeshBlocker_InstancesBlockedByMesh():
 
     import editor_python_test_tools.hydra_editor_utils as hydra
     from largeworlds.large_worlds_utils import editor_dynveg_test_helper as dynveg
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
 
@@ -78,7 +78,7 @@ def MeshBlocker_InstancesBlockedByMesh():
         bus.Broadcast, "GetAssetIdByPath", os.path.join("objects", "_primitives", "_box_1x1.azmodel"), math.Uuid(),
         False)
     blocker_entity.get_set_test(1, "Controller|Configuration|Mesh Asset", cubeId)
-    WaitForPrefabPropagation()
+    PrefabUtils.wait_for_propagation()
     components.TransformBus(bus.Event, "SetLocalUniformScale", blocker_entity.id, 2.0)
 
     # Verify spawned instance counts are accurate after addition of Blocker Entity

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully.py
@@ -43,7 +43,7 @@ def MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully():
     import azlmbr.surface_data as surface_data
 
     import editor_python_test_tools.hydra_editor_utils as hydra
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
 
@@ -59,7 +59,7 @@ def MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully():
     # 3) Add/ remove Surface Tags
     tag = surface_data.SurfaceTag()
     tag.SetTag("water")
-    WaitForPrefabPropagation()
+    PrefabUtils.wait_for_propagation()
     pte = hydra.get_property_tree(entity.components[0])
     path = "Configuration|Generated Tags"
     pte.add_container_item(path, 0, tag)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully.py
@@ -43,6 +43,7 @@ def MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully():
     import azlmbr.surface_data as surface_data
 
     import editor_python_test_tools.hydra_editor_utils as hydra
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report
     from editor_python_test_tools.utils import TestHelper as helper
 
@@ -58,7 +59,7 @@ def MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully():
     # 3) Add/ remove Surface Tags
     tag = surface_data.SurfaceTag()
     tag.SetTag("water")
-    azlmbr.legacy.general.idle_wait_frames(1)
+    WaitForPrefabPropagation()
     pte = hydra.get_property_tree(entity.components[0])
     path = "Configuration|Generated Tags"
     pte.add_container_item(path, 0, tag)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/EditorScripts/MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully.py
@@ -58,6 +58,7 @@ def MeshSurfaceTagEmitter_SurfaceTagsAddRemoveSuccessfully():
     # 3) Add/ remove Surface Tags
     tag = surface_data.SurfaceTag()
     tag.SetTag("water")
+    azlmbr.legacy.general.idle_wait_frames(1)
     pte = hydra.get_property_tree(entity.components[0])
     path = "Configuration|Generated Tags"
     pte.add_container_item(path, 0, tag)

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/dyn_veg/TestSuite_Main.py
@@ -37,11 +37,11 @@ class TestAutomation(EditorTestSuite):
     class test_AssetWeightSelector_InstancesExpressBasedOnWeight(EditorSharedTest):
         from .EditorScripts import AssetWeightSelector_InstancesExpressBasedOnWeight as test_module
 
-    @pytest.mark.xfail(reason="https://github.com/o3de/o3de/issues/4155")
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/4155")
     class test_DistanceBetweenFilter_InstancesPlantAtSpecifiedRadius(EditorSharedTest):
         from .EditorScripts import DistanceBetweenFilter_InstancesPlantAtSpecifiedRadius as test_module
 
-    @pytest.mark.xfail(reason="https://github.com/o3de/o3de/issues/4155")
+    @pytest.mark.skip(reason="https://github.com/o3de/o3de/issues/4155")
     class test_DistanceBetweenFilterOverrides_InstancesPlantAtSpecifiedRadius(EditorSharedTest):
         from .EditorScripts import DistanceBetweenFilterOverrides_InstancesPlantAtSpecifiedRadius as test_module
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/GradientMixer_NodeConstruction.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/GradientMixer_NodeConstruction.py
@@ -75,7 +75,7 @@ def GradientMixer_NodeConstruction():
     import azlmbr.paths
 
     import editor_python_test_tools.hydra_editor_utils as hydra
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import Report
 
     editorId = azlmbr.globals.property.LANDSCAPE_CANVAS_EDITOR_ID
@@ -142,7 +142,7 @@ def GradientMixer_NodeConstruction():
     gradientMixerNode = landscapecanvas.LandscapeCanvasNodeFactoryRequestBus(bus.Broadcast, 'CreateNodeForTypeName', newGraph,
                                                                              'GradientMixerNode')
     graph.GraphControllerRequestBus(bus.Event, 'AddNode', newGraphId, gradientMixerNode, math.Vector2(positionX, positionY))
-    WaitForPrefabPropagation()
+    PrefabUtils.wait_for_propagation()
     gradientMixerEntityId = newEntityId
 
     boundsSlotId = graph.GraphModelSlotId('Bounds')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/GradientMixer_NodeConstruction.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/GradientMixer_NodeConstruction.py
@@ -141,6 +141,7 @@ def GradientMixer_NodeConstruction():
     gradientMixerNode = landscapecanvas.LandscapeCanvasNodeFactoryRequestBus(bus.Broadcast, 'CreateNodeForTypeName', newGraph,
                                                                              'GradientMixerNode')
     graph.GraphControllerRequestBus(bus.Event, 'AddNode', newGraphId, gradientMixerNode, math.Vector2(positionX, positionY))
+    general.idle_wait_frames(1)
     gradientMixerEntityId = newEntityId
 
     boundsSlotId = graph.GraphModelSlotId('Bounds')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/GradientMixer_NodeConstruction.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/GradientMixer_NodeConstruction.py
@@ -75,6 +75,7 @@ def GradientMixer_NodeConstruction():
     import azlmbr.paths
 
     import editor_python_test_tools.hydra_editor_utils as hydra
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report
 
     editorId = azlmbr.globals.property.LANDSCAPE_CANVAS_EDITOR_ID
@@ -141,7 +142,7 @@ def GradientMixer_NodeConstruction():
     gradientMixerNode = landscapecanvas.LandscapeCanvasNodeFactoryRequestBus(bus.Broadcast, 'CreateNodeForTypeName', newGraph,
                                                                              'GradientMixerNode')
     graph.GraphControllerRequestBus(bus.Event, 'AddNode', newGraphId, gradientMixerNode, math.Vector2(positionX, positionY))
-    general.idle_wait_frames(1)
+    WaitForPrefabPropagation()
     gradientMixerEntityId = newEntityId
 
     boundsSlotId = graph.GraphModelSlotId('Bounds')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/LayerBlender_NodeConstruction.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/LayerBlender_NodeConstruction.py
@@ -125,6 +125,8 @@ def LayerBlender_NodeConstruction():
     positionX += offsetX
     positionY += offsetY
 
+    general.idle_wait_frames(1)
+
     outboundAreaSlotId = graph.GraphModelSlotId('OutboundArea')
     inboundAreaSlotId = graph.GraphModelSlotId('InboundArea')
     inboundAreaSlotId2 = graph.GraphControllerRequestBus(bus.Event, 'ExtendSlot', newGraphId, layerBlenderNode,

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/LayerBlender_NodeConstruction.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/LayerBlender_NodeConstruction.py
@@ -63,6 +63,7 @@ def LayerBlender_NodeConstruction():
     import azlmbr.math as math
 
     import editor_python_test_tools.hydra_editor_utils as hydra
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report
 
     editorId = azlmbr.globals.property.LANDSCAPE_CANVAS_EDITOR_ID
@@ -125,7 +126,7 @@ def LayerBlender_NodeConstruction():
     positionX += offsetX
     positionY += offsetY
 
-    general.idle_wait_frames(1)
+    WaitForPrefabPropagation()
 
     outboundAreaSlotId = graph.GraphModelSlotId('OutboundArea')
     inboundAreaSlotId = graph.GraphModelSlotId('InboundArea')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/LayerBlender_NodeConstruction.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/LayerBlender_NodeConstruction.py
@@ -63,7 +63,7 @@ def LayerBlender_NodeConstruction():
     import azlmbr.math as math
 
     import editor_python_test_tools.hydra_editor_utils as hydra
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import Report
 
     editorId = azlmbr.globals.property.LANDSCAPE_CANVAS_EDITOR_ID
@@ -126,7 +126,7 @@ def LayerBlender_NodeConstruction():
     positionX += offsetX
     positionY += offsetY
 
-    WaitForPrefabPropagation()
+    PrefabUtils.wait_for_propagation()
 
     outboundAreaSlotId = graph.GraphModelSlotId('OutboundArea')
     inboundAreaSlotId = graph.GraphModelSlotId('InboundArea')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/SlotConnections_UpdateComponentReferences.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/SlotConnections_UpdateComponentReferences.py
@@ -66,7 +66,7 @@ def SlotConnections_UpdateComponentReferences():
     import azlmbr.paths
 
     import editor_python_test_tools.hydra_editor_utils as hydra
-    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
+    import editor_python_test_tools.prefab_utils as PrefabUtils
     from editor_python_test_tools.utils import Report
 
     editorId = azlmbr.globals.property.LANDSCAPE_CANVAS_EDITOR_ID
@@ -164,7 +164,7 @@ def SlotConnections_UpdateComponentReferences():
                                                                                                       positionY))
     gradientMixerEntityId = newEntityId
 
-    WaitForPrefabPropagation()
+    PrefabUtils.wait_for_propagation()
 
     boundsSlotId = graph.GraphModelSlotId('Bounds')
     previewBoundsSlotId = graph.GraphModelSlotId('PreviewBounds')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/SlotConnections_UpdateComponentReferences.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/SlotConnections_UpdateComponentReferences.py
@@ -163,6 +163,8 @@ def SlotConnections_UpdateComponentReferences():
                                                                                                       positionY))
     gradientMixerEntityId = newEntityId
 
+    general.idle_wait_frames(1)
+
     boundsSlotId = graph.GraphModelSlotId('Bounds')
     previewBoundsSlotId = graph.GraphModelSlotId('PreviewBounds')
     inboundGradientSlotId = graph.GraphModelSlotId('InboundGradient')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/SlotConnections_UpdateComponentReferences.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/landscape_canvas/EditorScripts/SlotConnections_UpdateComponentReferences.py
@@ -66,6 +66,7 @@ def SlotConnections_UpdateComponentReferences():
     import azlmbr.paths
 
     import editor_python_test_tools.hydra_editor_utils as hydra
+    from editor_python_test_tools.prefab_utils import wait_for_propagation as WaitForPrefabPropagation
     from editor_python_test_tools.utils import Report
 
     editorId = azlmbr.globals.property.LANDSCAPE_CANVAS_EDITOR_ID
@@ -163,7 +164,7 @@ def SlotConnections_UpdateComponentReferences():
                                                                                                       positionY))
     gradientMixerEntityId = newEntityId
 
-    general.idle_wait_frames(1)
+    WaitForPrefabPropagation()
 
     boundsSlotId = graph.GraphModelSlotId('Bounds')
     previewBoundsSlotId = graph.GraphModelSlotId('PreviewBounds')

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
@@ -89,6 +89,7 @@ def create_mesh_surface_entity_with_slopes(name, center_point, uniform_scale):
     if surface_entity.id.IsValid():
         print(f"'{surface_entity.name}' created")
     hydra.get_set_test(surface_entity, 0, "Controller|Configuration|Mesh Asset", mesh_asset)
+    azlmbr.legacy.general.idle_wait_frames(1)
     components.TransformBus(bus.Event, "SetLocalUniformScale", surface_entity.id, uniform_scale)
     return surface_entity
 

--- a/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
+++ b/AutomatedTesting/Gem/PythonTests/largeworlds/large_worlds_utils/editor_dynveg_test_helper.py
@@ -22,7 +22,7 @@ import azlmbr.vegetation as vegetation
 sys.path.append(os.path.join(azlmbr.paths.projectroot, 'Gem', 'PythonTests'))
 import editor_python_test_tools.hydra_editor_utils as hydra
 from editor_python_test_tools.editor_entity_utils import EditorEntity
-from editor_python_test_tools.prefab_utils import Prefab
+from editor_python_test_tools.prefab_utils import Prefab, wait_for_propagation
 
 
 def create_temp_mesh_prefab(mesh_asset_path, prefab_filename):
@@ -89,7 +89,7 @@ def create_mesh_surface_entity_with_slopes(name, center_point, uniform_scale):
     if surface_entity.id.IsValid():
         print(f"'{surface_entity.name}' created")
     hydra.get_set_test(surface_entity, 0, "Controller|Configuration|Mesh Asset", mesh_asset)
-    azlmbr.legacy.general.idle_wait_frames(1)
+    wait_for_propagation()
     components.TransformBus(bus.Event, "SetLocalUniformScale", surface_entity.id, uniform_scale)
     return surface_entity
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h
@@ -28,6 +28,12 @@ namespace AzToolsFramework
         using RootAliasPath = AliasPath;
     }
 
+    enum class GameModeState
+    {
+        Started,
+        Stopped
+    };
+
     class PrefabEditorEntityOwnershipInterface
     {
     public:
@@ -83,5 +89,7 @@ namespace AzToolsFramework
         //! @return True if the iteration was halted by a callback returning true, false otherwise. Also returns false if the path is invalid.
         virtual bool GetInstancesInRootAliasPath(
             Prefab::RootAliasPath rootAliasPath, const AZStd::function<bool(const Prefab::InstanceOptionalReference)>& callback) const = 0;
+
+        virtual void RegisterGameModeEventHandler(AZ::Event<GameModeState>::Handler& handler) = 0;
     };
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.cpp
@@ -441,6 +441,7 @@ namespace AzToolsFramework
     {
         // This is a workaround until the replacement for GameEntityContext is done
         AzFramework::GameEntityContextEventBus::Broadcast(&AzFramework::GameEntityContextEventBus::Events::OnPreGameEntitiesStarted);
+        m_gameModeEvent.Signal(GameModeState::Started);
 
         if (m_rootInstance && !m_playInEditorData.m_isEnabled)
         {
@@ -500,7 +501,7 @@ namespace AzToolsFramework
             m_playInEditorData.m_entities.DespawnAllEntities();
             m_playInEditorData.m_entities.Alert(
                 [allSpawnableAssetData = m_playInEditorData.m_assetsCache.MoveAllInMemorySpawnableAssets(),
-                 deactivatedEntities = AZStd::move(m_playInEditorData.m_deactivatedEntities)]([[maybe_unused]] uint32_t generation) mutable
+                 deactivatedEntities = AZStd::move(m_playInEditorData.m_deactivatedEntities), this]([[maybe_unused]] uint32_t generation) mutable
                 {
                     auto end = deactivatedEntities.rend();
                     for (auto it = deactivatedEntities.rbegin(); it != end; ++it)
@@ -522,6 +523,7 @@ namespace AzToolsFramework
 
                     // This is a workaround until the replacement for GameEntityContext is done
                     AzFramework::GameEntityContextEventBus::Broadcast(&AzFramework::GameEntityContextEventBus::Events::OnGameEntitiesReset);
+                    m_gameModeEvent.Signal(GameModeState::Stopped);
                 });
             m_playInEditorData.m_entities.Clear();
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h
@@ -174,6 +174,11 @@ namespace AzToolsFramework
         bool GetInstancesInRootAliasPath(
             Prefab::RootAliasPath rootAliasPath, const AZStd::function<bool(const Prefab::InstanceOptionalReference)>& callback) const override;
 
+        void RegisterGameModeEventHandler(AZ::Event<GameModeState>::Handler& handler) override
+        {
+            handler.Connect(m_gameModeEvent);
+        }
+
     protected:
 
         AZ::SliceComponent::SliceInstanceAddress GetOwningSlice() override;
@@ -222,6 +227,7 @@ namespace AzToolsFramework
         Prefab::PrefabLoaderInterface* m_loaderInterface = nullptr;
         AzFramework::EntityContextId m_entityContextId;
         AZ::SerializeContext m_serializeContext;
+        AZ::Event<GameModeState> m_gameModeEvent;
         bool m_isRootPrefabAssigned = false;
     };
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/Instance.cpp
@@ -260,6 +260,7 @@ namespace AzToolsFramework
             ClearEntities();
 
             m_nestedInstances.clear();
+            m_cachedInstanceDom.SetNull();
             m_containerEntity.reset(aznew AZ::Entity());
             RegisterEntity(m_containerEntity->GetId(), GenerateEntityAlias());
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.cpp
@@ -31,7 +31,7 @@ namespace AzToolsFramework
             , m_GameModeEventHandler(
                   [this](GameModeState state)
                   {
-                      m_isGameModeInProgress = (state == GameModeState::Started) ? true : false;
+                      m_isGameModeInProgress = (state == GameModeState::Started);
                   })
         {
         }
@@ -51,13 +51,11 @@ namespace AzToolsFramework
                 "Check that it is being correctly initialized.");
 
             AZ::Interface<InstanceUpdateExecutorInterface>::Register(this);
-            //AzFramework::GameEntityContextEventBus::Handler::BusConnect();
         }
 
         void InstanceUpdateExecutor::UnregisterInstanceUpdateExecutorInterface()
         {
             m_GameModeEventHandler.Disconnect();
-            //AzFramework::GameEntityContextEventBus::Handler::BusDisconnect();
             AZ::Interface<InstanceUpdateExecutorInterface>::Unregister(this);
         }
 
@@ -277,16 +275,6 @@ namespace AzToolsFramework
             }
 
             return isUpdateSuccessful;
-        }
-
-        void InstanceUpdateExecutor::OnPreGameEntitiesStarted()
-        {
-            m_isGameModeInProgress = true;
-        }
-
-        void InstanceUpdateExecutor::OnGameEntitiesReset()
-        {
-            m_isGameModeInProgress = false;
         }
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -11,6 +11,8 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/std/containers/deque.h>
+#include <AzFramework/Entity/GameEntityContextBus.h>
+#include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
 
@@ -24,6 +26,7 @@ namespace AzToolsFramework
 
         class InstanceUpdateExecutor
             : public InstanceUpdateExecutorInterface
+            , private AzFramework::GameEntityContextEventBus::Handler
         {
         public:
             AZ_RTTI(InstanceUpdateExecutor, "{E21DB0D4-0478-4DA9-9011-31BC96F55837}", InstanceUpdateExecutorInterface);
@@ -39,11 +42,20 @@ namespace AzToolsFramework
             void UnregisterInstanceUpdateExecutorInterface();
 
         private:
+
+            // GameEntityContextEventBus
+            void OnPreGameEntitiesStarted() override;
+            void OnGameEntitiesReset() override;
+
+            void LazyConnectGameModeEventHandler();
+
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
             TemplateInstanceMapperInterface* m_templateInstanceMapperInterface = nullptr;
-            int m_instanceCountToUpdateInBatch = 0;
             AZStd::deque<Instance*> m_instancesUpdateQueue;
+            AZ::Event<GameModeState>::Handler m_GameModeEventHandler;
+            int m_instanceCountToUpdateInBatch = 0;
             bool m_updatingTemplateInstancesInQueue { false };
+            bool m_isGameModeInProgress = false;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -11,7 +11,6 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/Json/JsonSerialization.h>
 #include <AzCore/std/containers/deque.h>
-#include <AzFramework/Entity/GameEntityContextBus.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
@@ -26,7 +25,6 @@ namespace AzToolsFramework
 
         class InstanceUpdateExecutor
             : public InstanceUpdateExecutorInterface
-            , private AzFramework::GameEntityContextEventBus::Handler
         {
         public:
             AZ_RTTI(InstanceUpdateExecutor, "{E21DB0D4-0478-4DA9-9011-31BC96F55837}", InstanceUpdateExecutorInterface);
@@ -43,10 +41,9 @@ namespace AzToolsFramework
 
         private:
 
-            // GameEntityContextEventBus
-            void OnPreGameEntitiesStarted() override;
-            void OnGameEntitiesReset() override;
-
+            //! Connect the game mode event handler in a lazy fashion rather than at construction of this class.
+            //! This is required because the event won't be ready for connection during construction as EditorEntityContextComponent
+            //! gets initialized after the PrefabSystemComponent
             void LazyConnectGameModeEventHandler();
 
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -432,8 +432,9 @@ namespace AzToolsFramework
                         {
                             AZ_Warning(
                                 "Prefab", false,
-                                "A patch targeting '%s' is identified. Patches must be routed to Entities, Instances, or ContainerEntity.",
-                                patchPath.data());
+                                "A patch targeting '%.*s' is identified. Patches must be routed to Entities, Instances, or "
+                                "ContainerEntity.",
+                                AZ_STRING_ARG(patchPath));
                         }
                     }
                 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-
+#pragma optimize("", off)
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetJsonSerializer.h>
 #include <AzCore/JSON/prettywriter.h>
@@ -433,7 +433,7 @@ namespace AzToolsFramework
                             AZ_Warning(
                                 "Prefab", false,
                                 "A patch targeting '%s' is identified. Patches must be routed to Entities, Instances, or ContainerEntity.",
-                                patchPath);
+                                patchPath.data());
                         }
                     }
                 }
@@ -453,3 +453,4 @@ namespace AzToolsFramework
         } // namespace PrefabDomUtils
     } // namespace Prefab
 } // namespace AzToolsFramework
+#pragma optimize("", on)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabDomUtils.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */
-#pragma optimize("", off)
+
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetJsonSerializer.h>
 #include <AzCore/JSON/prettywriter.h>
@@ -453,4 +453,3 @@ namespace AzToolsFramework
         } // namespace PrefabDomUtils
     } // namespace Prefab
 } // namespace AzToolsFramework
-#pragma optimize("", on)


### PR DESCRIPTION
Due to the changes in https://github.com/aws-lumberyard-dev/o3de/tree/Prefab/SelectiveDeserialization branch, 37 automated tests were failing. The changes in this PR fixes them all.

Fixes include:
1. Most of the tests needed an additional frame for the propagation to finish and for the root instance to be in-sync with the underlying prefab dom. This wasn't needed previously(in current development) because we were excluding the root instance from propagation and letting it go out of sync with the dom. But with the current selective deserialization work, instance and dom needs to be in sync for iterative changes to work
2. Introduced 2 new events to notify about game mode starting and stopping. Propagation needn't happen during game mode. This wasn't an issue because so far because of the instanceToExclude paradigm. So, tecnically, propagation was allowed during game mode so far but the root instance was so far excluded from getting update during propagation.
3. Sets the cached dom of instance to be null when resetting it. Unless this is done, selective deserialization will try to update the instance by comparing differences between current state and cached state of previous instance
4. Fixed a bug where string is currectly formatted to be used with a string_view