### PR TITLE
[2/4] Using new material classes in PhysX Collider, PhysX Shape Collider, …

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Character.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Character.cpp
@@ -85,10 +85,10 @@ namespace Physics
         if (serializeContext)
         {
             serializeContext->Class<CharacterConfiguration, AzPhysics::SimulatedBodyConfiguration>()
-                ->Version(3)
+                ->Version(5)
                 ->Field("CollisionLayer", &CharacterConfiguration::m_collisionLayer)
                 ->Field("CollisionGroupId", &CharacterConfiguration::m_collisionGroupId)
-                ->Field("Material", &CharacterConfiguration::m_materialSelection)
+                ->Field("MaterialSlots", &CharacterConfiguration::m_materialSlots)
                 ->Field("UpDirection", &CharacterConfiguration::m_upDirection)
                 ->Field("MaximumSlopeAngle", &CharacterConfiguration::m_maximumSlopeAngle)
                 ->Field("StepHeight", &CharacterConfiguration::m_stepHeight)
@@ -107,8 +107,8 @@ namespace Physics
                         "Collision Layer", "The collision layer assigned to the controller")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterConfiguration::m_collisionGroupId,
                         "Collides With", "The collision layers this character controller collides with")
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterConfiguration::m_materialSelection,
-                        "Physics Material", "Assign physics material library and select materials to use for the character")
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterConfiguration::m_materialSlots, "", "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &CharacterConfiguration::m_maximumSlopeAngle,
                         "Maximum Slope Angle", "Maximum angle of slopes on which the controller can walk")
                         ->Attribute(AZ::Edit::Attributes::Min, 0.0f)

--- a/Code/Framework/AzFramework/AzFramework/Physics/Character.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Character.h
@@ -68,7 +68,7 @@ namespace Physics
 
         AzPhysics::CollisionGroups::Id m_collisionGroupId; //!< Which layers does this character collide with.
         AzPhysics::CollisionLayer m_collisionLayer; //!< Which collision layer is this character on.
-        MaterialSelection m_materialSelection; //!< Material selected from library for the body associated with the character.
+        MaterialSlots m_materialSlots; //!< Material slots for the character.
         AZ::Vector3 m_upDirection = AZ::Vector3::CreateAxisZ(); //!< Up direction for character orientation and step behavior.
         float m_maximumSlopeAngle = 30.0f; //!< The maximum slope on which the character can move, in degrees.
         float m_stepHeight = 0.5f; //!< Affects what size steps the character can climb.

--- a/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Common/PhysicsSceneQueries.h
@@ -17,6 +17,7 @@
 
 #include <AzFramework/Physics/Collision/CollisionGroups.h>
 #include <AzFramework/Physics/Common/PhysicsTypes.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialId.h>
 
 namespace AZ
 {
@@ -25,7 +26,7 @@ namespace AZ
 
 namespace Physics
 {
-    class Material;
+    class Material2;
     class Shape;
     class ShapeConfiguration;
 }
@@ -258,9 +259,9 @@ namespace AzPhysics
         //! The shape on the body that was hit.
         //! Valid if SceneQuery::ResultFlags::Shape is set.
         Physics::Shape* m_shape = nullptr;
-        //! The material on the shape (or face) that was hit.
+        //! The physics material id on the shape (or face) that was hit.
         //! Valid if SceneQuery::ResultFlags::Material is set.
-        Physics::Material* m_material = nullptr;
+        Physics::MaterialId2 m_physicsMaterialId;
         //! The position of the hit in world space.
         //! Valid if SceneQuery::ResultFlags::Position is set.
         AZ::Vector3 m_position = AZ::Vector3::CreateZero();

--- a/Code/Framework/AzFramework/AzFramework/Physics/HeightfieldProviderBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/HeightfieldProviderBus.h
@@ -12,7 +12,7 @@
 #include <AzCore/EBus/EBus.h>
 #include <AzCore/Component/ComponentBus.h>
 #include <AzCore/Math/Aabb.h>
-#include <AzFramework/Physics/Material.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialAsset.h>
 
 namespace Physics
 {
@@ -97,7 +97,7 @@ namespace Physics
 
         //! Returns the list of materials used by the height field.
         //! @return returns a vector of all materials.
-        virtual AZStd::vector<MaterialId> GetMaterialList() const = 0;
+        virtual AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> GetMaterialList() const = 0;
 
         //! Returns the list of heights used by the height field.
         //! @return the rows*columns vector of the heights.

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.cpp
@@ -6,9 +6,9 @@
  *
  */
 
-#include "Shape.h"
 #include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Physics/ClassConverters.h>
+#include <AzFramework/Physics/Shape.h>
 
 namespace Physics
 {
@@ -19,7 +19,7 @@ namespace Physics
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serializeContext->Class<ColliderConfiguration>()
-                ->Version(4, &Physics::ClassConverters::ColliderConfigurationConverter)
+                ->Version(6, &Physics::ClassConverters::ColliderConfigurationConverter)
                 ->Field("CollisionLayer", &ColliderConfiguration::m_collisionLayer)
                 ->Field("CollisionGroupId", &ColliderConfiguration::m_collisionGroupId)
                 ->Field("Visible", &ColliderConfiguration::m_visible)
@@ -29,7 +29,7 @@ namespace Physics
                 ->Field("Exclusive", &ColliderConfiguration::m_isExclusive)
                 ->Field("Position", &ColliderConfiguration::m_position)
                 ->Field("Rotation", &ColliderConfiguration::m_rotation)
-                ->Field("MaterialSelection", &ColliderConfiguration::m_materialSelection)
+                ->Field("MaterialSlots", &ColliderConfiguration::m_materialSlots)
                 ->Field("propertyVisibilityFlags", &ColliderConfiguration::m_propertyVisibilityFlags)
                 ->Field("ColliderTag", &ColliderConfiguration::m_tag)
                 ->Field("RestOffset", &ColliderConfiguration::m_restOffset)
@@ -58,8 +58,8 @@ namespace Physics
                         ->Attribute(AZ::Edit::Attributes::Step, 0.01f)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_rotation, "Rotation", "Local rotation relative to the rigid body")
                         ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetOffsetVisibility)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_materialSelection, "Physics Materials", "Select which physics materials to use for each element of this shape")
-                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetMaterialSelectionVisibility)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_materialSlots, "", "")
+                        ->Attribute(AZ::Edit::Attributes::Visibility, &ColliderConfiguration::GetMaterialSlotsVisibility)
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_tag, "Tag", "Tag used to identify colliders from one another")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &ColliderConfiguration::m_restOffset, "Rest offset",
                         "Bodies will come to rest separated by the sum of their rest offset values (must be less than contact offset)")
@@ -122,9 +122,11 @@ namespace Physics
         return GetPropertyVisibility(PropertyVisibility::CollisionLayer);
     }
 
-    AZ::Crc32 ColliderConfiguration::GetMaterialSelectionVisibility() const
+    AZ::Crc32 ColliderConfiguration::GetMaterialSlotsVisibility() const
     {
-        return GetPropertyVisibility(PropertyVisibility::MaterialSelection);
+        return (m_propertyVisibilityFlags & PropertyVisibility::MaterialSelection) != 0
+            ? AZ::Edit::PropertyVisibility::ShowChildrenOnly
+            : AZ::Edit::PropertyVisibility::Hide;
     }
 
     AZ::Crc32 ColliderConfiguration::GetOffsetVisibility() const

--- a/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Shape.h
@@ -9,7 +9,8 @@
 #pragma once
 
 #include <AzFramework/Physics/ShapeConfiguration.h>
-#include <AzFramework/Physics/Material.h>
+#include <AzFramework/Physics/Material/PhysicsMaterial.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
 #include <AzFramework/Physics/Collision/CollisionGroups.h>
 #include <AzFramework/Physics/Collision/CollisionLayers.h>
 #include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
@@ -21,8 +22,6 @@ namespace AZ
 
 namespace Physics
 {
-    class Material;
-
     class ColliderConfiguration
     {
     public:
@@ -51,7 +50,7 @@ namespace Physics
 
         AZ::Crc32 GetIsTriggerVisibility() const;
         AZ::Crc32 GetCollisionLayerVisibility() const;
-        AZ::Crc32 GetMaterialSelectionVisibility() const;
+        AZ::Crc32 GetMaterialSlotsVisibility() const;
         AZ::Crc32 GetOffsetVisibility() const;
 
         AzPhysics::CollisionLayer m_collisionLayer; ///< Which collision layer is this collider on.
@@ -62,7 +61,7 @@ namespace Physics
         bool m_isExclusive = true; ///< Can this collider be shared between multiple bodies?
         AZ::Vector3 m_position = AZ::Vector3::CreateZero(); /// Shape offset relative to the connected rigid body.
         AZ::Quaternion m_rotation = AZ::Quaternion::CreateIdentity(); ///< Shape rotation relative to the connected rigid body.
-        Physics::MaterialSelection m_materialSelection; ///< Materials for the collider.
+        MaterialSlots m_materialSlots; ///< Material slots for the collider.
         AZ::u8 m_propertyVisibilityFlags = (std::numeric_limits<AZ::u8>::max)(); ///< Visibility flags for collider.
                                                                                  ///< Note: added parenthesis for std::numeric_limits is
                                                                                  ///< to avoid collision with `max` macro in uber builds.
@@ -84,8 +83,8 @@ namespace Physics
         AZ_RTTI(Shape, "{0A47DDD6-2BD7-43B3-BF0D-2E12CC395C13}");
         virtual ~Shape() = default;
 
-        virtual void SetMaterial(const AZStd::shared_ptr<Material>& material) = 0;
-        virtual AZStd::shared_ptr<Material> GetMaterial() const = 0;
+        virtual void SetMaterial(const AZStd::shared_ptr<Material2>& material) = 0;
+        virtual AZStd::shared_ptr<Material2> GetMaterial() const = 0;
 
         virtual void SetCollisionLayer(const AzPhysics::CollisionLayer& layer) = 0;
         virtual AzPhysics::CollisionLayer GetCollisionLayer() const = 0;

--- a/Code/Framework/AzFramework/AzFramework/Physics/SystemBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/SystemBus.h
@@ -27,8 +27,6 @@ namespace AzPhysics
 namespace Physics
 {
     class Shape;
-    class Material;
-    class MaterialConfiguration;
     class ColliderConfiguration;
     class ShapeConfiguration;
 
@@ -129,8 +127,6 @@ namespace Physics
         //// General Physics
 
         virtual AZStd::shared_ptr<Shape> CreateShape(const ColliderConfiguration& colliderConfiguration, const ShapeConfiguration& configuration) = 0;
-
-        virtual AZStd::shared_ptr<Material> CreateMaterial(const Physics::MaterialConfiguration& materialConfiguration) = 0;
 
         /// Releases the height field object created by the physics backend.
         /// @param nativeHeightfieldObject Pointer to the height field object.

--- a/Code/Framework/AzFramework/AzFramework/Physics/Utils.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Utils.cpp
@@ -6,11 +6,6 @@
  *
  */
 
-
-#include "Utils.h"
-#include "Material.h"
-#include "Shape.h"
-
 #include <AzCore/RTTI/BehaviorContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzFramework/Physics/AnimationConfiguration.h>
@@ -31,10 +26,13 @@
 #include <AzFramework/Physics/Configuration/RigidBodyConfiguration.h>
 #include <AzFramework/Physics/Configuration/SceneConfiguration.h>
 #include <AzFramework/Physics/Configuration/SimulatedBodyConfiguration.h>
+#include <AzFramework/Physics/Material.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialAsset.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
 #include <AzFramework/Physics/Common/PhysicsJoint.h>
+#include <AzFramework/Physics/Shape.h>
+#include <AzFramework/Physics/Utils.h>
 
 namespace Physics
 {

--- a/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/ColliderCommands.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/ColliderCommands.cpp
@@ -448,7 +448,7 @@ namespace EMotionFX
         }
 
         serializeContext->Class<CommandAdjustCollider, MCore::Command, ParameterMixinActorId, ParameterMixinJointName>()
-            ->Version(1)
+            ->Version(2)
             ->Field("configType", &CommandAdjustCollider::m_configType)
             ->Field("index", &CommandAdjustCollider::m_index)
             ->Field("collisionLayer", &CommandAdjustCollider::m_collisionLayer)
@@ -456,7 +456,7 @@ namespace EMotionFX
             ->Field("isTrigger", &CommandAdjustCollider::m_isTrigger)
             ->Field("position", &CommandAdjustCollider::m_position)
             ->Field("rotation", &CommandAdjustCollider::m_rotation)
-            ->Field("material", &CommandAdjustCollider::m_material)
+            ->Field("materialSlots", &CommandAdjustCollider::m_materialSlots)
             ->Field("tag", &CommandAdjustCollider::m_tag)
             ->Field("radius", &CommandAdjustCollider::m_radius)
             ->Field("height", &CommandAdjustCollider::m_height)
@@ -485,7 +485,7 @@ namespace EMotionFX
         ExecuteParameter<bool>(m_oldIsTrigger, m_isTrigger, colliderConfig->m_isTrigger);
         ExecuteParameter<AZ::Vector3>(m_oldPosition, m_position, colliderConfig->m_position);
         ExecuteParameter<AZ::Quaternion>(m_oldRotation, m_rotation, colliderConfig->m_rotation);
-        ExecuteParameter<Physics::MaterialSelection>(m_oldMaterial, m_material, colliderConfig->m_materialSelection);
+        ExecuteParameter<Physics::MaterialSlots>(m_oldMaterialSlots, m_materialSlots, colliderConfig->m_materialSlots);
         ExecuteParameter<AZStd::string>(m_oldTag, m_tag, colliderConfig->m_tag);
 
         // ShapeConfiguration
@@ -550,9 +550,9 @@ namespace EMotionFX
         {
             colliderConfig->m_rotation = m_oldRotation.value();
         }
-        if (m_oldMaterial.has_value())
+        if (m_oldMaterialSlots.has_value())
         {
-            colliderConfig->m_materialSelection = m_oldMaterial.value();
+            colliderConfig->m_materialSlots = m_oldMaterialSlots.value();
         }
         if (m_oldTag.has_value())
         {

--- a/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/ColliderCommands.h
+++ b/Gems/EMotionFX/Code/EMotionFX/CommandSystem/Source/ColliderCommands.h
@@ -130,7 +130,7 @@ namespace EMotionFX
         void SetIsTrigger(bool isTrigger) { m_isTrigger = isTrigger; }
         void SetPosition(AZ::Vector3 position) { m_position = AZStd::move(position); }
         void SetRotation(AZ::Quaternion rotation) { m_rotation = AZStd::move(rotation); }
-        void SetMaterial(Physics::MaterialSelection material) { m_material = AZStd::move(material); }
+        void SetMaterialSlots(Physics::MaterialSlots materialSlots) { m_materialSlots = AZStd::move(materialSlots); }
         void SetTag(AZStd::string tag) { m_tag = AZStd::move(tag); }
 
         void SetOldCollisionLayer(AzPhysics::CollisionLayer collisionLayer) { m_oldCollisionLayer = collisionLayer; }
@@ -138,7 +138,7 @@ namespace EMotionFX
         void SetOldIsTrigger(bool isTrigger) { m_oldIsTrigger = isTrigger; }
         void SetOldPosition(AZ::Vector3 position) { m_oldPosition = AZStd::move(position); }
         void SetOldRotation(AZ::Quaternion rotation) { m_oldRotation = AZStd::move(rotation); }
-        void SetOldMaterial(Physics::MaterialSelection material) { m_oldMaterial = AZStd::move(material); }
+        void SetOldMaterialSlots(Physics::MaterialSlots materialSlots) { m_oldMaterialSlots = AZStd::move(materialSlots); }
         void SetOldTag(AZStd::string tag) { m_oldTag = AZStd::move(tag); }
 
         const AZStd::optional<AZStd::string>& GetOldTag() const { return m_oldTag; }
@@ -166,7 +166,7 @@ namespace EMotionFX
         AZStd::optional<bool> m_isTrigger;
         AZStd::optional<AZ::Vector3> m_position;
         AZStd::optional<AZ::Quaternion> m_rotation;
-        AZStd::optional<Physics::MaterialSelection> m_material;
+        AZStd::optional<Physics::MaterialSlots> m_materialSlots;
         AZStd::optional<AZStd::string> m_tag;
 
         AZStd::optional<AzPhysics::CollisionLayer> m_oldCollisionLayer;
@@ -174,7 +174,7 @@ namespace EMotionFX
         AZStd::optional<bool> m_oldIsTrigger;
         AZStd::optional<AZ::Vector3> m_oldPosition;
         AZStd::optional<AZ::Quaternion> m_oldRotation;
-        AZStd::optional<Physics::MaterialSelection> m_oldMaterial;
+        AZStd::optional<Physics::MaterialSlots> m_oldMaterialSlots;
         AZStd::optional<AZStd::string> m_oldTag;
 
         // ShapeConfiguration

--- a/Gems/EMotionFX/Code/EMotionFX/Source/PhysicsSetup.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/PhysicsSetup.cpp
@@ -233,10 +233,8 @@ namespace EMotionFX
         }
         
         AzPhysics::ShapeColliderPair pair(AZStd::make_shared<Physics::ColliderConfiguration>(), shapeConfig);
-        if (pair.first->m_materialSelection.GetMaterialIdsAssignedToSlots().empty())
-        {
-            pair.first->m_materialSelection.SetMaterialSlots(Physics::MaterialSelection::SlotsArray());
-        }
+        AZ_Assert(pair.first->m_materialSlots.GetSlotsCount() > 0, "Material slots is empty.");
+
         return AZ::Success(pair);
     }
 

--- a/Gems/EMotionFX/Code/Source/Editor/ColliderContainerWidget.cpp
+++ b/Gems/EMotionFX/Code/Source/Editor/ColliderContainerWidget.cpp
@@ -104,9 +104,9 @@ namespace EMotionFX
                 {
                     command->SetOldRotation(colliderConfig->m_rotation);
                 }
-                if (elementData->m_nameCrc == AZ_CRC("MaterialSelection", 0xfebd6d15))
+                if (elementData->m_nameCrc == AZ_CRC_CE("MaterialSlots"))
                 {
-                    command->SetOldMaterial(colliderConfig->m_materialSelection);
+                    command->SetOldMaterialSlots(colliderConfig->m_materialSlots);
                 }
                 if (elementData->m_nameCrc == AZ_CRC("ColliderTag", 0x5e2963ad))
                 {
@@ -202,9 +202,9 @@ namespace EMotionFX
                 {
                     command->SetRotation(colliderConfig->m_rotation);
                 }
-                if (elementData->m_nameCrc == AZ_CRC("MaterialSelection", 0xfebd6d15))
+                if (elementData->m_nameCrc == AZ_CRC_CE("MaterialSlots"))
                 {
-                    command->SetMaterial(colliderConfig->m_materialSelection);
+                    command->SetMaterialSlots(colliderConfig->m_materialSlots);
                 }
                 if (elementData->m_nameCrc == AZ_CRC("ColliderTag", 0x5e2963ad))
                 {

--- a/Gems/PhysX/Code/Editor/DebugDraw.cpp
+++ b/Gems/PhysX/Code/Editor/DebugDraw.cpp
@@ -13,12 +13,12 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Interface/Interface.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
-#include <AzFramework/Physics/MaterialBus.h>
 #include <AzToolsFramework/API/ToolsApplicationAPI.h>
 #include <LyViewPaneNames.h>
 #include <LmbrCentral/Geometry/GeometrySystemComponentBus.h>
 #include <Source/Utils.h>
 
+#include <PhysX/Material/PhysXMaterial.h>
 #include <PhysX/Debug/PhysXDebugInterface.h>
 #include <PhysX/MathConversion.h>
 
@@ -447,16 +447,13 @@ namespace PhysX
             {
             case GlobalCollisionDebugColorMode::MaterialColor:
             {
-                const Physics::MaterialId materialId = colliderConfig.m_materialSelection.GetMaterialId(elementDebugInfo.m_materialSlotIndex);
+                const auto materialAsset = colliderConfig.m_materialSlots.GetMaterialAsset(elementDebugInfo.m_materialSlotIndex);
 
-                AZStd::shared_ptr<Physics::Material> physicsMaterial;
-                Physics::PhysicsMaterialRequestBus::BroadcastResult(
-                    physicsMaterial,
-                    &Physics::PhysicsMaterialRequestBus::Events::GetMaterialById,
-                    materialId);
-                if (physicsMaterial)
+                AZStd::shared_ptr<Material2> material = Material2::FindOrCreateMaterial(materialAsset);
+
+                if (material)
                 {
-                    debugColor = physicsMaterial->GetDebugColor();
+                    debugColor = material->GetDebugColor();
                 }
                 break;
             }

--- a/Gems/PhysX/Code/Include/PhysX/MeshAsset.h
+++ b/Gems/PhysX/Code/Include/PhysX/MeshAsset.h
@@ -11,7 +11,7 @@
 
 #include <AzCore/Asset/AssetManager.h>
 #include <AzCore/Asset/AssetTypeInfoBus.h>
-#include <AzFramework/Physics/Material.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
 #include <AzFramework/Physics/Shape.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <AzFramework/Physics/Collision/CollisionGroups.h>
@@ -58,9 +58,8 @@ namespace PhysX
             using ShapeConfigurationList = AZStd::vector<ShapeConfigurationPair>;
 
             ShapeConfigurationList m_colliderShapes; //!< Shapes data with optional collider configuration override.
-            AZStd::vector<AZStd::string> m_materialNames; //!< List of material names of the mesh asset.
-            AZStd::vector<AZStd::string> m_physicsMaterialNames; //!< List of physics material names associated with each material.
-            AZStd::vector<AZ::u16> m_materialIndexPerShape; //!< An index of the material in m_materialNames for each shape.
+            Physics::MaterialSlots m_materialSlots; //!< List of material slots of the mesh asset.
+            AZStd::vector<AZ::u16> m_materialIndexPerShape; //!< An index of the material in m_materialSlots for each shape.
         };
 
         //! Represents a PhysX mesh asset. This is an AZ::Data::AssetData wrapper around MeshAssetData

--- a/Gems/PhysX/Code/Include/PhysX/MeshColliderComponentBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/MeshColliderComponentBus.h
@@ -26,17 +26,9 @@ namespace PhysX
         /// @return Asset pointer to mesh asset.
         virtual AZ::Data::Asset<Pipeline::MeshAsset> GetMeshAsset() const = 0;
 
-        /// Gets the material id from the material library for this entity.
-        /// @return The asset ID to set it to.
-        virtual Physics::MaterialId GetMaterialId() const = 0;
-
         /// Sets the mesh asset ID
         /// @param id The asset ID to set it to.
         virtual void SetMeshAsset(const AZ::Data::AssetId& id) = 0;
-
-        /// Sets the material id from the material library.
-        /// @param id The asset ID to set it to.
-        virtual void SetMaterialId(const Physics::MaterialId& id) = 0;
     };
 
     /// Bus to service the PhysX Mesh Collider Component event group.

--- a/Gems/PhysX/Code/Include/PhysX/Utils.h
+++ b/Gems/PhysX/Code/Include/PhysX/Utils.h
@@ -24,7 +24,7 @@ namespace AzPhysics
 
 namespace Physics
 {
-    class Material;
+    class Material2;
     class Shape;
 }
 
@@ -35,7 +35,7 @@ namespace PhysX
     namespace Utils
     {
         ActorData* GetUserData(const physx::PxActor* actor);
-        Physics::Material* GetUserData(const physx::PxMaterial* material);
+        Physics::Material2* GetUserData(const physx::PxMaterial* material);
         Physics::Shape* GetUserData(const physx::PxShape* shape);
         AzPhysics::Scene* GetUserData(physx::PxScene* scene);
 

--- a/Gems/PhysX/Code/Include/PhysX/Utils.inl
+++ b/Gems/PhysX/Code/Include/PhysX/Utils.inl
@@ -30,9 +30,9 @@ namespace PhysX
         return actorData;
     }
 
-    inline Physics::Material* Utils::GetUserData(const physx::PxMaterial* material)
+    inline Physics::Material2* Utils::GetUserData(const physx::PxMaterial* material)
     {
-        return (material == nullptr) ? nullptr : static_cast<Physics::Material*>(material->userData);
+        return (material == nullptr) ? nullptr : static_cast<Physics::Material2*>(material->userData);
     }
 
     inline Physics::Shape* Utils::GetUserData(const physx::PxShape* pxShape)

--- a/Gems/PhysX/Code/Mocks/PhysX/MockPhysXHeightfieldProviderComponent.h
+++ b/Gems/PhysX/Code/Mocks/PhysX/MockPhysXHeightfieldProviderComponent.h
@@ -64,7 +64,7 @@ namespace UnitTest
         MOCK_CONST_METHOD2(GetHeightfieldGridSize, void(int32_t&, int32_t&));
         MOCK_CONST_METHOD2(GetHeightfieldHeightBounds, void(float&, float&));
         MOCK_CONST_METHOD0(GetHeightfieldTransform, AZ::Transform());
-        MOCK_CONST_METHOD0(GetMaterialList, AZStd::vector<Physics::MaterialId>());
+        MOCK_CONST_METHOD0(GetMaterialList, AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>>());
         MOCK_CONST_METHOD0(GetHeights, AZStd::vector<float>());
         MOCK_CONST_METHOD1(UpdateHeights, AZStd::vector<float>(const AZ::Aabb& dirtyRegion));
         MOCK_CONST_METHOD1(UpdateHeightsAndMaterials, AZStd::vector<Physics::HeightMaterialPoint>(const AZ::Aabb& dirtyRegion));

--- a/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/BaseColliderComponent.cpp
@@ -85,9 +85,6 @@ namespace PhysX
         m_cacheOutdated = false;
     }
 
-    // BaseColliderComponent
-    const Physics::ColliderConfiguration BaseColliderComponent::s_defaultColliderConfig = Physics::ColliderConfiguration();
-
     void BaseColliderComponent::Reflect(AZ::ReflectContext* context)
     {
         if (auto serializeContext = azrtti_cast<AZ::SerializeContext*>(context))

--- a/Gems/PhysX/Code/Source/BaseColliderComponent.h
+++ b/Gems/PhysX/Code/Source/BaseColliderComponent.h
@@ -117,9 +117,5 @@ namespace PhysX
         bool InitMeshCollider();
 
         AZStd::vector<AZStd::shared_ptr<Physics::Shape>> m_shapes;
-        // This is here only to cover the edge case where GetColliderConfig (which expects a const reference to be
-        // returned) is called and m_shapeConfigList is empty. It can be removed as soon as the deprecation of
-        // GetColliderConfig is complete.
-        static const Physics::ColliderConfiguration s_defaultColliderConfig;
     };
 }

--- a/Gems/PhysX/Code/Source/Common/PhysXSceneQueryHelpers.cpp
+++ b/Gems/PhysX/Code/Source/Common/PhysXSceneQueryHelpers.cpp
@@ -79,7 +79,7 @@ namespace PhysX
             {
                 PHYSX_SCENE_READ_LOCK(pxHit.actor->getScene());
                 if (const auto* physicsMaterial = Utils::GetUserData(pxHit.shape->getMaterialFromInternalFaceIndex(pxHit.faceIndex));
-                    physicsMaterial)
+                    physicsMaterial != nullptr)
                 {
                     hit.m_physicsMaterialId = physicsMaterial->GetId();
                 }
@@ -87,7 +87,7 @@ namespace PhysX
             else if (hit.m_shape != nullptr)
             {
                 if (const auto& physicsMaterial = hit.m_shape->GetMaterial();
-                    physicsMaterial)
+                    physicsMaterial.get() != nullptr)
                 {
                     hit.m_physicsMaterialId = physicsMaterial->GetId();
                 }

--- a/Gems/PhysX/Code/Source/Common/PhysXSceneQueryHelpers.cpp
+++ b/Gems/PhysX/Code/Source/Common/PhysXSceneQueryHelpers.cpp
@@ -78,13 +78,21 @@ namespace PhysX
             if (pxHit.faceIndex != 0xFFFFffff)
             {
                 PHYSX_SCENE_READ_LOCK(pxHit.actor->getScene());
-                hit.m_material = Utils::GetUserData(pxHit.shape->getMaterialFromInternalFaceIndex(pxHit.faceIndex));
+                if (const auto* physicsMaterial = Utils::GetUserData(pxHit.shape->getMaterialFromInternalFaceIndex(pxHit.faceIndex));
+                    physicsMaterial)
+                {
+                    hit.m_physicsMaterialId = physicsMaterial->GetId();
+                }
             }
             else if (hit.m_shape != nullptr)
             {
-                hit.m_material = hit.m_shape->GetMaterial().get();
+                if (const auto& physicsMaterial = hit.m_shape->GetMaterial();
+                    physicsMaterial)
+                {
+                    hit.m_physicsMaterialId = physicsMaterial->GetId();
+                }
             }
-            if (hit.m_material != nullptr)
+            if (hit.m_physicsMaterialId.IsValid())
             {
                 hit.m_resultFlags |= AzPhysics::SceneQuery::ResultFlags::Material;
             }

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -12,7 +12,6 @@
 #include <AzCore/std/smart_ptr/shared_ptr.h>
 #include <AzFramework/Physics/ColliderComponentBus.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
-#include <AzFramework/Physics/MaterialBus.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBody.h>
 #include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
 #include <AzFramework/Viewport/ViewportColors.h>
@@ -370,16 +369,6 @@ namespace PhysX
                     AzToolsFramework::PropertyModificationRefreshLevel::Refresh_AttributesAndValues);
             });
 
-        m_onMaterialLibraryChangedEventHandler = AzPhysics::SystemEvents::OnMaterialLibraryChangedEvent::Handler(
-            [this](const AZ::Data::AssetId& defaultMaterialLibrary)
-            {
-                m_configuration.m_materialSelection.OnMaterialLibraryChanged(defaultMaterialLibrary);
-                UpdateMaterialSlotsFromMeshAsset();
-
-                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-                    AzToolsFramework::PropertyModificationRefreshLevel::Refresh_AttributesAndValues);
-            });
-
         AzToolsFramework::Components::EditorComponentBase::Activate();
         AzToolsFramework::EntitySelectionEvents::Bus::Handler::BusConnect(GetEntityId());
         PhysX::MeshColliderComponentRequestsBus::Handler::BusConnect(GetEntityId());
@@ -413,15 +402,15 @@ namespace PhysX
             EditorColliderComponent, ColliderComponentMode>(
                 AZ::EntityComponentIdPair(GetEntityId(), GetId()), nullptr);
 
-        bool usingMaterialsFromAsset = IsAssetConfig() ? m_shapeConfiguration.m_physicsAsset.m_configuration.m_useMaterialsFromAsset : false;
-        m_configuration.m_materialSelection.SetSlotsReadOnly(usingMaterialsFromAsset);
-
         if (ShouldUpdateCollisionMeshFromRender())
         {
             SetCollisionMeshFromRender();
         }
 
-        UpdateMeshAsset();
+        if (IsAssetConfig())
+        {
+            UpdateMeshAsset();
+        }
         UpdateShapeConfigurationScale();
         CreateStaticEditorCollider();
 
@@ -432,7 +421,7 @@ namespace PhysX
     {
         AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusDisconnect();
         m_colliderDebugDraw.Disconnect();
-        AZ::Data::AssetBus::MultiHandler::BusDisconnect();
+        AZ::Data::AssetBus::Handler::BusDisconnect();
         m_nonUniformScaleChangedHandler.Disconnect();
         EditorColliderValidationRequestBus::Handler::BusDisconnect();
         EditorColliderComponentRequestBus::Handler::BusDisconnect();
@@ -454,15 +443,16 @@ namespace PhysX
 
     AZ::u32 EditorColliderComponent::OnConfigurationChanged()
     {
-        if (m_shapeConfiguration.IsAssetConfig())
+        if (IsAssetConfig())
         {
             UpdateMeshAsset();
-            m_configuration.m_materialSelection.SetSlotsReadOnly(m_shapeConfiguration.m_physicsAsset.m_configuration.m_useMaterialsFromAsset);
         }
         else
         {
-            m_configuration.m_materialSelection.SetMaterialSlots(Physics::MaterialSelection::SlotsArray());
-            m_configuration.m_materialSelection.SetSlotsReadOnly(false);
+            AZ::Data::AssetBus::Handler::BusDisconnect(); // Disconnect since the asset is not used anymore
+
+            m_configuration.m_materialSlots.SetSlots(Physics::MaterialDefaultSlot::Default); // Non-asset configs only have the default slot.
+            m_configuration.m_materialSlots.SetSlotsReadOnly(false);
         }
 
         // ensure we refresh the ComponentMode (and Manipulators) when the configuration
@@ -488,13 +478,11 @@ namespace PhysX
         if (auto* physXSystem = GetPhysXSystem())
         {
             physXSystem->RegisterSystemConfigurationChangedEvent(m_physXConfigChangedHandler);
-            physXSystem->RegisterOnMaterialLibraryChangedEventHandler(m_onMaterialLibraryChangedEventHandler);
         }
     }
 
     void EditorColliderComponent::OnDeselected()
     {
-        m_onMaterialLibraryChangedEventHandler.Disconnect();
         m_physXConfigChangedHandler.Disconnect();
     }
 
@@ -590,7 +578,8 @@ namespace PhysX
     {
         if (m_shapeConfiguration.m_physicsAsset.m_pxAsset.GetId().IsValid())
         {
-            AZ::Data::AssetBus::MultiHandler::BusConnect(m_shapeConfiguration.m_physicsAsset.m_pxAsset.GetId());
+            AZ::Data::AssetBus::Handler::BusDisconnect(); // Disconnect in case there was a previous asset being used.
+            AZ::Data::AssetBus::Handler::BusConnect(m_shapeConfiguration.m_physicsAsset.m_pxAsset.GetId());
             m_shapeConfiguration.m_physicsAsset.m_pxAsset.QueueLoad();
             m_shapeConfiguration.m_physicsAsset.m_configuration.m_asset = m_shapeConfiguration.m_physicsAsset.m_pxAsset;
             m_colliderDebugDraw.ClearCachedGeometry();
@@ -689,11 +678,6 @@ namespace PhysX
         return m_shapeConfiguration.m_physicsAsset.m_pxAsset;
     }
 
-    Physics::MaterialId EditorColliderComponent::GetMaterialId() const
-    {
-        return m_configuration.m_materialSelection.GetMaterialId();
-    }
-
     void EditorColliderComponent::SetMeshAsset(const AZ::Data::AssetId& id)
     {
         if (id.IsValid())
@@ -705,17 +689,14 @@ namespace PhysX
         }
     }
 
-    void EditorColliderComponent::SetMaterialId(const Physics::MaterialId& id)
-    {
-        m_configuration.m_materialSelection.SetMaterialId(id);
-    }
-
     void EditorColliderComponent::UpdateMaterialSlotsFromMeshAsset()
     {
-        Physics::PhysicsMaterialRequestBus::Broadcast(
-            &Physics::PhysicsMaterialRequestBus::Events::UpdateMaterialSelectionFromPhysicsAsset,
-            m_shapeConfiguration.GetCurrent(),
-            m_configuration.m_materialSelection);
+        Utils::SetMaterialsFromPhysicsAssetShape(m_shapeConfiguration.GetCurrent(), m_configuration.m_materialSlots);
+
+        if (IsAssetConfig())
+        {
+            m_configuration.m_materialSlots.SetSlotsReadOnly(m_shapeConfiguration.m_physicsAsset.m_configuration.m_useMaterialsFromAsset);
+        }
 
         AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
 
@@ -733,7 +714,7 @@ namespace PhysX
 
         // Here we check the material indices assigned to every shape and validate that every index is used at least once.
         // It's not an error if the validation fails here but something we want to let the designers know about.
-        [[maybe_unused]] size_t materialsNum = physicsAsset->m_assetData.m_materialNames.size();
+        [[maybe_unused]] size_t materialsNum = physicsAsset->m_assetData.m_materialSlots.GetSlotsCount();
         const AZStd::vector<AZ::u16>& indexPerShape = physicsAsset->m_assetData.m_materialIndexPerShape;
 
         AZStd::unordered_set<AZ::u16> usedIndices;
@@ -775,7 +756,6 @@ namespace PhysX
         else
         {
             m_componentWarnings.clear();
-            m_configuration.m_materialSelection.SetMaterialSlots(Physics::MaterialSelection::SlotsArray());
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
                 &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
         }

--- a/Gems/PhysX/Code/Source/EditorColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.h
@@ -100,7 +100,7 @@ namespace PhysX
         , protected DebugDraw::DisplayCallback
         , protected AzToolsFramework::EntitySelectionEvents::Bus::Handler
         , private AzToolsFramework::BoxManipulatorRequestBus::Handler
-        , private AZ::Data::AssetBus::MultiHandler
+        , private AZ::Data::AssetBus::Handler
         , private PhysX::MeshColliderComponentRequestsBus::Handler
         , private AZ::TransformNotificationBus::Handler
         , private PhysX::ColliderShapeRequestBus::Handler
@@ -156,9 +156,7 @@ namespace PhysX
 
         // PhysXMeshColliderComponentRequestBus
         AZ::Data::Asset<Pipeline::MeshAsset> GetMeshAsset() const override;
-        Physics::MaterialId GetMaterialId() const override;
         void SetMeshAsset(const AZ::Data::AssetId& id) override;
-        void SetMaterialId(const Physics::MaterialId& id) override;
         void UpdateMaterialSlotsFromMeshAsset();
 
         // TransformBus
@@ -252,7 +250,6 @@ namespace PhysX
         DebugDraw::Collider m_colliderDebugDraw;
 
         AzPhysics::SystemEvents::OnConfigurationChangedEvent::Handler m_physXConfigChangedHandler;
-        AzPhysics::SystemEvents::OnMaterialLibraryChangedEvent::Handler m_onMaterialLibraryChangedEventHandler;
         AZ::Transform m_cachedWorldTransform;
 
         AZ::NonUniformScaleChangedEvent::Handler m_nonUniformScaleChangedHandler; //!< Responds to changes in non-uniform scale.

--- a/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorHeightfieldColliderComponent.h
@@ -90,13 +90,12 @@ namespace PhysX
             Physics::HeightfieldProviderNotifications::HeightfieldChangeMask changeMask,
             const AZ::Aabb& dirtyRegion = AZ::Aabb::CreateNull());
 
-        void UpdateHeightfieldMaterialSelection(const Physics::MaterialSelection& updatedMaterialSelection);
+        void UpdateHeightfieldMaterialSlots(const Physics::MaterialSlots& updatedMaterialSlots);
 
         DebugDraw::Collider m_colliderDebugDraw; //!< Handles drawing the collider
         AzPhysics::SceneInterface* m_sceneInterface{ nullptr };
 
         AzPhysics::SystemEvents::OnConfigurationChangedEvent::Handler m_physXConfigChangedHandler;
-        AzPhysics::SystemEvents::OnMaterialLibraryChangedEvent::Handler m_onMaterialLibraryChangedEventHandler;
 
         Physics::ColliderConfiguration m_colliderConfig; //!< Stores collision layers, whether the collider is a trigger, etc.
         AZStd::shared_ptr<Physics::HeightfieldShapeConfiguration> m_shapeConfig{ new Physics::HeightfieldShapeConfiguration() };

--- a/Gems/PhysX/Code/Source/EditorShapeColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorShapeColliderComponent.cpp
@@ -41,15 +41,6 @@ namespace PhysX
                 AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
                     AzToolsFramework::PropertyModificationRefreshLevel::Refresh_AttributesAndValues);
             })
-        , m_onMaterialLibraryChangedEventHandler(
-            [this](const AZ::Data::AssetId& defaultMaterialLibrary)
-            {
-                m_colliderConfig.m_materialSelection.OnMaterialLibraryChanged(defaultMaterialLibrary);
-                Physics::ColliderComponentEventBus::Event(GetEntityId(), &Physics::ColliderComponentEvents::OnColliderChanged);
-
-                AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-                    AzToolsFramework::PropertyModificationRefreshLevel::Refresh_AttributesAndValues);
-            })
         , m_nonUniformScaleChangedHandler([this](const AZ::Vector3& scale) {OnNonUniformScaleChanged(scale);})
     {
         m_colliderConfig.SetPropertyVisibility(Physics::ColliderConfiguration::Offset, false);
@@ -311,7 +302,7 @@ namespace PhysX
 
     AZ::u32 EditorShapeColliderComponent::OnConfigurationChanged()
     {
-        m_colliderConfig.m_materialSelection.SetMaterialSlots(Physics::MaterialSelection::SlotsArray());
+        m_colliderConfig.m_materialSlots.SetSlots(Physics::MaterialDefaultSlot::Default);
         CreateStaticEditorCollider();
         return AZ::Edit::PropertyRefreshLevels::None;
     }
@@ -740,16 +731,11 @@ namespace PhysX
             {
                 physXSystem->RegisterSystemConfigurationChangedEvent(m_physXConfigChangedHandler);
             }
-            if (!m_onMaterialLibraryChangedEventHandler.IsConnected())
-            {
-                physXSystem->RegisterOnMaterialLibraryChangedEventHandler(m_onMaterialLibraryChangedEventHandler);
-            }
         }
     }
 
     void EditorShapeColliderComponent::OnDeselected()
     {
-        m_onMaterialLibraryChangedEventHandler.Disconnect();
         m_physXConfigChangedHandler.Disconnect();
     }
 

--- a/Gems/PhysX/Code/Source/EditorShapeColliderComponent.h
+++ b/Gems/PhysX/Code/Source/EditorShapeColliderComponent.h
@@ -164,7 +164,6 @@ namespace PhysX
         AZStd::optional<bool> m_previousSingleSided; //!< Stores the previous single sided setting when unable to support single-sided shapes (such as when used with a dynamic rigid body).
 
         AzPhysics::SystemEvents::OnConfigurationChangedEvent::Handler m_physXConfigChangedHandler;
-        AzPhysics::SystemEvents::OnMaterialLibraryChangedEvent::Handler m_onMaterialLibraryChangedEventHandler;
         AZ::Transform m_cachedWorldTransform;
         AZ::NonUniformScaleChangedEvent::Handler m_nonUniformScaleChangedHandler; //!< Responds to changes in non-uniform scale.
         AZ::Vector3 m_currentNonUniformScale = AZ::Vector3::CreateOne(); //!< Caches the current non-uniform scale.

--- a/Gems/PhysX/Code/Source/HeightfieldColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/HeightfieldColliderComponent.cpp
@@ -142,7 +142,7 @@ namespace PhysX
 
         // Update material selection from the mapping
         Physics::ColliderConfiguration* colliderConfig = m_shapeConfig.first.get();
-        Utils::SetMaterialsFromHeightfieldProvider(GetEntityId(), colliderConfig->m_materialSelection);
+        Utils::SetMaterialsFromHeightfieldProvider(GetEntityId(), colliderConfig->m_materialSlots);
     }
 
     void HeightfieldColliderComponent::RefreshHeightfield( 

--- a/Gems/PhysX/Code/Source/Joint/PhysXJointUtils.cpp
+++ b/Gems/PhysX/Code/Source/Joint/PhysXJointUtils.cpp
@@ -197,6 +197,8 @@ namespace PhysX::Utils
                 return nullptr;
             }
 
+            PHYSX_SCENE_WRITE_LOCK(actorData.parentActor->getScene());
+
             const physx::PxTransform parentWorldTransform =
                 actorData.parentActor ? actorData.parentActor->getGlobalPose() : physx::PxTransform(physx::PxIdentity);
             const physx::PxTransform childWorldTransform =

--- a/Gems/PhysX/Code/Source/Material.cpp
+++ b/Gems/PhysX/Code/Source/Material.cpp
@@ -405,7 +405,7 @@ namespace PhysX
         }
 
         // Set the slots from the mesh asset
-        materialSelection.SetMaterialSlots(meshAsset->m_assetData.m_materialNames);
+        materialSelection.SetMaterialSlots(meshAsset->m_assetData.m_materialSlots.GetSlotsNames());
 
         if (!assetConfiguration.m_useMaterialsFromAsset)
         {
@@ -414,7 +414,7 @@ namespace PhysX
         }
 
         // Update material IDs in the selection for each slot
-        const AZStd::vector<AZStd::string>& physicsMaterialNames = meshAsset->m_assetData.m_physicsMaterialNames;
+        /*const AZStd::vector<AZStd::string>& physicsMaterialNames = meshAsset->m_assetData.m_physicsMaterialNames;
         for (size_t slotIndex = 0; slotIndex < physicsMaterialNames.size(); ++slotIndex)
         {
             const AZStd::string& physicsMaterialNameFromPhysicsAsset = physicsMaterialNames[slotIndex];
@@ -438,7 +438,7 @@ namespace PhysX
                     meshAsset->m_assetData.m_materialNames[slotIndex].c_str());
                 materialSelection.SetMaterialId(Physics::MaterialId(), static_cast<int>(slotIndex));
             }
-        }
+        }*/
     }
 
     AZStd::shared_ptr<Physics::Material> MaterialsManager::GetGenericDefaultMaterial()

--- a/Gems/PhysX/Code/Source/MeshColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/MeshColliderComponent.cpp
@@ -68,20 +68,10 @@ namespace PhysX
             AZ::Data::AssetLoadBehavior::Default);
     }
 
-    Physics::MaterialId MeshColliderComponent::GetMaterialId() const
-    {
-        return m_colliderConfiguration->m_materialSelection.GetMaterialId();
-    }
-
     void MeshColliderComponent::SetMeshAsset(const AZ::Data::AssetId& id)
     {
         m_shapeConfiguration->m_asset.Create(id);
         UpdateMeshAsset();
-    }
-
-    void MeshColliderComponent::SetMaterialId(const Physics::MaterialId& id)
-    {
-        m_colliderConfiguration->m_materialSelection.SetMaterialId(id);
     }
 
     void MeshColliderComponent::UpdateMeshAsset()
@@ -100,10 +90,7 @@ namespace PhysX
         {
             m_shapeConfiguration->m_asset = asset;
 
-            Physics::PhysicsMaterialRequestBus::Broadcast(
-                &Physics::PhysicsMaterialRequestBus::Events::UpdateMaterialSelectionFromPhysicsAsset,
-                *m_shapeConfiguration,
-                m_colliderConfiguration->m_materialSelection);
+            Utils::SetMaterialsFromPhysicsAssetShape(*m_shapeConfiguration, m_colliderConfiguration->m_materialSlots);
         }
     }
 
@@ -113,10 +100,7 @@ namespace PhysX
         {
             m_shapeConfiguration->m_asset = asset;
 
-            Physics::PhysicsMaterialRequestBus::Broadcast(
-                &Physics::PhysicsMaterialRequestBus::Events::UpdateMaterialSelectionFromPhysicsAsset,
-                *m_shapeConfiguration,
-                m_colliderConfiguration->m_materialSelection);
+            Utils::SetMaterialsFromPhysicsAssetShape(*m_shapeConfiguration, m_colliderConfiguration->m_materialSlots);
         }
     }
 

--- a/Gems/PhysX/Code/Source/MeshColliderComponent.h
+++ b/Gems/PhysX/Code/Source/MeshColliderComponent.h
@@ -34,9 +34,7 @@ namespace PhysX
 
         // MeshColliderComponentRequestsBus
         AZ::Data::Asset<Pipeline::MeshAsset> GetMeshAsset() const override;
-        Physics::MaterialId GetMaterialId() const override;
         void SetMeshAsset(const AZ::Data::AssetId& id) override;
-        void SetMaterialId(const Physics::MaterialId& id) override;
 
         // BaseColliderComponent
         void UpdateScaleForShapeConfigs() override;

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.cpp
@@ -380,7 +380,6 @@ namespace PhysX
         }
 
         m_pxController = nullptr;
-        m_material = nullptr;
     }
 
     // Physics::Character

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.h
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterController.h
@@ -237,7 +237,6 @@ namespace PhysX
         PhysX::ActorData m_actorUserData; ///< Used to populate the user data on the PxActor associated with the controller.
         physx::PxFilterData m_filterData; ///< Controls filtering for collisions with other objects and scene queries.
         physx::PxControllerFilters m_pxControllerFilters; ///< Controls which objects the controller interacts with when moving.
-        AZStd::shared_ptr<Physics::Material> m_material; ///< The generic physics API material for the controller.
         AZStd::shared_ptr<Physics::Shape> m_shape; ///< The generic physics API shape associated with the controller.
         AzPhysics::RigidBody* m_shadowBody = nullptr; ///< A kinematic-synchronised rigid body used to store additional colliders.
         AzPhysics::SimulatedBodyHandle m_shadowBodyHandle = AzPhysics::InvalidSimulatedBodyHandle; //!<A handle to the shadow body.

--- a/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterUtils.cpp
+++ b/Gems/PhysX/Code/Source/PhysXCharacters/API/CharacterUtils.cpp
@@ -16,10 +16,10 @@
 #include <Source/RigidBody.h>
 #include <Source/Scene/PhysXScene.h>
 #include <Source/Shape.h>
+#include <PhysX/Material/PhysXMaterial.h>
 
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzCore/Interface/Interface.h>
-#include <AzFramework/Physics/MaterialBus.h>
 
 #include <cfloat>
 
@@ -45,37 +45,10 @@ namespace PhysX::Utils::Characters
     static void AppendShapeIndependentProperties(physx::PxControllerDesc& controllerDesc,
         const Physics::CharacterConfiguration& characterConfig, CharacterControllerCallbackManager* callbackManager)
     {
-        AZStd::vector<AZStd::shared_ptr<Physics::Material>> materials;
+        AZStd::vector<AZStd::shared_ptr<Material2>> materials = Material2::FindOrCreateMaterials(characterConfig.m_materialSlots);
+        AZ_Assert(!materials.empty(), "Material list is empty, it should at least include the default material.");
 
-        if (characterConfig.m_materialSelection.GetMaterialIdsAssignedToSlots().empty())
-        {
-            // If material selection has no slots, falling back to default material.
-            AZStd::shared_ptr<Physics::Material> defaultMaterial;
-            Physics::PhysicsMaterialRequestBus::BroadcastResult(defaultMaterial,
-                &Physics::PhysicsMaterialRequestBus::Events::GetGenericDefaultMaterial);
-            if (!defaultMaterial)
-            {
-                AZ_Error("PhysX Character Controller", false, "Invalid default material.");
-                return;
-            }
-            materials.push_back(AZStd::move(defaultMaterial));
-        }
-        else
-        {
-            Physics::PhysicsMaterialRequestBus::Broadcast(
-                &Physics::PhysicsMaterialRequestBus::Events::GetMaterials,
-                characterConfig.m_materialSelection,
-                materials);
-            if (materials.empty())
-            {
-                AZ_Error("PhysX Character Controller", false, "Could not create character controller, material list was empty.");
-                return;
-            }
-        }
-
-        physx::PxMaterial* pxMaterial = static_cast<physx::PxMaterial*>(materials.front()->GetNativePointer());
-
-        controllerDesc.material = pxMaterial;
+        controllerDesc.material = const_cast<physx::PxMaterial*>(materials.front()->GetPxMaterial());
         controllerDesc.position = PxMathConvertExtended(characterConfig.m_position);
         controllerDesc.slopeLimit = cosf(AZ::DegToRad(characterConfig.m_maximumSlopeAngle));
         controllerDesc.stepOffset = characterConfig.m_stepHeight;

--- a/Gems/PhysX/Code/Source/Pipeline/MeshAssetHandler.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshAssetHandler.cpp
@@ -145,9 +145,9 @@ namespace PhysX
                 serializeContext->ClassDeprecate("MeshAssetCookedData", "{82955F2F-4DA1-4AEF-ACEF-0AE16BA20EF4}");
 
                 serializeContext->Class<MeshAssetData>()
+                    ->Version(2)
                     ->Field("ColliderShapes", &MeshAssetData::m_colliderShapes)
-                    ->Field("SurfaceNames", &MeshAssetData::m_materialNames)
-                    ->Field("MaterialNames", &MeshAssetData::m_physicsMaterialNames)
+                    ->Field("MaterialSlots", &MeshAssetData::m_materialSlots)
                     ->Field("MaterialIndexPerShape", &MeshAssetData::m_materialIndexPerShape)
                     ;
             }

--- a/Gems/PhysX/Code/Source/Pipeline/MeshExporter.h
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshExporter.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
+
 #include <SceneAPI/SceneCore/Components/ExportingComponent.h>
 
 namespace AZ
@@ -76,12 +78,11 @@ namespace PhysX
                 const MeshGroup& meshGroup,
                 const AZ::SceneAPI::Containers::SceneGraph& sceneGraph);
 
-            //! Function to update a list of materials and physics materials from a new list.
+            //! Function to update a list of physics material slots from a new list.
             //! All those new materials not found in the previous list will fallback to default physics material.
-            bool UpdateAssetPhysicsMaterials(
+            void UpdateAssetPhysicsMaterials(
                 const AZStd::vector<AZStd::string>& newMaterials,
-                AZStd::vector<AZStd::string>& materials,
-                AZStd::vector<AZStd::string>& physicsMaterials);
+                Physics::MaterialSlots& physicsMaterialSlots);
         } // namespace Utils
     } // namespace Pipeline
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/Pipeline/MeshGroup.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshGroup.cpp
@@ -10,7 +10,7 @@
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
-#include <AzFramework/Physics/PhysicsSystem.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 #include <SceneAPI/SceneCore/DataTypes/Rules/IRule.h>
 #include <SceneAPI/SceneCore/DataTypes/GraphData/IBoneData.h>
@@ -20,7 +20,6 @@
 
 #include <Source/Pipeline/MeshGroup.h>
 #include <Source/Pipeline/MeshExporter.h>
-#include <Source/Material.h>
 
 #include <PxPhysicsAPI.h>
 
@@ -576,21 +575,11 @@ namespace PhysX
 
         MeshGroup::MeshGroup()
             : m_id(AZ::Uuid::CreateRandom())
-            , m_materialLibraryChangedHandler(
-                [this](const AZ::Data::AssetId& materialLibraryAssetId)
-                {
-                    OnMaterialLibraryChanged(materialLibraryAssetId);
-                })
         {
-            if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
-            {
-                physicsSystem->RegisterOnMaterialLibraryChangedEventHandler(m_materialLibraryChangedHandler);
-            }
         }
 
         MeshGroup::~MeshGroup()
         {
-            m_materialLibraryChangedHandler.Disconnect();
         }
 
         void MeshGroup::Reflect(AZ::ReflectContext* context)
@@ -605,7 +594,7 @@ namespace PhysX
                 serializeContext
             )
             {
-                serializeContext->Class<MeshGroup, AZ::SceneAPI::DataTypes::ISceneNodeGroup>()->Version(2, &MeshGroup::VersionConverter)
+                serializeContext->Class<MeshGroup, AZ::SceneAPI::DataTypes::ISceneNodeGroup>()->Version(4, &MeshGroup::VersionConverter)
                     ->Field("id", &MeshGroup::m_id)
                     ->Field("name", &MeshGroup::m_name)
                     ->Field("NodeSelectionList", &MeshGroup::m_nodeSelectionList)
@@ -615,8 +604,7 @@ namespace PhysX
                     ->Field("PrimitiveAssetParams", &MeshGroup::m_primitiveAssetParams)
                     ->Field("DecomposeMeshes", &MeshGroup::m_decomposeMeshes)
                     ->Field("ConvexDecompositionParams", &MeshGroup::m_convexDecompositionParams)
-                    ->Field("MaterialSlots", &MeshGroup::m_materialSlots)
-                    ->Field("PhysicsMaterials", &MeshGroup::m_physicsMaterials)
+                    ->Field("PhysicsMaterialSlots", &MeshGroup::m_physicsMaterialSlots)
                     ->Field("rules", &MeshGroup::m_rules);
 
                 if (
@@ -674,13 +662,8 @@ namespace PhysX
                             ->Attribute(AZ::Edit::Attributes::Visibility, &MeshGroup::GetDecomposeMeshes)
                             ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
 
-                        ->DataElement(AZ::Edit::UIHandlers::Default, &MeshGroup::m_physicsMaterials, "Physics Materials",
-                            "<span>Configure which physics materials to use for each element.</span>")
-                            ->Attribute(AZ::Edit::Attributes::IndexedChildNameLabelOverride, &MeshGroup::GetMaterialSlotLabel)
-                            ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                            ->Attribute(AZ::Edit::Attributes::ContainerCanBeModified, false)
-                            ->ElementAttribute(AZ::Edit::UIHandlers::Handler, AZ::Edit::UIHandlers::ComboBox)
-                            ->ElementAttribute(AZ::Edit::Attributes::StringList, &MeshGroup::GetPhysicsMaterialNames)
+                        ->DataElement(AZ::Edit::UIHandlers::Default, &MeshGroup::m_physicsMaterialSlots, "", "")
+                            ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
 
                         ->DataElement(AZ::Edit::UIHandlers::Default, &MeshGroup::m_rules, "",
                             "Add or remove rules to fine-tune the export process.")
@@ -734,14 +717,9 @@ namespace PhysX
             return (GetExportAsConvex() || GetExportAsPrimitive()) && m_decomposeMeshes;
         }
 
-        const AZStd::vector<AZStd::string>& MeshGroup::GetPhysicsMaterials() const
+        const Physics::MaterialSlots& MeshGroup::GetMaterialSlots() const
         {
-            return m_physicsMaterials;
-        }
-
-        const AZStd::vector<AZStd::string>& MeshGroup::GetMaterialSlots() const
-        {
-            return m_materialSlots;
+            return m_physicsMaterialSlots;
         }
 
         void MeshGroup::SetSceneGraph(const AZ::SceneAPI::Containers::SceneGraph* graph)
@@ -762,7 +740,7 @@ namespace PhysX
                 return;
             }
 
-            Utils::UpdateAssetPhysicsMaterials(assetMaterialData->m_sourceSceneMaterialNames, m_materialSlots, m_physicsMaterials);
+            Utils::UpdateAssetPhysicsMaterials(assetMaterialData->m_sourceSceneMaterialNames, m_physicsMaterialSlots);
         }
 
         AZ::SceneAPI::Containers::RuleContainer& MeshGroup::GetRuleContainer()
@@ -846,48 +824,6 @@ namespace PhysX
         bool MeshGroup::GetDecomposeMeshesVisibility() const
         {
             return GetExportAsConvex() || GetExportAsPrimitive();
-        }
-
-        AZStd::string MeshGroup::GetMaterialSlotLabel(int index) const
-        {
-            if (index < m_materialSlots.size())
-            {
-                return m_materialSlots[index];
-            }
-            else
-            {
-                return "<Unknown>";
-            }
-        }
-
-        AZStd::vector<AZStd::string> MeshGroup::GetPhysicsMaterialNames() const
-        {
-            if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
-            {
-                if (const auto* physicsConfiguration = physicsSystem->GetConfiguration();
-                    physicsConfiguration && physicsConfiguration->m_materialLibraryAsset)
-                {
-                    const auto& materials = physicsConfiguration->m_materialLibraryAsset->GetMaterialsData();
-
-                    AZStd::vector<AZStd::string> physicsMaterialNames;
-                    physicsMaterialNames.reserve(materials.size() + 1);
-
-                    physicsMaterialNames.emplace_back(Physics::DefaultPhysicsMaterialLabel);
-                    for (const auto& material : materials)
-                    {
-                        physicsMaterialNames.emplace_back(material.m_configuration.m_surfaceType);
-                    }
-
-                    return physicsMaterialNames;
-                }
-            }
-            return {Physics::DefaultPhysicsMaterialLabel};
-        }
-
-        void MeshGroup::OnMaterialLibraryChanged([[maybe_unused]] const AZ::Data::AssetId& materialLibraryAssetId)
-        {
-            AzToolsFramework::PropertyEditorGUIMessages::Bus::Broadcast(&AzToolsFramework::PropertyEditorGUIMessages::RequestRefresh,
-                AzToolsFramework::PropertyModificationRefreshLevel::Refresh_AttributesAndValues);
         }
 
         bool MeshGroup::VersionConverter(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement)

--- a/Gems/PhysX/Code/Source/Pipeline/MeshGroup.h
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshGroup.h
@@ -187,8 +187,7 @@ namespace PhysX
             bool GetExportAsTriMesh() const;
             bool GetExportAsPrimitive() const;
             bool GetDecomposeMeshes() const;
-            const AZStd::vector<AZStd::string>& GetPhysicsMaterials() const;
-            const AZStd::vector<AZStd::string>& GetMaterialSlots() const;
+            const Physics::MaterialSlots& GetMaterialSlots() const;
 
             void SetSceneGraph(const AZ::SceneAPI::Containers::SceneGraph* graph);
             void UpdateMaterialSlots();
@@ -220,11 +219,6 @@ namespace PhysX
 
             bool GetDecomposeMeshesVisibility() const;
 
-            AZStd::string GetMaterialSlotLabel(int index) const;
-            AZStd::vector<AZStd::string> GetPhysicsMaterialNames() const;
-
-            void OnMaterialLibraryChanged(const AZ::Data::AssetId& materialLibraryAssetId);
-
             AZ::Uuid m_id{};
             AZStd::string m_name{};
             AZ::SceneAPI::SceneData::SceneNodeSelectionList m_nodeSelectionList{};
@@ -235,12 +229,9 @@ namespace PhysX
             PrimitiveAssetParams m_primitiveAssetParams{};
             ConvexDecompositionParams m_convexDecompositionParams{};
             AZ::SceneAPI::Containers::RuleContainer m_rules{};
-            AZStd::vector<AZStd::string> m_materialSlots;
-            AZStd::vector<AZStd::string> m_physicsMaterials;
+            Physics::MaterialSlots m_physicsMaterialSlots;
 
             const AZ::SceneAPI::Containers::SceneGraph* m_graph = nullptr;
-            
-            AzPhysics::SystemEvents::OnMaterialLibraryChangedEvent::Handler m_materialLibraryChangedHandler;
         };
     }
 }

--- a/Gems/PhysX/Code/Source/Shape.h
+++ b/Gems/PhysX/Code/Source/Shape.h
@@ -18,12 +18,12 @@
 
 namespace Physics
 {
-    class Material;
+    class Material2;
 }
 
 namespace PhysX
 {
-    class Material;
+    class Material2;
 
     class Shape
         : public Physics::Shape
@@ -44,13 +44,11 @@ namespace PhysX
 
         physx::PxShape* GetPxShape();
 
-        void SetMaterial(const AZStd::shared_ptr<Physics::Material>& material) override;
-        AZStd::shared_ptr<Physics::Material> GetMaterial() const override;
+        void SetMaterial(const AZStd::shared_ptr<Physics::Material2>& material) override;
+        AZStd::shared_ptr<Physics::Material2> GetMaterial() const override;
 
-        void SetMaterials(const AZStd::vector<AZStd::shared_ptr<Physics::Material>>& materials);
-
-        void SetMaterials(const AZStd::vector<AZStd::shared_ptr<PhysX::Material>>& materials);
-        const AZStd::vector<AZStd::shared_ptr<PhysX::Material>>& GetMaterials();
+        void SetMaterials(const AZStd::vector<AZStd::shared_ptr<PhysX::Material2>>& materials);
+        const AZStd::vector<AZStd::shared_ptr<PhysX::Material2>>& GetMaterials();
 
         void SetCollisionLayer(const AzPhysics::CollisionLayer& layer) override;
         AzPhysics::CollisionLayer GetCollisionLayer() const override;
@@ -106,7 +104,7 @@ namespace PhysX
         Shape() = default;
 
         PxShapeUniquePtr m_pxShape;
-        AZStd::vector<AZStd::shared_ptr<PhysX::Material>> m_materials;
+        AZStd::vector<AZStd::shared_ptr<PhysX::Material2>> m_materials;
         AzPhysics::CollisionLayer m_collisionLayer;
         AzPhysics::CollisionGroup m_collisionGroup;
         AZ::Crc32 m_tag;

--- a/Gems/PhysX/Code/Source/SystemComponent.h
+++ b/Gems/PhysX/Code/Source/SystemComponent.h
@@ -79,7 +79,7 @@ namespace PhysX
         physx::PxFilterData CreateFilterData(const AzPhysics::CollisionLayer& layer, const AzPhysics::CollisionGroup& group) override;
         physx::PxCooking* GetCooking() override;
 
-        // Physics::SystemRequestBus::Handler overrides...
+        // Physics::SystemRequestBus overrides...
         AZStd::shared_ptr<Physics::Shape> CreateShape(const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& configuration) override;
         void ReleaseNativeMeshObject(void* nativeMeshObject) override;
         void ReleaseNativeHeightfieldObject(void* nativeHeightfieldObject) override;

--- a/Gems/PhysX/Code/Source/SystemComponent.h
+++ b/Gems/PhysX/Code/Source/SystemComponent.h
@@ -19,7 +19,6 @@
 #include <AzFramework/Physics/Shape.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <AzFramework/Physics/SystemBus.h>
-#include <AzFramework/Physics/Material.h>
 #include <AzFramework/Physics/CollisionBus.h>
 #include <AzFramework/Physics/Configuration/CollisionConfiguration.h>
 #include <AzFramework/Physics/Collision/CollisionGroups.h>
@@ -30,7 +29,6 @@
 #include <PhysX/Configuration/PhysXConfiguration.h>
 #include <Configuration/PhysXSettingsRegistryManager.h>
 #include <DefaultWorldComponent.h>
-#include <Material.h>
 
 namespace AzPhysics
 {
@@ -41,6 +39,7 @@ namespace AzPhysics
 
 namespace PhysX
 {
+    class MaterialManager;
     class WindProvider;
     class PhysXSystem;
 
@@ -72,27 +71,26 @@ namespace PhysX
     protected:
         SystemComponent(const SystemComponent&) = delete;
 
-        // SystemRequestsBus
+        // SystemRequestsBus overrides...
         physx::PxConvexMesh* CreateConvexMesh(const void* vertices, AZ::u32 vertexNum, AZ::u32 vertexStride) override; // should we use AZ::Vector3* or physx::PxVec3 here?
         physx::PxConvexMesh* CreateConvexMeshFromCooked(const void* cookedMeshData, AZ::u32 bufferSize) override;
         physx::PxTriangleMesh* CreateTriangleMeshFromCooked(const void* cookedMeshData, AZ::u32 bufferSize) override;
         physx::PxHeightField* CreateHeightField(const physx::PxHeightFieldSample* samples, AZ::u32 numRows, AZ::u32 numColumns) override;
-
-
-        bool CookConvexMeshToFile(const AZStd::string& filePath, const AZ::Vector3* vertices, AZ::u32 vertexCount) override;
-        
-        bool CookConvexMeshToMemory(const AZ::Vector3* vertices, AZ::u32 vertexCount, AZStd::vector<AZ::u8>& result) override;
-
-        bool CookTriangleMeshToFile(const AZStd::string& filePath, const AZ::Vector3* vertices, AZ::u32 vertexCount,
-            const AZ::u32* indices, AZ::u32 indexCount) override;
-
-        bool CookTriangleMeshToMemory(const AZ::Vector3* vertices, AZ::u32 vertexCount,
-            const AZ::u32* indices, AZ::u32 indexCount, AZStd::vector<AZ::u8>& result) override;
-
         physx::PxFilterData CreateFilterData(const AzPhysics::CollisionLayer& layer, const AzPhysics::CollisionGroup& group) override;
         physx::PxCooking* GetCooking() override;
 
-        // CollisionRequestBus
+        // Physics::SystemRequestBus::Handler overrides...
+        AZStd::shared_ptr<Physics::Shape> CreateShape(const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& configuration) override;
+        void ReleaseNativeMeshObject(void* nativeMeshObject) override;
+        void ReleaseNativeHeightfieldObject(void* nativeHeightfieldObject) override;
+        bool CookConvexMeshToFile(const AZStd::string& filePath, const AZ::Vector3* vertices, AZ::u32 vertexCount) override;
+        bool CookConvexMeshToMemory(const AZ::Vector3* vertices, AZ::u32 vertexCount, AZStd::vector<AZ::u8>& result) override;
+        bool CookTriangleMeshToFile(const AZStd::string& filePath, const AZ::Vector3* vertices, AZ::u32 vertexCount,
+            const AZ::u32* indices, AZ::u32 indexCount) override;
+        bool CookTriangleMeshToMemory(const AZ::Vector3* vertices, AZ::u32 vertexCount,
+            const AZ::u32* indices, AZ::u32 indexCount, AZStd::vector<AZ::u8>& result) override;
+
+        // CollisionRequestBus overrides...
         AzPhysics::CollisionLayer GetCollisionLayerByName(const AZStd::string& layerName) override;
         AZStd::string GetCollisionLayerName(const AzPhysics::CollisionLayer& layer) override;
         bool TryGetCollisionLayerByName(const AZStd::string& layerName, AzPhysics::CollisionLayer& layer) override;
@@ -103,26 +101,18 @@ namespace PhysX
         void SetCollisionLayerName(int index, const AZStd::string& layerName) override;
         void CreateCollisionGroup(const AZStd::string& groupName, const AzPhysics::CollisionGroup& group) override;
 
-        // AZ::Component interface implementation
+        // AZ::Component overrides...
         void Init() override;
         void Activate() override;
         void Deactivate() override;
 
-        // Physics::SystemRequestBus::Handler
-        AZStd::shared_ptr<Physics::Shape> CreateShape(const Physics::ColliderConfiguration& colliderConfiguration, const Physics::ShapeConfiguration& configuration) override;
-        AZStd::shared_ptr<Physics::Material> CreateMaterial(const Physics::MaterialConfiguration& materialConfiguration) override;
-
-        void ReleaseNativeMeshObject(void* nativeMeshObject) override;
-        void ReleaseNativeHeightfieldObject(void* nativeHeightfieldObject) override;
-
         // Assets related data
         AZStd::vector<AZStd::unique_ptr<AZ::Data::AssetHandler>> m_assetHandlers;
-        PhysX::MaterialsManager m_materialManager;
 
         static bool VersionConverter(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement);
 
     private:
-        // AZ::TickBus::Handler ...
+        // AZ::TickBus::Handler overrides...
         void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
         int GetTickOrder() override;
 
@@ -132,6 +122,7 @@ namespace PhysX
 
         bool m_enabled; ///< If false, this component will not activate itself in the Activate() function.
 
+        AZStd::unique_ptr<MaterialManager> m_materialManager;
         AZStd::unique_ptr<WindProvider> m_windProvider;
         DefaultWorldComponent m_defaultWorldComponent;
         AZ::Interface<Physics::CollisionRequests> m_collisionRequests;

--- a/Gems/PhysX/Code/Source/Utils.cpp
+++ b/Gems/PhysX/Code/Source/Utils.cpp
@@ -40,6 +40,7 @@
 #include <Source/StaticRigidBodyComponent.h>
 #include <Source/RigidBodyStatic.h>
 #include <Source/Utils.h>
+#include <PhysX/Material/PhysXMaterial.h>
 #include <PhysX/PhysXLocks.h>
 #include <PhysX/Joint/Configuration/PhysXJointConfiguration.h>
 #include <PhysX/MathConversion.h>
@@ -353,86 +354,78 @@ namespace PhysX
         physx::PxShape* CreatePxShapeFromConfig(const Physics::ColliderConfiguration& colliderConfiguration,
             const Physics::ShapeConfiguration& shapeConfiguration, AzPhysics::CollisionGroup& assignedCollisionGroup)
         {
-            AZStd::vector<physx::PxMaterial*> materials;
-            MaterialManagerRequestsBus::Broadcast(&MaterialManagerRequestsBus::Events::GetPxMaterials, colliderConfiguration.m_materialSelection, materials);
-
-            if (materials.empty())
-            {
-                AZStd::shared_ptr<Material> defaultMaterial = nullptr;
-                MaterialManagerRequestsBus::BroadcastResult(defaultMaterial, &MaterialManagerRequestsBus::Events::GetDefaultMaterial);
-                if (!defaultMaterial)
-                {
-                    AZ_Error("PhysX", false, "Material array can't be empty!");
-                    return nullptr;
-                }
-                materials.push_back(defaultMaterial->GetPxMaterial());
-            }
-
             physx::PxGeometryHolder pxGeomHolder;
-            if (Utils::CreatePxGeometryFromConfig(shapeConfiguration, pxGeomHolder))
+            if (!Utils::CreatePxGeometryFromConfig(shapeConfiguration, pxGeomHolder))
             {
-                auto materialsCount = static_cast<physx::PxU16>(materials.size());
-
-                physx::PxShape* shape = PxGetPhysics().createShape(pxGeomHolder.any(), materials.begin(), materialsCount, colliderConfiguration.m_isExclusive);
-
-                if (shape)
-                {
-                    AzPhysics::CollisionGroup collisionGroup;
-                    Physics::CollisionRequestBus::BroadcastResult(collisionGroup, &Physics::CollisionRequests::GetCollisionGroupById, colliderConfiguration.m_collisionGroupId);
-
-                    physx::PxFilterData filterData = PhysX::Collision::CreateFilterData(colliderConfiguration.m_collisionLayer, collisionGroup);
-                    shape->setSimulationFilterData(filterData);
-                    shape->setQueryFilterData(filterData);
-
-                    // Do custom logic for specific shape types
-                    if (pxGeomHolder.getType() == physx::PxGeometryType::eCAPSULE)
-                    {
-                        // PhysX capsules are oriented around x by default.
-                        physx::PxQuat pxQuat(AZ::Constants::HalfPi, physx::PxVec3(0.0f, 1.0f, 0.0f));
-                        shape->setLocalPose(physx::PxTransform(pxQuat));
-                    }
-                    else if (pxGeomHolder.getType() == physx::PxGeometryType::eHEIGHTFIELD)
-                    {
-                        const Physics::HeightfieldShapeConfiguration& heightfieldConfig =
-                            static_cast<const Physics::HeightfieldShapeConfiguration&>(shapeConfiguration);
-
-                        // PhysX heightfields have the origin at the corner, not the center, so add an offset to the passed-in transform
-                        // to account for this difference.
-                        const AZ::Vector2 gridSpacing = heightfieldConfig.GetGridResolution();
-                        AZ::Vector3 offset(
-                            -(gridSpacing.GetX() * heightfieldConfig.GetNumColumns() / 2.0f),
-                            -(gridSpacing.GetY() * heightfieldConfig.GetNumRows() / 2.0f),
-                            0.0f);
-
-                        // PhysX heightfields are always defined to have the height in the Y direction, not the Z direction, so we need
-                        // to provide additional rotations to make it Z-up.
-                        physx::PxQuat pxQuat = PxMathConvert(
-                            AZ::Quaternion::CreateFromEulerAnglesRadians(AZ::Vector3(AZ::Constants::HalfPi, AZ::Constants::HalfPi, 0.0f)));
-                        physx::PxTransform pxHeightfieldTransform = physx::PxTransform(PxMathConvert(offset), pxQuat);
-                        shape->setLocalPose(pxHeightfieldTransform);
-                    }
-
-                    // Handle a possible misconfiguration when a shape is set to be both simulated & trigger. This is illegal in PhysX.
-                    shape->setFlag(physx::PxShapeFlag::eSIMULATION_SHAPE, colliderConfiguration.m_isSimulated && !colliderConfiguration.m_isTrigger);
-                    shape->setFlag(physx::PxShapeFlag::eSCENE_QUERY_SHAPE, colliderConfiguration.m_isInSceneQueries);
-                    shape->setFlag(physx::PxShapeFlag::eTRIGGER_SHAPE, colliderConfiguration.m_isTrigger);
-
-                    shape->setRestOffset(colliderConfiguration.m_restOffset);
-                    shape->setContactOffset(colliderConfiguration.m_contactOffset);
-
-                    physx::PxTransform pxShapeTransform = PxMathConvert(colliderConfiguration.m_position, colliderConfiguration.m_rotation);
-                    shape->setLocalPose(pxShapeTransform * shape->getLocalPose());
-
-                    assignedCollisionGroup = collisionGroup;
-                    return shape;
-                }
-                else
-                {
-                    AZ_Error("PhysX Rigid Body", false, "Failed to create shape.");
-                    return nullptr;
-                }
+                return nullptr;
             }
-            return nullptr;
+
+            AZStd::vector<AZStd::shared_ptr<Material2>> materials = Material2::FindOrCreateMaterials(colliderConfiguration.m_materialSlots);
+            AZStd::vector<const physx::PxMaterial*> pxMaterials(materials.size(), nullptr);
+            for (size_t materialIndex = 0; materialIndex < materials.size(); ++materialIndex)
+            {
+                pxMaterials[materialIndex] = materials[materialIndex]->GetPxMaterial();
+            }
+
+            physx::PxShape* shape = PxGetPhysics().createShape(
+                pxGeomHolder.any(),
+                const_cast<physx::PxMaterial**>(pxMaterials.data()),
+                static_cast<physx::PxU16>(pxMaterials.size()),
+                colliderConfiguration.m_isExclusive);
+            if (!shape)
+            {
+                AZ_Error("PhysX Rigid Body", false, "Failed to create shape.");
+                return nullptr;
+            }
+
+            AzPhysics::CollisionGroup collisionGroup;
+            Physics::CollisionRequestBus::BroadcastResult(collisionGroup, &Physics::CollisionRequests::GetCollisionGroupById, colliderConfiguration.m_collisionGroupId);
+
+            physx::PxFilterData filterData = PhysX::Collision::CreateFilterData(colliderConfiguration.m_collisionLayer, collisionGroup);
+            shape->setSimulationFilterData(filterData);
+            shape->setQueryFilterData(filterData);
+
+            // Do custom logic for specific shape types
+            if (pxGeomHolder.getType() == physx::PxGeometryType::eCAPSULE)
+            {
+                // PhysX capsules are oriented around x by default.
+                physx::PxQuat pxQuat(AZ::Constants::HalfPi, physx::PxVec3(0.0f, 1.0f, 0.0f));
+                shape->setLocalPose(physx::PxTransform(pxQuat));
+            }
+            else if (pxGeomHolder.getType() == physx::PxGeometryType::eHEIGHTFIELD)
+            {
+                const Physics::HeightfieldShapeConfiguration& heightfieldConfig =
+                    static_cast<const Physics::HeightfieldShapeConfiguration&>(shapeConfiguration);
+
+                // PhysX heightfields have the origin at the corner, not the center, so add an offset to the passed-in transform
+                // to account for this difference.
+                const AZ::Vector2 gridSpacing = heightfieldConfig.GetGridResolution();
+                AZ::Vector3 offset(
+                    -(gridSpacing.GetX() * heightfieldConfig.GetNumColumns() / 2.0f),
+                    -(gridSpacing.GetY() * heightfieldConfig.GetNumRows() / 2.0f),
+                    0.0f);
+
+                // PhysX heightfields are always defined to have the height in the Y direction, not the Z direction, so we need
+                // to provide additional rotations to make it Z-up.
+                physx::PxQuat pxQuat = PxMathConvert(
+                    AZ::Quaternion::CreateFromEulerAnglesRadians(AZ::Vector3(AZ::Constants::HalfPi, AZ::Constants::HalfPi, 0.0f)));
+                physx::PxTransform pxHeightfieldTransform = physx::PxTransform(PxMathConvert(offset), pxQuat);
+                shape->setLocalPose(pxHeightfieldTransform);
+            }
+
+            // Handle a possible misconfiguration when a shape is set to be both simulated & trigger. This is illegal in PhysX.
+            shape->setFlag(physx::PxShapeFlag::eSIMULATION_SHAPE, colliderConfiguration.m_isSimulated && !colliderConfiguration.m_isTrigger);
+            shape->setFlag(physx::PxShapeFlag::eSCENE_QUERY_SHAPE, colliderConfiguration.m_isInSceneQueries);
+            shape->setFlag(physx::PxShapeFlag::eTRIGGER_SHAPE, colliderConfiguration.m_isTrigger);
+
+            shape->setRestOffset(colliderConfiguration.m_restOffset);
+            shape->setContactOffset(colliderConfiguration.m_contactOffset);
+
+            physx::PxTransform pxShapeTransform = PxMathConvert(colliderConfiguration.m_position, colliderConfiguration.m_rotation);
+            shape->setLocalPose(pxShapeTransform * shape->getLocalPose());
+
+            assignedCollisionGroup = collisionGroup;
+            return shape;
         }
 
         AzPhysics::Scene* GetDefaultScene()
@@ -1006,12 +999,12 @@ namespace PhysX
                 if (shapeMaterialIndex != Pipeline::MeshAssetData::TriangleMeshMaterialIndex)
                 {
                     // Clear the materials that came in from the component collider configuration
-                    thisColliderConfiguration->m_materialSelection.SetMaterialSlots({});
+                    thisColliderConfiguration->m_materialSlots.SetSlots(Physics::MaterialDefaultSlot::Default);
 
                     // Set the material that is relevant for this specific shape
-                    Physics::MaterialId assignedMaterialForShape =
-                        originalColliderConfiguration.m_materialSelection.GetMaterialId(shapeMaterialIndex);
-                    thisColliderConfiguration->m_materialSelection.SetMaterialId(assignedMaterialForShape);
+                    thisColliderConfiguration->m_materialSlots.SetMaterialAsset(
+                        0,
+                        originalColliderConfiguration.m_materialSlots.GetMaterialAsset(shapeMaterialIndex));
                 }
 
                 // Here we use the collider configuration data saved in the asset to update the one coming from the component
@@ -1603,17 +1596,62 @@ namespace PhysX
             return configuration;
         }
 
-        void SetMaterialsFromHeightfieldProvider(const AZ::EntityId& heightfieldProviderId, Physics::MaterialSelection& materialSelection)
+        void SetMaterialsFromPhysicsAssetShape(const Physics::ShapeConfiguration& shapeConfiguration, Physics::MaterialSlots& materialSlots)
         {
-            AZStd::vector<Physics::MaterialId> materialList;
+            if (shapeConfiguration.GetShapeType() != Physics::ShapeType::PhysicsAsset)
+            {
+                return;
+            }
+
+            const Physics::PhysicsAssetShapeConfiguration& assetConfiguration =
+                static_cast<const Physics::PhysicsAssetShapeConfiguration&>(shapeConfiguration);
+
+            if (!assetConfiguration.m_asset.GetId().IsValid())
+            {
+                // Set the default selection if there's no physics asset.
+                materialSlots.SetSlots(Physics::MaterialDefaultSlot::Default);
+                return;
+            }
+
+            if (!assetConfiguration.m_asset.IsReady())
+            {
+                // The asset is valid but is still loading,
+                // Do not set the empty slots in this case to avoid the entity being in invalid state
+                return;
+            }
+
+            Pipeline::MeshAsset* meshAsset = assetConfiguration.m_asset.GetAs<Pipeline::MeshAsset>();
+            if (!meshAsset)
+            {
+                materialSlots.SetSlots(Physics::MaterialDefaultSlot::Default);
+                AZ_Warning("Physics", false, "Invalid mesh asset in physics asset shape configuration.");
+                return;
+            }
+
+            // If it has to use the materials assets from the mesh.
+            if (assetConfiguration.m_useMaterialsFromAsset)
+            {
+                // Copy slots entirely, which also include the material assets assigned to them.
+                materialSlots = meshAsset->m_assetData.m_materialSlots;
+            }
+            else
+            {
+                // Set only the slots, but do not set the material assets.
+                materialSlots.SetSlots(meshAsset->m_assetData.m_materialSlots.GetSlotsNames());
+            }
+        }
+
+        void SetMaterialsFromHeightfieldProvider(const AZ::EntityId& heightfieldProviderId, Physics::MaterialSlots& materialSlots)
+        {
+            AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> materialList;
             Physics::HeightfieldProviderRequestsBus::EventResult(
                 materialList, heightfieldProviderId, &Physics::HeightfieldProviderRequestsBus::Events::GetMaterialList);
 
-            materialSelection.SetMaterialSlots(Physics::MaterialSelection::SlotsArray(materialList.size(), ""));
+            materialSlots.SetSlots({ materialList.size(), "" }); // Nameless slots, their names are not shown in the heightfield component.
 
-            for (int i = 0; i < materialList.size(); ++i)
+            for (size_t slotIndex = 0; slotIndex < materialList.size(); ++slotIndex)
             {
-                materialSelection.SetMaterialId(materialList[i], i);
+                materialSlots.SetMaterialAsset(slotIndex, materialList[slotIndex]);
             }
         }
     } // namespace Utils

--- a/Gems/PhysX/Code/Source/Utils.h
+++ b/Gems/PhysX/Code/Source/Utils.h
@@ -13,7 +13,7 @@
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>
-#include <AzFramework/Physics/Material.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
 #include <AzFramework/Physics/Shape.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <AzCore/std/optional.h>
@@ -40,7 +40,6 @@ namespace PhysX
 {
     class Shape;
     class ActorData;
-    class Material;
     struct TerrainConfiguration;
 
     namespace Pipeline
@@ -199,7 +198,20 @@ namespace PhysX
         Physics::HeightfieldShapeConfiguration CreateBaseHeightfieldShapeConfiguration(AZ::EntityId entityId);
         Physics::HeightfieldShapeConfiguration CreateHeightfieldShapeConfiguration(AZ::EntityId entityId);
 
-        void SetMaterialsFromHeightfieldProvider(const AZ::EntityId& heightfieldProviderId, Physics::MaterialSelection& materialSelection);
+        //! Sets an array of material slots from Physics Asset.
+        //! If the configuration indicates that it should use the physics materials
+        //! assignment from the physics asset it will also use those materials for the slots.
+        //! If the shape configuration passed does not use Physics Asset this call won't do any operations.
+        //! @param shapeConfiguration Shape configuration with the information about Physics Assets.
+        //! @param materialSlots Output materials slots.
+        void SetMaterialsFromPhysicsAssetShape(const Physics::ShapeConfiguration& shapeConfiguration, Physics::MaterialSlots& materialSlots);
+
+        //! Sets an array of material slots from a heightfield provider, plus
+        //! it will also set materials to the slots.
+        //! If the entity doesn't have a heightfield provider then the default slot will be used.
+        //! @param heightfieldProviderId Entity id for the heightfield provider.
+        //! @param materialSlots Output materials slots.
+        void SetMaterialsFromHeightfieldProvider(const AZ::EntityId& heightfieldProviderId, Physics::MaterialSlots& materialSlots);
 
         namespace Geometry
         {

--- a/Gems/PhysX/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
@@ -13,10 +13,12 @@
 #include <HeightfieldColliderComponent.h>
 #include <LmbrCentral/Shape/BoxShapeComponentBus.h>
 #include <AzFramework/Physics/HeightfieldProviderBus.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 #include <StaticRigidBodyComponent.h>
 #include <RigidBodyStatic.h>
 #include <PhysX/PhysXLocks.h>
 #include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 #include <PhysX/MockPhysXHeightfieldProviderComponent.h>
 #include <AzCore/Casting/lossy_cast.h>
 #include <Utils.h>
@@ -40,14 +42,31 @@ namespace PhysXEditorTests
         return samples;
     }
 
-    AZStd::vector<Physics::MaterialId> GetMaterialList()
+    AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> GetMaterialList()
     {
-        AZStd::vector<Physics::MaterialId> materials{
-            {Physics::MaterialId::FromUUID("{EC976D51-2C26-4C1E-BBF2-75BAAAFA162C}")},
-            {Physics::MaterialId::FromUUID("{B9836F51-A235-4781-95E3-A6302BEE9EFF}")},
-            {Physics::MaterialId::FromUUID("{7E060707-BB03-47EB-B046-4503C7145B6E}")}
+        AZ::Data::Asset<Physics::MaterialAsset> materialAsset1 =
+            AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
+                AZ::Data::AssetId(AZ::Uuid::CreateString("{EC976D51-2C26-4C1E-BBF2-75BAAAFA162C}")),
+                AZ::Data::AssetLoadBehavior::Default);
+        materialAsset1->SetData(Physics::MaterialConfiguration2{});
+
+        AZ::Data::Asset<Physics::MaterialAsset> materialAsset2 =
+            AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
+                AZ::Data::AssetId(AZ::Uuid::CreateString("{B9836F51-A235-4781-95E3-A6302BEE9EFF}")),
+                AZ::Data::AssetLoadBehavior::Default);
+        materialAsset2->SetData(Physics::MaterialConfiguration2{});
+
+        AZ::Data::Asset<Physics::MaterialAsset> materialAsset3 =
+            AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
+                AZ::Data::AssetId(AZ::Uuid::CreateString("{7E060707-BB03-47EB-B046-4503C7145B6E}")),
+                AZ::Data::AssetLoadBehavior::Default);
+        materialAsset3->SetData(Physics::MaterialConfiguration2{});
+
+        return {
+            materialAsset1,
+            materialAsset2,
+            materialAsset3
         };
-        return materials;
     }
 
     EntityPtr SetupHeightfieldComponent()
@@ -107,7 +126,6 @@ namespace PhysXEditorTests
         void SetUp() override
         {
             PhysXEditorFixture::SetUp();
-            PopulateDefaultMaterialLibrary();
 
             m_editorEntity = SetupHeightfieldComponent();
             m_editorMockShapeRequests = AZStd::make_unique<NiceMock<UnitTest::MockPhysXHeightfieldProvider>>(m_editorEntity->GetId());
@@ -126,6 +144,11 @@ namespace PhysXEditorTests
 
         void TearDown() override
         {
+            if (auto* materialManager = AZ::Interface<Physics::MaterialManager>::Get())
+            {
+                materialManager->DeleteAllMaterials();
+            }
+
             CleanupHeightfieldComponent();
 
             m_editorEntity = nullptr;
@@ -136,34 +159,7 @@ namespace PhysXEditorTests
             PhysXEditorFixture::TearDown();
         }
 
-        void PopulateDefaultMaterialLibrary()
-        {
-            AZ::Data::AssetId assetId = AZ::Data::AssetId(AZ::Uuid::Create());
-
-            // Create an asset out of our Script Event
-            Physics::MaterialLibraryAsset* matLibAsset = aznew Physics::MaterialLibraryAsset;
-            {
-                const AZStd::vector<Physics::MaterialId> matIds = GetMaterialList();
-
-                for (const Physics::MaterialId& matId : matIds)
-                {
-                    Physics::MaterialFromAssetConfiguration matConfig;
-                    matConfig.m_id = matId;
-                    matConfig.m_configuration.m_surfaceType = matId.GetUuid().ToString<AZStd::string>();
-                    matLibAsset->AddMaterialData(matConfig);
-                }
-            }
-
-            // Note: There is no interface to simply update material library asset. It has to go via updating the entire configuration which causes assets reloading.
-            // It makes sense as a safety mechanism in the Editor but makes it harder to write tests.
-            // Hence have to work around it via const_cast here to be able to simply set the generated asset into configuration.
-            AzPhysics::SystemConfiguration* sysConfig = const_cast<AzPhysics::SystemConfiguration*>(AZ::Interface<AzPhysics::SystemInterface>::Get()->GetConfiguration());
-
-            AZ::Data::Asset<Physics::MaterialLibraryAsset> assetData(assetId, matLibAsset, AZ::Data::AssetLoadBehavior::Default);
-            sysConfig->m_materialLibraryAsset = assetData;
-        }
-
-        Physics::Material* GetMaterialFromRaycast(float x, float y)
+        Physics::MaterialId2 GetMaterialFromRaycast(float x, float y)
         {
             AzPhysics::RayCastRequest request;
             request.m_start = AZ::Vector3(x, y, 5.0f);
@@ -177,10 +173,10 @@ namespace PhysXEditorTests
 
             if (result)
             {
-                return result.m_hits[0].m_material;
+                return result.m_hits[0].m_physicsMaterialId;
             }
 
-            return nullptr;
+            return {};
         };
 
         EntityPtr m_editorEntity;
@@ -333,11 +329,7 @@ namespace PhysXEditorTests
 
         physx::PxHeightField* heightfield = heightfieldGeometry.heightField;
 
-        AZStd::vector<AZStd::string> physicsSurfaceTypes;
-        for (Physics::MaterialId materialId : GetMaterialList())
-        {
-            physicsSurfaceTypes.emplace_back(materialId.GetUuid().ToString<AZStd::string>());
-        }
+        const AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> physicsMaterialAssets = GetMaterialList();
 
         // PhysX Heightfield cooking doesn't map 1-1 sample material indices to triangle material indices 
         // Hence hardcoding the expected material indices in the test 
@@ -362,16 +354,23 @@ namespace PhysXEditorTests
                     float rayX = x_offset + sampleColumn;
                     float rayY = y_offset + sampleRow;
 
-                    Physics::Material* mat1 = GetMaterialFromRaycast(rayX, rayY);
-                    EXPECT_NE(mat1, nullptr);
+                    Physics::MaterialId2 matId1 = GetMaterialFromRaycast(rayX, rayY);
+                    EXPECT_TRUE(matId1.IsValid());
 
-                    Physics::Material* mat2 = GetMaterialFromRaycast(rayX + secondRayOffset, rayY + secondRayOffset);
-                    EXPECT_NE(mat2, nullptr);
+                    Physics::MaterialId2 matId2 = GetMaterialFromRaycast(rayX + secondRayOffset, rayY + secondRayOffset);
+                    EXPECT_TRUE(matId2.IsValid());
 
-                    if (mat1)
+                    if (matId1.IsValid())
                     {
-                        AZStd::string expectedMaterialName = physicsSurfaceTypes[physicsMaterialsValidationDataIndex[sampleRow * 2 + sampleColumn]];
-                        EXPECT_EQ(mat1->GetSurfaceTypeName(), expectedMaterialName);
+                        const AZ::Data::Asset<Physics::MaterialAsset> expectedMaterialAsset = physicsMaterialAssets[physicsMaterialsValidationDataIndex[sampleRow * 2 + sampleColumn]];
+
+                        AZStd::shared_ptr<Physics::Material2> mat1 = AZ::Interface<Physics::MaterialManager>::Get()->GetMaterial(matId1);
+
+                        EXPECT_TRUE(mat1.get() != nullptr);
+                        if (mat1)
+                        {
+                            EXPECT_EQ(mat1->GetMaterialAsset(), expectedMaterialAsset);
+                        }
                     }
                 }
             }

--- a/Gems/PhysX/Code/Tests/PhysXGenericTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXGenericTest.cpp
@@ -443,6 +443,7 @@ namespace PhysX
         AzPhysics::RigidBody* boxC = TestUtils::AddUnitBoxToScene(sceneHandle, AZ::Vector3(-1.0f, 0.0f, 10.0f));
 
         auto material = boxC->GetShape(0)->GetMaterial();
+        const float prevRestitution = material->GetRestitution();
         material->SetRestitution(1.0f);
 
         TestUtils::UpdateScene(sceneHandle, 1.0f / 60.0f, 150);
@@ -450,6 +451,9 @@ namespace PhysX
         // boxB and boxC should have the same material (default)
         // so they should both bounce high
         EXPECT_NEAR(boxB->GetPosition().GetZ(), boxC->GetPosition().GetZ(), 0.5f);
+
+        // Restore restitution value
+        material->SetRestitution(prevRestitution);
     }
 
     TEST_F(GenericPhysicsInterfaceTest, Collider_ColliderTag_IsSetFromConfiguration)

--- a/Gems/PhysX/Code/Tests/PhysXMaterialTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXMaterialTest.cpp
@@ -8,175 +8,281 @@
 
 #include <AzTest/AzTest.h>
 #include <AZTestShared/Math/MathTestHelpers.h>
+#include <AzCore/Asset/AssetManager.h>
 
-#include <Material/PhysXMaterial.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
+
+#include <PhysX/Material/PhysXMaterial.h>
 
 namespace UnitTest
 {
     static constexpr float Tolerance = 1e-4f;
 
-    TEST(PhysXMaterial, Material_GetSet_DynamicFriction)
+    class PhysXMaterialFixture
+        : public testing::Test
+    {
+    public:
+        void TearDown() override
+        {
+            if (auto* materialManager = AZ::Interface<Physics::MaterialManager>::Get())
+            {
+                materialManager->DeleteAllMaterials();
+            }
+        }
+
+    protected:
+        AZ::Data::Asset<Physics::MaterialAsset> CreateMaterialAsset(const Physics::MaterialConfiguration2& materialConfiguration)
+        {
+            AZ::Data::Asset<Physics::MaterialAsset> materialAsset =
+                AZ::Data::AssetManager::Instance().CreateAsset<Physics::MaterialAsset>(
+                    AZ::Data::AssetId(AZ::Uuid::CreateRandom()));
+            materialAsset->SetData(materialConfiguration);
+            return materialAsset;
+        }
+    };
+
+    TEST_F(PhysXMaterialFixture, Material_FindOrCreateMaterial)
+    {
+        AZStd::shared_ptr<PhysX::Material2> materialNull = PhysX::Material2::FindOrCreateMaterial(AZ::Data::Asset<Physics::MaterialAsset>());
+
+        EXPECT_TRUE(materialNull.get() == nullptr);
+
+        Physics::MaterialConfiguration2 materialConfiguration;
+        const auto materialAsset = CreateMaterialAsset(materialConfiguration);
+
+        AZStd::shared_ptr<PhysX::Material2> material1 = PhysX::Material2::FindOrCreateMaterial(materialAsset);
+
+        EXPECT_TRUE(material1.get() != nullptr);
+
+        AZStd::shared_ptr<PhysX::Material2> material2 = PhysX::Material2::FindOrCreateMaterial(materialAsset);
+
+        EXPECT_TRUE(material2.get() != nullptr);
+        EXPECT_EQ(material1.get(), material2.get());
+        EXPECT_EQ(material1->GetId(), material2->GetId());
+    }
+
+    TEST_F(PhysXMaterialFixture, Material_FindOrCreateMaterials)
+    {
+        const auto defaultMaterial = AZ::Interface<Physics::MaterialManager>::Get()->GetDefaultMaterial();
+
+        Physics::MaterialSlots defaultMaterialSlots;
+
+        AZStd::vector<AZStd::shared_ptr<PhysX::Material2>> materials = PhysX::Material2::FindOrCreateMaterials(defaultMaterialSlots);
+
+        EXPECT_EQ(materials.size(), 1);
+        EXPECT_EQ(materials[0]->GetId(), defaultMaterial->GetId());
+
+        Physics::MaterialSlots materialSlotsWithNoAssets;
+        materialSlotsWithNoAssets.SetSlots({"Slot1", "Slot2", "Slot3"});
+
+        AZStd::vector<AZStd::shared_ptr<PhysX::Material2>> materials2 = PhysX::Material2::FindOrCreateMaterials(materialSlotsWithNoAssets);
+
+        EXPECT_EQ(materials2.size(), 3);
+        for (const auto& material : materials2)
+        {
+            EXPECT_EQ(material->GetId(), defaultMaterial->GetId());
+        }
+
+        const auto materialAsset1 = CreateMaterialAsset(Physics::MaterialConfiguration2{});
+        const auto materialAsset2 = CreateMaterialAsset(Physics::MaterialConfiguration2{});
+
+        Physics::MaterialSlots materialSlotsWithAssets;
+        materialSlotsWithAssets.SetSlots({ "Slot1", "Slot2" });
+        materialSlotsWithAssets.SetMaterialAsset(0, materialAsset1);
+        materialSlotsWithAssets.SetMaterialAsset(1, materialAsset2);
+
+        AZStd::vector<AZStd::shared_ptr<PhysX::Material2>> materials3 = PhysX::Material2::FindOrCreateMaterials(materialSlotsWithAssets);
+
+        EXPECT_EQ(materials3.size(), 2);
+        EXPECT_EQ(materials3[0]->GetMaterialAsset(), materialAsset1);
+        EXPECT_EQ(materials3[1]->GetMaterialAsset(), materialAsset2);
+    }
+
+    TEST_F(PhysXMaterialFixture, Material_CreateMaterialWithRandomId)
+    {
+        AZStd::shared_ptr<PhysX::Material2> materialNull = PhysX::Material2::CreateMaterialWithRandomId(AZ::Data::Asset<Physics::MaterialAsset>());
+
+        EXPECT_TRUE(materialNull.get() == nullptr);
+
+        Physics::MaterialConfiguration2 materialConfiguration;
+        const auto materialAsset = CreateMaterialAsset(materialConfiguration);
+
+        AZStd::shared_ptr<PhysX::Material2> material1 = PhysX::Material2::CreateMaterialWithRandomId(materialAsset);
+
+        EXPECT_TRUE(material1.get() != nullptr);
+
+        AZStd::shared_ptr<PhysX::Material2> material2 = PhysX::Material2::CreateMaterialWithRandomId(materialAsset);
+
+        EXPECT_TRUE(material2.get() != nullptr);
+        EXPECT_NE(material1.get(), material2.get());
+        EXPECT_NE(material1->GetId(), material2->GetId());
+    }
+
+    TEST_F(PhysXMaterialFixture, Material_GetSet_DynamicFriction)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_dynamicFriction = 68.6f;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_NEAR(material.GetDynamicFriction(), 68.6f, Tolerance);
+        EXPECT_NEAR(material->GetDynamicFriction(), 68.6f, Tolerance);
 
-        material.SetDynamicFriction(31.2f);
-        EXPECT_NEAR(material.GetDynamicFriction(), 31.2f, Tolerance);
+        material->SetDynamicFriction(31.2f);
+        EXPECT_NEAR(material->GetDynamicFriction(), 31.2f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_Clamps_DynamicFriction)
+    TEST_F(PhysXMaterialFixture, Material_Clamps_DynamicFriction)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_dynamicFriction = -7.0f;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_NEAR(material.GetDynamicFriction(), 0.0f, Tolerance);
+        EXPECT_NEAR(material->GetDynamicFriction(), 0.0f, Tolerance);
 
-        material.SetDynamicFriction(-61.0f);
-        EXPECT_NEAR(material.GetDynamicFriction(), 0.0f, Tolerance);
+        material->SetDynamicFriction(-61.0f);
+        EXPECT_NEAR(material->GetDynamicFriction(), 0.0f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_StaticFriction)
+    TEST_F(PhysXMaterialFixture, Material_GetSet_StaticFriction)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_staticFriction = 68.6f;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_NEAR(material.GetStaticFriction(), 68.6f, Tolerance);
+        EXPECT_NEAR(material->GetStaticFriction(), 68.6f, Tolerance);
 
-        material.SetStaticFriction(31.2f);
-        EXPECT_NEAR(material.GetStaticFriction(), 31.2f, Tolerance);
+        material->SetStaticFriction(31.2f);
+        EXPECT_NEAR(material->GetStaticFriction(), 31.2f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_Clamps_StaticFriction)
+    TEST_F(PhysXMaterialFixture, Material_Clamps_StaticFriction)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_staticFriction = -7.0f;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_NEAR(material.GetStaticFriction(), 0.0f, Tolerance);
+        EXPECT_NEAR(material->GetStaticFriction(), 0.0f, Tolerance);
 
-        material.SetStaticFriction(-61.0f);
-        EXPECT_NEAR(material.GetStaticFriction(), 0.0f, Tolerance);
+        material->SetStaticFriction(-61.0f);
+        EXPECT_NEAR(material->GetStaticFriction(), 0.0f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_Restitution)
+    TEST_F(PhysXMaterialFixture, Material_GetSet_Restitution)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_restitution = 0.43f;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_NEAR(material.GetRestitution(), 0.43f, Tolerance);
+        EXPECT_NEAR(material->GetRestitution(), 0.43f, Tolerance);
 
-        material.SetRestitution(0.78f);
-        EXPECT_NEAR(material.GetRestitution(), 0.78f, Tolerance);
+        material->SetRestitution(0.78f);
+        EXPECT_NEAR(material->GetRestitution(), 0.78f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_Clamps_Restitution)
+    TEST_F(PhysXMaterialFixture, Material_Clamps_Restitution)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_restitution = -13.0f;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_NEAR(material.GetRestitution(), 0.0f, Tolerance);
+        EXPECT_NEAR(material->GetRestitution(), 0.0f, Tolerance);
 
-        material.SetRestitution(0.0f);
-        EXPECT_NEAR(material.GetRestitution(), 0.0f, Tolerance);
+        material->SetRestitution(0.0f);
+        EXPECT_NEAR(material->GetRestitution(), 0.0f, Tolerance);
 
-        material.SetRestitution(1.0f);
-        EXPECT_NEAR(material.GetRestitution(), 1.0f, Tolerance);
+        material->SetRestitution(1.0f);
+        EXPECT_NEAR(material->GetRestitution(), 1.0f, Tolerance);
 
-        material.SetRestitution(61.0f);
-        EXPECT_NEAR(material.GetRestitution(), 1.0f, Tolerance);
+        material->SetRestitution(61.0f);
+        EXPECT_NEAR(material->GetRestitution(), 1.0f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_Density)
+    TEST_F(PhysXMaterialFixture, Material_GetSet_Density)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_density = 245.0f;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_NEAR(material.GetDensity(), 245.0f, Tolerance);
+        EXPECT_NEAR(material->GetDensity(), 245.0f, Tolerance);
 
-        material.SetDensity(43.1f);
-        EXPECT_NEAR(material.GetDensity(), 43.1f, Tolerance);
+        material->SetDensity(43.1f);
+        EXPECT_NEAR(material->GetDensity(), 43.1f, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_Clamps_Density)
+    TEST_F(PhysXMaterialFixture, Material_Clamps_Density)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_density = -13.0f;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_NEAR(material.GetDensity(), Physics::MaterialConfiguration2::MinDensityLimit, Tolerance);
+        EXPECT_NEAR(material->GetDensity(), Physics::MaterialConfiguration2::MinDensityLimit, Tolerance);
 
-        material.SetDensity(0.0f);
-        EXPECT_NEAR(material.GetDensity(), Physics::MaterialConfiguration2::MinDensityLimit, Tolerance);
+        material->SetDensity(0.0f);
+        EXPECT_NEAR(material->GetDensity(), Physics::MaterialConfiguration2::MinDensityLimit, Tolerance);
 
-        material.SetDensity(Physics::MaterialConfiguration2::MinDensityLimit);
-        EXPECT_NEAR(material.GetDensity(), Physics::MaterialConfiguration2::MinDensityLimit, Tolerance);
+        material->SetDensity(Physics::MaterialConfiguration2::MinDensityLimit);
+        EXPECT_NEAR(material->GetDensity(), Physics::MaterialConfiguration2::MinDensityLimit, Tolerance);
 
-        material.SetDensity(Physics::MaterialConfiguration2::MaxDensityLimit);
-        EXPECT_NEAR(material.GetDensity(), Physics::MaterialConfiguration2::MaxDensityLimit, Tolerance);
+        material->SetDensity(Physics::MaterialConfiguration2::MaxDensityLimit);
+        EXPECT_NEAR(material->GetDensity(), Physics::MaterialConfiguration2::MaxDensityLimit, Tolerance);
 
-        material.SetDensity(200000.0f);
-        EXPECT_NEAR(material.GetDensity(), Physics::MaterialConfiguration2::MaxDensityLimit, Tolerance);
+        material->SetDensity(200000.0f);
+        EXPECT_NEAR(material->GetDensity(), Physics::MaterialConfiguration2::MaxDensityLimit, Tolerance);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_FrictionCombineMode)
+    TEST_F(PhysXMaterialFixture, Material_GetSet_FrictionCombineMode)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_frictionCombine = Physics::CombineMode::Maximum;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_EQ(material.GetFrictionCombineMode(), Physics::CombineMode::Maximum);
+        EXPECT_EQ(material->GetFrictionCombineMode(), Physics::CombineMode::Maximum);
 
-        material.SetFrictionCombineMode(Physics::CombineMode::Minimum);
-        EXPECT_EQ(material.GetFrictionCombineMode(), Physics::CombineMode::Minimum);
+        material->SetFrictionCombineMode(Physics::CombineMode::Minimum);
+        EXPECT_EQ(material->GetFrictionCombineMode(), Physics::CombineMode::Minimum);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_RestitutionCombineMode)
+    TEST_F(PhysXMaterialFixture, Material_GetSet_RestitutionCombineMode)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_restitutionCombine = Physics::CombineMode::Maximum;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_EQ(material.GetRestitutionCombineMode(), Physics::CombineMode::Maximum);
+        EXPECT_EQ(material->GetRestitutionCombineMode(), Physics::CombineMode::Maximum);
 
-        material.SetRestitutionCombineMode(Physics::CombineMode::Minimum);
-        EXPECT_EQ(material.GetRestitutionCombineMode(), Physics::CombineMode::Minimum);
+        material->SetRestitutionCombineMode(Physics::CombineMode::Minimum);
+        EXPECT_EQ(material->GetRestitutionCombineMode(), Physics::CombineMode::Minimum);
     }
 
-    TEST(PhysXMaterial, Material_GetSet_DebugColor)
+    TEST_F(PhysXMaterialFixture, Material_GetSet_DebugColor)
     {
         Physics::MaterialConfiguration2 materialConfiguration;
         materialConfiguration.m_debugColor = AZ::Colors::Lavender;
 
-        PhysX::Material2 material(materialConfiguration);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
 
-        EXPECT_THAT(material.GetDebugColor(), IsClose(AZ::Colors::Lavender));
+        EXPECT_THAT(material->GetDebugColor(), IsClose(AZ::Colors::Lavender));
 
-        material.SetDebugColor(AZ::Colors::Aquamarine);
-        EXPECT_THAT(material.GetDebugColor(), IsClose(AZ::Colors::Aquamarine));
+        material->SetDebugColor(AZ::Colors::Aquamarine);
+        EXPECT_THAT(material->GetDebugColor(), IsClose(AZ::Colors::Aquamarine));
     }
 
-    TEST(PhysXMaterial, Material_ReturnsValid_NativePointer)
+    TEST_F(PhysXMaterialFixture, Material_ReturnsValid_PxMaterial)
     {
-        PhysX::Material2 material(Physics::MaterialConfiguration2{});
+        Physics::MaterialConfiguration2 materialConfiguration;
 
-        EXPECT_TRUE(material.GetNativePointer() != nullptr);
+        AZStd::shared_ptr<PhysX::Material2> material = PhysX::Material2::FindOrCreateMaterial(CreateMaterialAsset(materialConfiguration));
+
+        EXPECT_TRUE(material->GetPxMaterial() != nullptr);
     }
 } // namespace UnitTest

--- a/Gems/PhysX/Code/Tests/PhysXSceneQueryTests.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXSceneQueryTests.cpp
@@ -17,6 +17,7 @@
 #include <AzFramework/Physics/SystemBus.h>
 #include <AzFramework/Physics/Common/PhysicsSceneQueries.h>
 #include <AzFramework/Physics/Configuration/RigidBodyConfiguration.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 
 #include <RigidBodyComponent.h>
 #include <SphereColliderComponent.h>
@@ -37,6 +38,10 @@ namespace PhysX
         }
         void TearDownFixture()
         {
+            if (auto* materialManager = AZ::Interface<Physics::MaterialManager>::Get())
+            {
+                materialManager->DeleteAllMaterials();
+            }
             //Cleanup any created scenes
             if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
             {
@@ -161,12 +166,9 @@ namespace PhysX
 
         //Verify shape and material
         ASSERT_NE(rigidBody->GetShape(0), nullptr);
-        ASSERT_NE(hit.m_material, nullptr);
+        EXPECT_TRUE(hit.m_physicsMaterialId.IsValid());
         ASSERT_EQ(hit.m_shape, rigidBody->GetShape(0).get());
-        ASSERT_EQ(hit.m_material, rigidBody->GetShape(0).get()->GetMaterial().get());
-
-        const AZStd::string& typeName = hit.m_material->GetSurfaceTypeName();
-        ASSERT_EQ(typeName, Physics::DefaultPhysicsMaterialLabel);
+        ASSERT_EQ(hit.m_physicsMaterialId, rigidBody->GetShape(0).get()->GetMaterial()->GetId());
     }
 
     TEST_F(PhysXSceneQueryFixture, RayCast_AgainstStaticObject_ReturnsHit)

--- a/Gems/PhysX/Code/Tests/PhysXTestCommon.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXTestCommon.cpp
@@ -16,6 +16,7 @@
 #include <AzFramework/Physics/Configuration/StaticRigidBodyConfiguration.h>
 #include <AzFramework/Physics/SimulatedBodies/RigidBody.h>
 #include <AzFramework/Physics/SimulatedBodies/StaticRigidBody.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 #include <PhysX/SystemComponentBus.h>
 
 #include <BoxColliderComponent.h>
@@ -43,6 +44,11 @@ namespace PhysX
 
         void ResetPhysXSystem()
         {
+            if (auto* materialManager = AZ::Interface<Physics::MaterialManager>::Get())
+            {
+                materialManager->DeleteAllMaterials();
+            }
+            
             if (auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
             {
                 physicsSystem->RemoveAllScenes(); //Cleanup any created scenes

--- a/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
+++ b/Gems/SceneProcessing/Code/Source/SceneBuilder/SceneBuilderWorker.cpp
@@ -79,7 +79,7 @@ namespace SceneBuilder
                 m_cachedFingerprint.append(element);
             }
             // A general catch all version fingerprint. Update this to force all FBX files to recompile.
-            m_cachedFingerprint.append("Version 3");
+            m_cachedFingerprint.append("Version 4");
         }
 
         return m_cachedFingerprint.c_str();

--- a/Gems/ScriptCanvasPhysics/Code/Source/WorldNodes.h
+++ b/Gems/ScriptCanvasPhysics/Code/Source/WorldNodes.h
@@ -10,7 +10,7 @@
 
 #include <ScriptCanvas/Core/NodeFunctionGeneric.h>
 #include <ScriptCanvas/Data/Data.h>
-#include <AzFramework/Physics/Material.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialId.h>
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
 #include <AzFramework/Physics/Collision/CollisionGroups.h>
@@ -94,11 +94,7 @@ namespace ScriptCanvasPhysics
             }
             if (result)
             {
-                AZ::Crc32 surfaceType;
-                if (result.m_hits[0].m_material)
-                {
-                    surfaceType = result.m_hits[0].m_material->GetSurfaceType();
-                }
+                const AZ::Crc32 surfaceType(result.m_hits[0].m_physicsMaterialId.ToString<AZStd::string>());
                 return AZStd::make_tuple(result.m_hits[0].IsValid(), result.m_hits[0].m_position,
                     result.m_hits[0].m_normal, result.m_hits[0].m_distance,
                     result.m_hits[0].m_entityId, surfaceType);
@@ -358,11 +354,7 @@ namespace ScriptCanvasPhysics
             }
             if (result)
             {
-                AZ::Crc32 surfaceType;
-                if (result.m_hits[0].m_material)
-                {
-                    surfaceType = result.m_hits[0].m_material->GetSurfaceType();
-                }
+                const AZ::Crc32 surfaceType(result.m_hits[0].m_physicsMaterialId.ToString<AZStd::string>());
                 return AZStd::make_tuple(result.m_hits[0].IsValid(), result.m_hits[0].m_position,
                     result.m_hits[0].m_normal, result.m_hits[0].m_distance,
                     result.m_hits[0].m_entityId, surfaceType);

--- a/Gems/ScriptCanvasPhysics/Code/Tests/ScriptCanvasPhysicsTest.cpp
+++ b/Gems/ScriptCanvasPhysics/Code/Tests/ScriptCanvasPhysicsTest.cpp
@@ -8,7 +8,6 @@
 
 #include <AzTest/GemTestEnvironment.h>
 #include <gmock/gmock.h>
-#include <AzFramework/Physics/Material.h>
 #include <AzFramework/Physics/PhysicsScene.h>
 #include <AzFramework/Physics/Shape.h>
 #include <AzFramework/Physics/ShapeConfiguration.h>
@@ -179,8 +178,8 @@ namespace ScriptCanvasPhysicsTests
         : public Physics::Shape
     {
     public:
-        MOCK_METHOD1(SetMaterial, void(const AZStd::shared_ptr<Physics::Material>& material));
-        MOCK_CONST_METHOD0(GetMaterial, AZStd::shared_ptr<Physics::Material>());
+        MOCK_METHOD1(SetMaterial, void(const AZStd::shared_ptr<Physics::Material2>& material));
+        MOCK_CONST_METHOD0(GetMaterial, AZStd::shared_ptr<Physics::Material2>());
         MOCK_METHOD1(SetCollisionLayer, void(const AzPhysics::CollisionLayer& layer));
         MOCK_CONST_METHOD0(GetCollisionLayer, AzPhysics::CollisionLayer());
         MOCK_METHOD1(SetCollisionGroup, void(const AzPhysics::CollisionGroup& group));
@@ -203,33 +202,6 @@ namespace ScriptCanvasPhysicsTests
         MOCK_METHOD1(SetContactOffset, void(float));
     };
 
-    class MockPhysicsMaterial
-        : public Physics::Material
-    {
-    public:
-        virtual ~MockPhysicsMaterial() = default;
-
-        MOCK_CONST_METHOD0(GetSurfaceType, AZ::Crc32());
-        MOCK_CONST_METHOD0(GetSurfaceTypeName, const AZStd::string&());
-        MOCK_METHOD1(SetSurfaceTypeName, void(const AZStd::string&));
-        MOCK_CONST_METHOD0(GetDynamicFriction, float());
-        MOCK_METHOD1(SetDynamicFriction, void(float));
-        MOCK_CONST_METHOD0(GetStaticFriction, float());
-        MOCK_METHOD1(SetStaticFriction, void(float));
-        MOCK_CONST_METHOD0(GetRestitution, float());
-        MOCK_METHOD1(SetRestitution, void(float));
-        MOCK_CONST_METHOD0(GetFrictionCombineMode, CombineMode());
-        MOCK_METHOD1(SetFrictionCombineMode, void(CombineMode));
-        MOCK_CONST_METHOD0(GetRestitutionCombineMode, CombineMode());
-        MOCK_METHOD1(SetRestitutionCombineMode, void(CombineMode));
-        MOCK_CONST_METHOD0(GetCryEngineSurfaceId, AZ::u32());
-        MOCK_METHOD0(GetNativePointer, void*());
-        MOCK_CONST_METHOD0(GetDensity, float());
-        MOCK_METHOD1(SetDensity, void(float));
-        MOCK_CONST_METHOD0(GetDebugColor, AZ::Color());
-        MOCK_METHOD1(SetDebugColor, void(const AZ::Color&));
-    };
-
     class ScriptCanvasPhysicsTestEnvironment
         : public AZ::Test::GemTestEnvironment
     {
@@ -247,14 +219,11 @@ namespace ScriptCanvasPhysicsTests
         {
             ::testing::Test::SetUp();
 
-            ON_CALL(m_material, GetSurfaceType())
-                .WillByDefault(Return(AZ::Crc32("CustomSurface")));
-
             m_hit.m_position = AZ::Vector3(1.f, 2.f, 3.f);
             m_hit.m_distance = 2.5f;
             m_hit.m_normal = AZ::Vector3(-1.f, 3.5f, 0.5f);
             m_hit.m_shape = &m_shape;
-            m_hit.m_material = &m_material;
+            m_hit.m_physicsMaterialId = Physics::MaterialId2::CreateName("Default");
             m_hit.m_resultFlags = AzPhysics::SceneQuery::ResultFlags::Position |
                 AzPhysics::SceneQuery::ResultFlags::Distance |
                 AzPhysics::SceneQuery::ResultFlags::Normal |
@@ -265,7 +234,6 @@ namespace ScriptCanvasPhysicsTests
 
         NiceMock<MockSimulatedBody> m_worldBody;
         NiceMock<MockShape> m_shape;
-        NiceMock<MockPhysicsMaterial> m_material;
         NiceMock<MockPhysicsSceneInterface> m_sceneInterfaceMock;
         AzPhysics::SceneQueryHit m_hit;
         AzPhysics::SceneQueryHits m_hitResult;
@@ -278,7 +246,7 @@ namespace ScriptCanvasPhysicsTests
                 AZStd::get<2>(result) == hit.m_normal &&
                 AZStd::get<3>(result) == hit.m_distance &&
                 AZStd::get<4>(result) == hit.m_entityId &&
-                AZStd::get<5>(result) == (hit.m_material ? hit.m_material->GetSurfaceType() : AZ::Crc32())
+                AZStd::get<5>(result) == AZ::Crc32(hit.m_physicsMaterialId.ToString<AZStd::string>())
                 ;
         }
     };
@@ -372,7 +340,7 @@ namespace ScriptCanvasPhysicsTests
         for (auto result : results)
         {
             EXPECT_EQ(result.m_distance, m_hit.m_distance);
-            EXPECT_EQ(result.m_material, m_hit.m_material);
+            EXPECT_EQ(result.m_physicsMaterialId, m_hit.m_physicsMaterialId);
             EXPECT_EQ(result.m_normal, m_hit.m_normal);
             EXPECT_EQ(result.m_position, m_hit.m_position);
             EXPECT_EQ(result.m_shape, m_hit.m_shape);

--- a/Registry/AssetProcessorPlatformConfig.setreg
+++ b/Registry/AssetProcessorPlatformConfig.setreg
@@ -461,12 +461,6 @@
                     "glob": "*.physmaterial",
                     "params": "copy",
                     "critical": true,
-                    "productAssetType": "{9E366D8C-33BB-4825-9A1F-FA3ADBE11D0F}"
-                },
-                "RC physmaterial": {
-                    "glob": "*.physmaterial2",
-                    "params": "copy",
-                    "critical": true,
                     "productAssetType": "{E4EF58EE-B1D1-46C8-BE48-BB62B8247386}"
                 },
                 "RC ocm": {


### PR DESCRIPTION
…PhysX Character Controller, Ragdoll Collider, Hit Detection Collider and PhysX Mesh Group.

**This PR is part of the work to refactoring physics materials. It's NOT merging to development branch.**

Physics materials doesn't have a library of materials, it works like render materials in the sense that 1 asset is 1 material, so in the PhysX components now instead of a dropdown menu there is the typical asset field to assign a physics material.

All unit tests of AzFramework, PhysX, EMotionFX and ScriptCanvasPhysics pass.

Tested creating a level with physx colliders and rigid body, check they collide and that changing to a different material results in a different behavior.
Tested swapping between different shapes in physx colliders and check the editor card is updated properly.

Signed-off-by: moraaar <moraaar@amazon.com>