### PR TITLE
[3/4] Using new material classes in Blast.

### DIFF
--- a/Gems/Blast/Code/Source/Actor/BlastActorDesc.h
+++ b/Gems/Blast/Code/Source/Actor/BlastActorDesc.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <AzCore/std/containers/vector.h>
-#include <AzFramework/Physics/Material.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialId.h>
 #include <AzFramework/Physics/Configuration/RigidBodyConfiguration.h>
 
 namespace Nv::Blast
@@ -25,7 +25,7 @@ namespace Blast
     {
         BlastFamily* m_family;
         Nv::Blast::TkActor* m_tkActor;
-        Physics::MaterialId m_physicsMaterialId;
+        Physics::MaterialId2 m_physicsMaterialId;
         AZ::Vector3 m_parentLinearVelocity = AZ::Vector3::CreateZero();
         AZ::Vector3 m_parentCenterOfMass = AZ::Vector3::CreateZero();
         AzPhysics::RigidBodyConfiguration m_bodyConfiguration; //!< Either rigid dynamic or rigid static

--- a/Gems/Blast/Code/Source/Actor/BlastActorImpl.cpp
+++ b/Gems/Blast/Code/Source/Actor/BlastActorImpl.cpp
@@ -15,6 +15,7 @@
 #include <AzFramework/Physics/Shape.h>
 #include <AzFramework/Physics/SystemBus.h>
 #include <AzFramework/Physics/Utils.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 #include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
 #include <Blast/BlastActor.h>
 #include <Family/BlastFamily.h>
@@ -55,8 +56,15 @@ namespace Blast
 
     void BlastActorImpl::Spawn()
     {
+        // Get physics material from id
+        AZStd::shared_ptr<Physics::Material2> physicsMaterial = AZ::Interface<Physics::MaterialManager>::Get()->GetMaterial(m_physicsMaterialId);
+        if (!physicsMaterial)
+        {
+            physicsMaterial = AZ::Interface<Physics::MaterialManager>::Get()->GetDefaultMaterial();
+        }
+
         // Add shapes for each of the visible chunks
-        AddShapes(m_chunkIndices, m_family.GetPxAsset(), m_physicsMaterialId);
+        AddShapes(m_chunkIndices, m_family.GetPxAsset(), physicsMaterial->GetMaterialAsset());
 
         m_entity->Init();
         m_entity->Activate();
@@ -87,7 +95,7 @@ namespace Blast
 
     void BlastActorImpl::AddShapes(
         const AZStd::vector<uint32_t>& chunkIndices, const Nv::Blast::ExtPxAsset& asset,
-        const Physics::MaterialId& material)
+        const AZ::Data::Asset<Physics::MaterialAsset>& physicsMaterialAsset)
     {
         const Nv::Blast::ExtPxChunk* pxChunks = asset.getChunks();
         const Nv::Blast::ExtPxSubchunk* pxSubchunks = asset.getSubchunks();
@@ -121,7 +129,7 @@ namespace Blast
 
                 auto& subchunk = pxSubchunks[subchunkIndex];
                 AZ::Transform transform = PxMathConvert(subchunk.transform);
-                auto colliderConfiguration = CalculateColliderConfiguration(transform, material);
+                auto colliderConfiguration = CalculateColliderConfiguration(transform, physicsMaterialAsset);
 
                 Physics::NativeShapeConfiguration shapeConfiguration;
                 shapeConfiguration.m_nativeShapePtr =
@@ -139,14 +147,14 @@ namespace Blast
     }
 
     Physics::ColliderConfiguration BlastActorImpl::CalculateColliderConfiguration(
-        const AZ::Transform& transform, Physics::MaterialId material)
+        const AZ::Transform& transform, const AZ::Data::Asset<Physics::MaterialAsset>& physicsMaterialAsset)
     {
         auto& actorConfiguration = m_family.GetActorConfiguration();
         Physics::ColliderConfiguration colliderConfiguration;
         colliderConfiguration.m_position = transform.GetTranslation();
         colliderConfiguration.m_rotation = transform.GetRotation();
         colliderConfiguration.m_isExclusive = true;
-        colliderConfiguration.m_materialSelection.SetMaterialId(material);
+        colliderConfiguration.m_materialSlots.SetMaterialAsset(0, physicsMaterialAsset);
         colliderConfiguration.m_collisionGroupId = actorConfiguration.m_collisionGroupId;
         colliderConfiguration.m_collisionLayer = actorConfiguration.m_collisionLayer;
         colliderConfiguration.m_isInSceneQueries = actorConfiguration.m_isInSceneQueries;

--- a/Gems/Blast/Code/Source/Actor/BlastActorImpl.h
+++ b/Gems/Blast/Code/Source/Actor/BlastActorImpl.h
@@ -49,15 +49,15 @@ namespace Blast
         //! a separate Spawn method that invokes CalculateColliderConfiguration, since if it's invoked from
         //! constructor it does not call override method.
         virtual Physics::ColliderConfiguration CalculateColliderConfiguration(
-            const AZ::Transform& transform, Physics::MaterialId material);
+            const AZ::Transform& transform, const AZ::Data::Asset<Physics::MaterialAsset>& physicsMaterialAsset);
 
         //! Static function to add shapes, based on a list of indices that references chunks in a Blast asset.
         //! @param chunkIndices The indices of chunks in the asset parameter that will instantiate shapes.
         //! @param asset The Blast asset that stores chunk data based on indices.
-        //! @param material The PhysX material to use to create shapes.
+        //! @param physicsMaterialAsset The physics material assset to use to create shapes.
         void AddShapes(
             const AZStd::vector<uint32_t>& chunkIndices, const Nv::Blast::ExtPxAsset& asset,
-            const Physics::MaterialId& material);
+            const AZ::Data::Asset<Physics::MaterialAsset>& physicsMaterialAsset);
 
         const BlastFamily& m_family;
         Nv::Blast::TkActor& m_tkActor;
@@ -69,7 +69,7 @@ namespace Blast
         bool m_isStatic;
 
         // Stored from BlastActorDescription, because we can't use them right away in constructor
-        Physics::MaterialId m_physicsMaterialId;
+        Physics::MaterialId2 m_physicsMaterialId;
         AZ::Vector3 m_parentLinearVelocity = AZ::Vector3::CreateZero();
         AZ::Vector3 m_parentCenterOfMass = AZ::Vector3::CreateZero();
         AzPhysics::RigidBodyConfiguration m_bodyConfiguration;

--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.cpp
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.cpp
@@ -17,12 +17,13 @@
 #include <AzCore/std/smart_ptr/make_shared.h>
 #include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Physics/SystemBus.h>
-#include <AzFramework/Physics/MaterialBus.h>
 #include <AzFramework/Physics/Collision/CollisionEvents.h>
 #include <AzFramework/Physics/Common/PhysicsTypes.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 #include <Blast/BlastActor.h>
 #include <Blast/BlastSystemBus.h>
 #include <Material/BlastMaterial.h>
+#include <PhysX/Material/PhysXMaterial.h>
 #include <Common/Utils.h>
 #include <Components/BlastFamilyComponentNotificationBusHandler.h>
 #include <Components/BlastMeshDataComponent.h>
@@ -37,11 +38,11 @@ namespace Blast
     BlastFamilyComponent::BlastFamilyComponent(
         AZ::Data::Asset<BlastAsset> blastAsset,
         AZ::Data::Asset<MaterialAsset> blastMaterialAsset,
-        Physics::MaterialId physicsMaterialId,
+        AZ::Data::Asset<Physics::MaterialAsset> physicsMaterialAsset,
         const BlastActorConfiguration& actorConfiguration)
         : m_blastAsset(blastAsset)
         , m_blastMaterialAsset(blastMaterialAsset)
-        , m_physicsMaterialId(physicsMaterialId)
+        , m_physicsMaterialAsset(physicsMaterialAsset)
         , m_actorConfiguration(actorConfiguration)
         , m_debugRenderMode(DebugRenderDisabled)
     {
@@ -57,10 +58,10 @@ namespace Blast
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<BlastFamilyComponent, AZ::Component>()
-                ->Version(3)
+                ->Version(4)
                 ->Field("BlastAsset", &BlastFamilyComponent::m_blastAsset)
                 ->Field("BlastMaterialAsset", &BlastFamilyComponent::m_blastMaterialAsset)
-                ->Field("PhysicsMaterial", &BlastFamilyComponent::m_physicsMaterialId)
+                ->Field("PhysicsMaterialAsset", &BlastFamilyComponent::m_physicsMaterialAsset)
                 ->Field("ActorConfiguration", &BlastFamilyComponent::m_actorConfiguration);
         }
 
@@ -241,6 +242,15 @@ namespace Blast
             m_blastMaterial = AZStd::make_unique<Material>(MaterialConfiguration{});
         }
 
+        // Create physx material instance
+        m_physxMaterial = PhysX::Material2::FindOrCreateMaterial(m_physicsMaterialAsset);
+        if (!m_physxMaterial)
+        {
+            m_physxMaterial =
+                AZStd::rtti_pointer_cast<PhysX::Material2>(
+                    AZ::Interface<Physics::MaterialManager>::Get()->GetDefaultMaterial());
+        }
+
         auto blastSystem = AZ::Interface<BlastSystemRequests>::Get();
 
         // Create family
@@ -248,7 +258,7 @@ namespace Blast
             {*m_blastAsset.Get(),
              this,
              blastSystem->CreateTkGroup(), // Blast system takes care of destroying this group when it's empty.
-             m_physicsMaterialId,
+             m_physxMaterial->GetId(),
              m_blastMaterial.get(),
              AZStd::make_shared<BlastActorFactoryImpl>(),
              EntityProvider::Create(),
@@ -264,22 +274,7 @@ namespace Blast
             const_cast<NvBlastFamily&>(*m_family->GetTkFamily()->getFamilyLL()), stressSolverSettings);
         m_solver = physx::unique_ptr<Nv::Blast::ExtStressSolver>(solverPtr);
 
-        AZStd::shared_ptr<Physics::Material> physicsMaterial;
-        Physics::PhysicsMaterialRequestBus::BroadcastResult(
-            physicsMaterial,
-            &Physics::PhysicsMaterialRequestBus::Events::GetMaterialById,
-            m_physicsMaterialId);
-        if (!physicsMaterial)
-        {
-            AZ_Warning("BlastFamilyComponent", false, "Material Id %s was not found, using default material instead.",
-                m_physicsMaterialId.GetUuid().ToString<AZStd::string>().c_str());
-
-            Physics::PhysicsMaterialRequestBus::BroadcastResult(
-                physicsMaterial,
-                &Physics::PhysicsMaterialRequestBus::Events::GetGenericDefaultMaterial);
-            AZ_Assert(physicsMaterial, "BlastFamilyComponent: Invalid default physics material");
-        }
-        m_solver->setAllNodesInfoFromLL(physicsMaterial->GetDensity());
+        m_solver->setAllNodesInfoFromLL(m_physxMaterial->GetDensity());
 
         // Create damage and actor render managers
         m_damageManager = AZStd::make_unique<DamageManager>(m_blastMaterial.get(), m_family->GetActorTracker());
@@ -329,6 +324,7 @@ namespace Blast
         m_solver.reset();
         m_family.reset();
         m_blastMaterial.reset();
+        m_physxMaterial.reset();
 
         m_isSpawned = false;
     }

--- a/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
+++ b/Gems/Blast/Code/Source/Components/BlastFamilyComponent.h
@@ -14,6 +14,7 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzFramework/Physics/Common/PhysicsSimulatedBodyEvents.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialAsset.h>
 #include <Blast/BlastDebug.h>
 #include <Blast/BlastFamilyComponentBus.h>
 #include <Material/BlastMaterialAsset.h>
@@ -28,6 +29,11 @@
 namespace AzPhysics
 {
     struct CollisionEvent;
+}
+
+namespace PhysX
+{
+    class Material2;
 }
 
 namespace Blast
@@ -46,7 +52,7 @@ namespace Blast
         BlastFamilyComponent(
             AZ::Data::Asset<BlastAsset> blastAsset,
             AZ::Data::Asset<MaterialAsset> blastMaterialAsset,
-            Physics::MaterialId physicsMaterialId,
+            AZ::Data::Asset<Physics::MaterialAsset> physicsMaterialAsset,
             const BlastActorConfiguration& actorConfiguration);
 
         BlastFamilyComponent() = default;
@@ -114,13 +120,16 @@ namespace Blast
         // Blast material instance
         AZStd::unique_ptr<Material> m_blastMaterial;
 
+        // PhysX material instance
+        AZStd::shared_ptr<PhysX::Material2> m_physxMaterial;
+
         // Dependencies
         BlastMeshData* m_meshDataComponent = nullptr;
 
         // Configurations
         AZ::Data::Asset<BlastAsset> m_blastAsset;
         AZ::Data::Asset<MaterialAsset> m_blastMaterialAsset;
-        Physics::MaterialId m_physicsMaterialId;
+        AZ::Data::Asset<Physics::MaterialAsset> m_physicsMaterialAsset;
         const BlastActorConfiguration m_actorConfiguration{};
 
         bool m_isSpawned = false;

--- a/Gems/Blast/Code/Source/Editor/EditorBlastFamilyComponent.cpp
+++ b/Gems/Blast/Code/Source/Editor/EditorBlastFamilyComponent.cpp
@@ -22,11 +22,11 @@ namespace Blast
         if (AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<EditorBlastFamilyComponent, EditorComponentBase>()
-                ->Version(2)
+                ->Version(4)
                 ->Field("BlastAsset", &EditorBlastFamilyComponent::m_blastAsset)
                 ->Field("BlastMaterialAsset", &EditorBlastFamilyComponent::m_blastMaterialAsset)
                 ->Field("BlastMaterial", &EditorBlastFamilyComponent::m_legacyBlastMaterialId)
-                ->Field("PhysicsMaterial", &EditorBlastFamilyComponent::m_physicsMaterialId)
+                ->Field("PhysicsMaterialAsset", &EditorBlastFamilyComponent::m_physicsMaterialAsset)
                 ->Field("ActorConfiguration", &EditorBlastFamilyComponent::m_actorConfiguration);
 
             if (AZ::EditContext* ec = serialize->GetEditContext())
@@ -49,12 +49,14 @@ namespace Blast
                         ->Attribute(AZ_CRC_CE("EditButton"), "")
                         ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
                         ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
+
                     ->DataElement(
-                        AZ::Edit::UIHandlers::Default, &EditorBlastFamilyComponent::m_physicsMaterialId,
-                        "Physics Material", "Assigned physics material from current physics material library")
-                    ->ElementAttribute(
-                        Physics::Attributes::MaterialLibraryAssetId,
-                        &EditorBlastFamilyComponent::GetPhysicsMaterialLibraryAssetId)
+                        AZ::Edit::UIHandlers::Default, &EditorBlastFamilyComponent::m_physicsMaterialAsset, "Physics Material",
+                        "Assigned physics material asset")
+                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &EditorBlastFamilyComponent::GetDefaultPhysicsAssetId)
+                        ->Attribute(AZ_CRC_CE("EditButton"), "")
+                        ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
+                        ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &EditorBlastFamilyComponent::m_actorConfiguration,
                         "Actor configuration", "Configurations for actors in this family");
@@ -127,7 +129,7 @@ namespace Blast
     void EditorBlastFamilyComponent::BuildGameEntity(AZ::Entity* gameEntity)
     {
         gameEntity->CreateComponent<BlastFamilyComponent>(
-            m_blastAsset, m_blastMaterialAsset, m_physicsMaterialId, m_actorConfiguration);
+            m_blastAsset, m_blastMaterialAsset, m_physicsMaterialAsset, m_actorConfiguration);
     }
 
     AZ::Data::AssetId EditorBlastFamilyComponent::GetPhysicsMaterialLibraryAssetId() const
@@ -139,6 +141,14 @@ namespace Blast
     {
         // Used for Edit Context.
         // When the blast material asset property doesn't have an asset assigned it
+        // will show "(default)" to indicate that the default material will be used.
+        return {};
+    }
+
+    AZ::Data::AssetId EditorBlastFamilyComponent::GetDefaultPhysicsAssetId() const
+    {
+        // Used for Edit Context.
+        // When the physics material asset property doesn't have an asset assigned it
         // will show "(default)" to indicate that the default material will be used.
         return {};
     }

--- a/Gems/Blast/Code/Source/Editor/EditorBlastFamilyComponent.h
+++ b/Gems/Blast/Code/Source/Editor/EditorBlastFamilyComponent.h
@@ -9,7 +9,7 @@
 
 #include <Asset/BlastAsset.h>
 #include <AzCore/Component/Component.h>
-#include <AzFramework/Physics/Material.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialAsset.h>
 #include <Blast/BlastActorConfiguration.h>
 #include <Blast/BlastDebug.h>
 #include <Material/BlastMaterialAsset.h>
@@ -52,12 +52,14 @@ namespace Blast
         AZ::Data::AssetId GetPhysicsMaterialLibraryAssetId() const;
 
         AZ::Data::AssetId GetDefaultBlastAssetId() const;
+        AZ::Data::AssetId GetDefaultPhysicsAssetId() const;
 
         // Configurations
         AZ::Data::Asset<BlastAsset> m_blastAsset;
         AZ::Data::Asset<MaterialAsset> m_blastMaterialAsset;
         BlastMaterialId m_legacyBlastMaterialId; // Kept to convert old blast material assets. It will be removed eventually.
-        Physics::MaterialId m_physicsMaterialId;
+        AZ::Data::Asset<Physics::MaterialAsset> m_physicsMaterialAsset;
+
         BlastActorConfiguration m_actorConfiguration;
     };
 } // namespace Blast

--- a/Gems/Blast/Code/Source/Family/BlastFamily.h
+++ b/Gems/Blast/Code/Source/Family/BlastFamily.h
@@ -40,7 +40,7 @@ namespace Blast
         BlastAsset& m_asset; //!< Blast asset to create from.
         BlastListener* m_listener = nullptr; //!< Blast listener to notify about actor creations/destructions, this would generally be BlastFamilyComponent instance.
         Nv::Blast::TkGroup* m_group = nullptr; //!< if not nullptr created TkActor (and TkFamily) will be placed in this group
-        Physics::MaterialId m_physicsMaterial;
+        Physics::MaterialId2 m_physicsMaterialId;
         const Material* m_blastMaterial = nullptr;
         AZStd::shared_ptr<BlastActorFactory> m_actorFactory;
         AZStd::shared_ptr<EntityProvider> m_entityProvider;

--- a/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
+++ b/Gems/Blast/Code/Source/Family/BlastFamilyImpl.cpp
@@ -38,7 +38,7 @@ namespace Blast
         , m_actorFactory(desc.m_actorFactory)
         , m_entityProvider(desc.m_entityProvider)
         , m_listener(desc.m_listener)
-        , m_physicsMaterialId(desc.m_physicsMaterial)
+        , m_physicsMaterialId(desc.m_physicsMaterialId)
         , m_blastMaterial(desc.m_blastMaterial)
         , m_actorConfiguration(desc.m_actorConfiguration)
         , m_isSpawned(false)

--- a/Gems/Blast/Code/Source/Family/BlastFamilyImpl.h
+++ b/Gems/Blast/Code/Source/Family/BlastFamilyImpl.h
@@ -84,7 +84,7 @@ namespace Blast
         AZStd::shared_ptr<EntityProvider> m_entityProvider;
         BlastListener* m_listener;
 
-        const Physics::MaterialId m_physicsMaterialId;
+        Physics::MaterialId2 m_physicsMaterialId;
         const Material* m_blastMaterial = nullptr;
         const BlastActorConfiguration& m_actorConfiguration;
         AZ::Transform m_initialTransform;

--- a/Gems/Blast/Code/Tests/BlastActorTest.cpp
+++ b/Gems/Blast/Code/Tests/BlastActorTest.cpp
@@ -32,7 +32,7 @@ namespace Blast
 
     protected:
         Physics::ColliderConfiguration CalculateColliderConfiguration(
-            [[maybe_unused]] const AZ::Transform& transform, [[maybe_unused]] Physics::MaterialId material) override
+            [[maybe_unused]] const AZ::Transform& transform, [[maybe_unused]] const AZ::Data::Asset<Physics::MaterialAsset>& physicsMaterialAsset) override
         {
             return Physics::ColliderConfiguration();
         }
@@ -50,9 +50,14 @@ namespace Blast
             m_mockPhysicsSystemRequestsHandler = AZStd::make_unique<MockPhysicsSystemRequestsHandler>();
             m_mockPhysicsDefaultWorldRequestsHandler = AZStd::make_unique<MockPhysicsDefaultWorldRequestsHandler>();
             m_mockRigidBodyRequestBusHandler = AZStd::make_unique<MockRigidBodyRequestBusHandler>();
+            m_physicsMaterialManager = AZStd::make_unique<DummyPhysicsMaterialManager>();
+            m_physicsMaterialManager->Init();
         }
 
-        void TearDown() override {}
+        void TearDown() override
+        {
+            m_physicsMaterialManager.reset();
+        }
 
         AZStd::unique_ptr<FakeBlastFamily> m_mockFamily;
         AZStd::unique_ptr<MockTkActor> m_mockTkActor;
@@ -60,6 +65,7 @@ namespace Blast
         AZStd::unique_ptr<MockPhysicsSystemRequestsHandler> m_mockPhysicsSystemRequestsHandler;
         AZStd::unique_ptr<MockPhysicsDefaultWorldRequestsHandler> m_mockPhysicsDefaultWorldRequestsHandler;
         AZStd::unique_ptr<MockRigidBodyRequestBusHandler> m_mockRigidBodyRequestBusHandler;
+        AZStd::unique_ptr<DummyPhysicsMaterialManager> m_physicsMaterialManager;
 
         AZStd::unique_ptr<BlastActor> m_blastActor;
     };
@@ -76,7 +82,7 @@ namespace Blast
         auto actorDesc = BlastActorDesc
             {m_mockFamily.get(),
              m_mockTkActor.get(),
-             Physics::MaterialId(),
+             Physics::MaterialId2(),
              AZ::Vector3::CreateZero(),
              AZ::Vector3::CreateZero(),
              configuration,

--- a/Gems/Blast/Code/Tests/BlastFamilyTest.cpp
+++ b/Gems/Blast/Code/Tests/BlastFamilyTest.cpp
@@ -41,6 +41,8 @@ namespace Blast
             m_mockPxAsset = AZStd::make_unique<FakeExtPxAsset>(actorDesc);
             m_asset = AZStd::make_unique<BlastAsset>(m_mockPxAsset.get());
             m_blastMaterial = AZStd::make_unique<Material>(MaterialConfiguration());
+            m_physicsMaterialManager = AZStd::make_unique<DummyPhysicsMaterialManager>();
+            m_physicsMaterialManager->Init();
 
             m_systemHandler = AZStd::make_shared<MockBlastSystemBusHandler>();
             m_mockTkFramework = AZStd::make_unique<MockTkFramework>();
@@ -53,6 +55,7 @@ namespace Blast
         {
             m_fakeActorFactory = nullptr;
             m_systemHandler = nullptr;
+            m_physicsMaterialManager.reset();
         }
 
         AZStd::shared_ptr<FakeActorFactory> m_fakeActorFactory;
@@ -60,6 +63,7 @@ namespace Blast
         AZStd::unique_ptr<FakeExtPxAsset> m_mockPxAsset;
         AZStd::unique_ptr<BlastAsset> m_asset;
         AZStd::unique_ptr<Material> m_blastMaterial;
+        AZStd::unique_ptr<DummyPhysicsMaterialManager> m_physicsMaterialManager;
 
         AZStd::shared_ptr<MockBlastSystemBusHandler> m_systemHandler;
         AZStd::unique_ptr<MockTkFramework> m_mockTkFramework;
@@ -91,7 +95,7 @@ namespace Blast
                 {*m_asset,
                  m_mockListener.get(),
                  nullptr,
-                 Physics::MaterialId(),
+                 Physics::MaterialId2(),
                  m_blastMaterial.get(),
                  m_fakeActorFactory,
                  m_fakeEntityProvider,


### PR DESCRIPTION
**This PR is part of the work to refactoring physics materials. It's NOT merging to development branch.**

Physics materials doesn't have a library of materials, it works like render materials in the sense that 1 asset is 1 material, so in the blast component now instead of a dropdown menu there is the typical asset field to assign a physics material.

All unit tests of Blass pass.

Signed-off-by: moraaar <moraaar@amazon.com>