### PR TITLE
[4/4] Using new material classes in Terrain.

### DIFF
--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.cpp
@@ -9,6 +9,7 @@
 
 #include <Components/TerrainPhysicsColliderComponent.h>
 
+#include <AzCore/Asset/AssetSerializer.h>
 #include <AzCore/Asset/AssetManagerBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TransformBus.h>
@@ -18,8 +19,6 @@
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/Serialization/SerializeContext.h>
 
-#include <AzFramework/Physics/Material.h>
-#include <AzFramework/Physics/PhysicsSystem.h>
 #include <AzFramework/Terrain/TerrainDataRequestBus.h>
 #include <AzFramework/Physics/HeightfieldProviderBus.h>
 
@@ -57,23 +56,11 @@ namespace Terrain
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<TerrainPhysicsSurfaceMaterialMapping>()
-                ->Version(1)
+                ->Version(3)
                 ->Field("Surface", &TerrainPhysicsSurfaceMaterialMapping::m_surfaceTag)
-                ->Field("Material", &TerrainPhysicsSurfaceMaterialMapping::m_materialId);
+                ->Field("MaterialAsset", &TerrainPhysicsSurfaceMaterialMapping::m_materialAsset)
+            ;
         }
-    }
-
-
-    AZ::Data::AssetId TerrainPhysicsSurfaceMaterialMapping::GetMaterialLibraryId()
-    {
-        if (const auto* physicsSystem = AZ::Interface<AzPhysics::SystemInterface>::Get())
-        {
-            if (const auto* physicsConfiguration = physicsSystem->GetConfiguration())
-            {
-                return physicsConfiguration->m_materialLibraryAsset.GetId();
-            }
-        }
-        return {};
     }
 
     void TerrainPhysicsColliderConfig::Reflect(AZ::ReflectContext* context)
@@ -83,8 +70,8 @@ namespace Terrain
         if (auto serialize = azrtti_cast<AZ::SerializeContext*>(context))
         {
             serialize->Class<TerrainPhysicsColliderConfig>()
-                ->Version(3)
-                ->Field("DefaultMaterial", &TerrainPhysicsColliderConfig::m_defaultMaterialSelection)
+                ->Version(5)
+                ->Field("DefaultMaterialAsset", &TerrainPhysicsColliderConfig::m_defaultMaterialAsset)
                 ->Field("Mappings", &TerrainPhysicsColliderConfig::m_surfaceMaterialMappings)
             ;
         }
@@ -301,9 +288,11 @@ namespace Terrain
             worldSize, gridResolution, perPositionHeightCallback, AzFramework::Terrain::TerrainDataRequests::Sampler::DEFAULT);
     }
 
-    uint8_t TerrainPhysicsColliderComponent::GetMaterialIdIndex(const Physics::MaterialId& materialId, const AZStd::vector<Physics::MaterialId>& materialList) const
+    uint8_t TerrainPhysicsColliderComponent::GetMaterialIndex(
+        const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset,
+        const AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>>& materialList) const
     {
-        const auto& materialIter = AZStd::find(materialList.begin(), materialList.end(), materialId);
+        const auto& materialIter = AZStd::find(materialList.begin(), materialList.end(), materialAsset);
         if (materialIter != materialList.end())
         {
             return static_cast<uint8_t>(materialIter - materialList.begin());
@@ -312,7 +301,7 @@ namespace Terrain
         return 0;
     }
 
-    Physics::MaterialId TerrainPhysicsColliderComponent::FindMaterialIdForSurfaceTag(const SurfaceData::SurfaceTag tag) const
+    AZ::Data::Asset<Physics::MaterialAsset> TerrainPhysicsColliderComponent::FindMaterialAssetForSurfaceTag(const SurfaceData::SurfaceTag tag) const
     {
         uint8_t index = 0;
 
@@ -320,13 +309,13 @@ namespace Terrain
         {
             if (mapping.m_surfaceTag == tag)
             {
-                return mapping.m_materialId;
+                return mapping.m_materialAsset;
             }
             index++;
         }
 
         // If this surface isn't mapped, use the default material.
-        return m_configuration.m_defaultMaterialSelection.GetMaterialId();
+        return m_configuration.m_defaultMaterialAsset;
     }
 
     void TerrainPhysicsColliderComponent::UpdateHeightsAndMaterials(
@@ -378,7 +367,7 @@ namespace Terrain
         int32_t gridWidth, gridHeight;
         GetHeightfieldGridSize(gridWidth, gridHeight);
 
-        AZStd::vector<Physics::MaterialId> materialList = GetMaterialList();
+        AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> materialList = GetMaterialList();
 
         auto perPositionCallback = [xOffset, yOffset, &updateHeightsMaterialsCallback, &materialList, this, worldCenterZ, worldHeightBoundsMin, worldHeightBoundsMax]
             (size_t xIndex, size_t yIndex, const AzFramework::SurfaceData::SurfacePoint& surfacePoint, bool terrainExists)
@@ -404,8 +393,8 @@ namespace Terrain
             Physics::HeightMaterialPoint point;
             point.m_height = height - worldCenterZ;
             point.m_quadMeshType = terrainExists ? Physics::QuadMeshType::SubdivideUpperLeftToBottomRight : Physics::QuadMeshType::Hole;
-            Physics::MaterialId materialId = FindMaterialIdForSurfaceTag(surfaceWeight.m_surfaceType);
-            point.m_materialIndex = GetMaterialIdIndex(materialId, materialList);
+            AZ::Data::Asset<Physics::MaterialAsset> materialAsset = FindMaterialAssetForSurfaceTag(surfaceWeight.m_surfaceType);
+            point.m_materialIndex = GetMaterialIndex(materialAsset, materialList);
 
             int32_t column = aznumeric_cast<int32_t>(xOffset + xIndex);
             int32_t row = aznumeric_cast<int32_t>(yOffset + yIndex);
@@ -460,19 +449,20 @@ namespace Terrain
         return numRows;
     }
 
-    AZStd::vector<Physics::MaterialId> TerrainPhysicsColliderComponent::GetMaterialList() const
+    AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> TerrainPhysicsColliderComponent::GetMaterialList() const
     {
-        AZStd::vector<Physics::MaterialId> materialList;
+        AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> materialList;
+        materialList.reserve(m_configuration.m_surfaceMaterialMappings.size() + 1); // +1 for default material asset
 
         // Ensure the list contains the default material as the first entry.
-        materialList.emplace_back(m_configuration.m_defaultMaterialSelection.GetMaterialId());
+        materialList.push_back(m_configuration.m_defaultMaterialAsset);
 
         for (auto& mapping : m_configuration.m_surfaceMaterialMappings)
         {
-            const auto& existingInstance = AZStd::find(materialList.begin(), materialList.end(), mapping.m_materialId);
-            if (existingInstance == materialList.end())
+            const auto& existingInstance = AZStd::find(materialList.begin(), materialList.end(), mapping.m_materialAsset);
+            if (existingInstance == materialList.end()) // Avoid having the same asset more than once
             {
-                materialList.emplace_back(mapping.m_materialId);
+                materialList.push_back(mapping.m_materialAsset);
             }
         }
 

--- a/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
+++ b/Gems/Terrain/Code/Source/Components/TerrainPhysicsColliderComponent.h
@@ -10,9 +10,9 @@
 
 #include <AzCore/Component/Component.h>
 #include <AzCore/Math/Aabb.h>
+#include <AzCore/Asset/AssetCommon.h>
 
 #include <AzFramework/Physics/HeightfieldProviderBus.h>
-#include <AzFramework/Physics/Material.h>
 #include <SurfaceData/SurfaceTag.h>
 #include <TerrainSystem/TerrainSystemBus.h>
 
@@ -36,13 +36,13 @@ namespace Terrain
         AZ_CLASS_ALLOCATOR(TerrainPhysicsSurfaceMaterialMapping, AZ::SystemAllocator, 0);
         AZ_TYPE_INFO(TerrainPhysicsSurfaceMaterialMapping, "{A88B5289-DFCD-4564-8395-E2177DFE5B18}");
         static void Reflect(AZ::ReflectContext* context);
-        static AZ::Data::AssetId GetMaterialLibraryId();
 
         AZStd::vector<AZStd::pair<AZ::u32, AZStd::string>> BuildSelectableTagList() const;
         void SetTagListProvider(const EditorSurfaceTagListProvider* tagListProvider);
+        AZ::Data::AssetId GetDefaultPhysicsAssetId() const;
 
         SurfaceData::SurfaceTag m_surfaceTag;
-        Physics::MaterialId m_materialId;
+        AZ::Data::Asset<Physics::MaterialAsset> m_materialAsset;
 
     private:
         const EditorSurfaceTagListProvider* m_tagListProvider = nullptr;
@@ -55,7 +55,9 @@ namespace Terrain
         AZ_TYPE_INFO(TerrainPhysicsColliderConfig, "{E9EADB8F-C3A5-4B9C-A62D-2DBC86B4CE59}");
         static void Reflect(AZ::ReflectContext* context);
 
-        Physics::MaterialSelection m_defaultMaterialSelection;
+        AZ::Data::AssetId GetDefaultPhysicsAssetId() const;
+
+        AZ::Data::Asset<Physics::MaterialAsset> m_defaultMaterialAsset;
         AZStd::vector<TerrainPhysicsSurfaceMaterialMapping> m_surfaceMaterialMappings;
     };
 
@@ -89,7 +91,7 @@ namespace Terrain
         float GetHeightfieldMaxHeight() const override;
         AZ::Aabb GetHeightfieldAabb() const override;
         AZ::Transform GetHeightfieldTransform() const override;
-        AZStd::vector<Physics::MaterialId> GetMaterialList() const override;
+        AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> GetMaterialList() const override;
         AZStd::vector<float> GetHeights() const override;
         AZStd::vector<Physics::HeightMaterialPoint> GetHeightsAndMaterials() const override;
         void UpdateHeightsAndMaterials(const Physics::UpdateHeightfieldSampleFunction& updateHeightsMaterialsCallback,
@@ -103,8 +105,8 @@ namespace Terrain
         void Activate() override;
         void Deactivate() override;
 
-        uint8_t GetMaterialIdIndex(const Physics::MaterialId& materialId, const AZStd::vector<Physics::MaterialId>& materialList) const;
-        Physics::MaterialId FindMaterialIdForSurfaceTag(const SurfaceData::SurfaceTag tag) const;
+        uint8_t GetMaterialIndex(const AZ::Data::Asset<Physics::MaterialAsset>& materialAsset, const AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>>& materialList) const;
+        AZ::Data::Asset<Physics::MaterialAsset> FindMaterialAssetForSurfaceTag(const SurfaceData::SurfaceTag tag) const;
 
         void GenerateHeightsInBounds(AZStd::vector<float>& heights) const;
         AZ::Aabb GetRegionClampedToGrid(const AZ::Aabb& region) const;

--- a/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
+++ b/Gems/Terrain/Code/Source/EditorComponents/EditorTerrainPhysicsColliderComponent.cpp
@@ -36,10 +36,11 @@ namespace Terrain
                         "Surface type to map to a physics material.")
                     ->Attribute(AZ::Edit::Attributes::EnumValues, &TerrainPhysicsSurfaceMaterialMapping::BuildSelectableTagList)
 
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainPhysicsSurfaceMaterialMapping::m_materialId, "Material ID", "")
-                    ->ElementAttribute(Physics::Attributes::MaterialLibraryAssetId, &TerrainPhysicsSurfaceMaterialMapping::GetMaterialLibraryId)
-                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->Attribute(AZ::Edit::Attributes::ShowProductAssetFileName, true)
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainPhysicsSurfaceMaterialMapping::m_materialAsset, "Material Asset", "")
+                    ->Attribute(AZ::Edit::Attributes::DefaultAsset, &TerrainPhysicsSurfaceMaterialMapping::GetDefaultPhysicsAssetId)
+                    ->Attribute(AZ_CRC_CE("EditButton"), "")
+                    ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
+                    ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
                     ;
 
                 edit->Class<TerrainPhysicsColliderConfig>(
@@ -48,8 +49,12 @@ namespace Terrain
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
-                    ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainPhysicsColliderConfig::m_defaultMaterialSelection,
+                    ->DataElement(AZ::Edit::UIHandlers::Default, &TerrainPhysicsColliderConfig::m_defaultMaterialAsset,
                         "Default Surface Physics Material", "Select a material to be used by unmapped surfaces by default")
+                        ->Attribute(AZ::Edit::Attributes::DefaultAsset, &TerrainPhysicsColliderConfig::GetDefaultPhysicsAssetId)
+                        ->Attribute(AZ_CRC_CE("EditButton"), "")
+                        ->Attribute(AZ_CRC_CE("EditDescription"), "Open in Asset Editor")
+                        ->Attribute(AZ_CRC_CE("DisableEditButtonWhenNoAssetSelected"), true)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default, &TerrainPhysicsColliderConfig::m_surfaceMaterialMappings,
                         "Surface to Material Mappings", "Maps surfaces to physics materials")
@@ -149,5 +154,21 @@ namespace Terrain
     void TerrainPhysicsSurfaceMaterialMapping::SetTagListProvider(const EditorSurfaceTagListProvider* tagListProvider)
     {
         m_tagListProvider = tagListProvider;
+    }
+
+    AZ::Data::AssetId TerrainPhysicsSurfaceMaterialMapping::GetDefaultPhysicsAssetId() const
+    {
+        // Used for Edit Context.
+        // When the physics material asset property doesn't have an asset assigned it
+        // will show "(default)" to indicate that the default material will be used.
+        return {};
+    }
+
+    AZ::Data::AssetId TerrainPhysicsColliderConfig::GetDefaultPhysicsAssetId() const
+    {
+        // Used for Edit Context.
+        // When the physics material asset property doesn't have an asset assigned it
+        // will show "(default)" to indicate that the default material will be used.
+        return {};
     }
 }

--- a/Gems/Terrain/Code/Tests/TerrainPhysicsColliderTests.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainPhysicsColliderTests.cpp
@@ -305,34 +305,34 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderReturnsMateria
     // Create two SurfaceTag/Material mappings and add them to the collider.
     Terrain::TerrainPhysicsColliderConfig config;
 
-    const Physics::MaterialId mat1 = Physics::MaterialId::Create();
-    const Physics::MaterialId mat2 = Physics::MaterialId::Create();
+    const AZ::Data::Asset<Physics::MaterialAsset> mat1(AZ::Data::AssetId(AZ::Uuid::CreateRandom()), nullptr);
+    const AZ::Data::Asset<Physics::MaterialAsset> mat2(AZ::Data::AssetId(AZ::Uuid::CreateRandom()), nullptr);
 
     const SurfaceData::SurfaceTag tag1 = SurfaceData::SurfaceTag("tag1");
     const SurfaceData::SurfaceTag tag2 = SurfaceData::SurfaceTag("tag2");
 
     Terrain::TerrainPhysicsSurfaceMaterialMapping mapping1;
-    mapping1.m_materialId = mat1;
+    mapping1.m_materialAsset = mat1;
     mapping1.m_surfaceTag = tag1;
     config.m_surfaceMaterialMappings.emplace_back(mapping1);
 
     Terrain::TerrainPhysicsSurfaceMaterialMapping mapping2;
-    mapping2.m_materialId = mat2;
+    mapping2.m_materialAsset = mat2;
     mapping2.m_surfaceTag = tag2;
     config.m_surfaceMaterialMappings.emplace_back(mapping2);
 
     AddTerrainPhysicsColliderToEntity(config);
     ActivateEntity(m_entity.get());
 
-    AZStd::vector<Physics::MaterialId> materialList;
+    AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> materialList;
     Physics::HeightfieldProviderRequestsBus::EventResult(
         materialList, m_entity->GetId(), &Physics::HeightfieldProviderRequestsBus::Events::GetMaterialList);
 
     // The materialList should be 3 items long: the two materials we've added, plus a default material.
     EXPECT_EQ(materialList.size(), 3);
 
-    Physics::MaterialId defaultMaterial = Physics::MaterialId();
-    EXPECT_EQ(materialList[0], defaultMaterial);
+    const AZ::Data::AssetId nullId; // Not having an asset in the slot lead to use the default material
+    EXPECT_EQ(materialList[0].GetId(), nullId);
     EXPECT_EQ(materialList[1], mat1);
     EXPECT_EQ(materialList[2], mat2);
 }
@@ -343,15 +343,15 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderReturnsMateria
     AddTerrainPhysicsColliderToEntity(Terrain::TerrainPhysicsColliderConfig());
     ActivateEntity(m_entity.get());
 
-    AZStd::vector<Physics::MaterialId> materialList;
+    AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> materialList;
     Physics::HeightfieldProviderRequestsBus::EventResult(
         materialList, m_entity->GetId(), &Physics::HeightfieldProviderRequestsBus::Events::GetMaterialList);
 
     // The materialList should be 1 items long: which should be the default material.
     EXPECT_EQ(materialList.size(), 1);
 
-    Physics::MaterialId defaultMaterial = Physics::MaterialId();
-    EXPECT_EQ(materialList[0], defaultMaterial);
+    const AZ::Data::AssetId nullId; // Not having an asset in the slot lead to use the default material
+    EXPECT_EQ(materialList[0].GetId(), nullId);
 }
 
 TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderGetHeightsAndMaterialsReturnsCorrectly)
@@ -360,19 +360,19 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderGetHeightsAndM
     // Create two SurfaceTag/Material mappings and add them to the collider.
     Terrain::TerrainPhysicsColliderConfig config;
 
-    const Physics::MaterialId mat1 = Physics::MaterialId::Create();
-    const Physics::MaterialId mat2 = Physics::MaterialId::Create();
+    const AZ::Data::Asset<Physics::MaterialAsset> mat1(AZ::Data::AssetId(AZ::Uuid::CreateRandom()), nullptr);
+    const AZ::Data::Asset<Physics::MaterialAsset> mat2(AZ::Data::AssetId(AZ::Uuid::CreateRandom()), nullptr);
 
     const SurfaceData::SurfaceTag tag1 = SurfaceData::SurfaceTag("tag1");
     const SurfaceData::SurfaceTag tag2 = SurfaceData::SurfaceTag("tag2");
 
     Terrain::TerrainPhysicsSurfaceMaterialMapping mapping1;
-    mapping1.m_materialId = mat1;
+    mapping1.m_materialAsset = mat1;
     mapping1.m_surfaceTag = tag1;
     config.m_surfaceMaterialMappings.emplace_back(mapping1);
 
     Terrain::TerrainPhysicsSurfaceMaterialMapping mapping2;
-    mapping2.m_materialId = mat2;
+    mapping2.m_materialAsset = mat2;
     mapping2.m_surfaceTag = tag2;
     config.m_surfaceMaterialMappings.emplace_back(mapping2);
 
@@ -432,17 +432,17 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderDefaultMateria
     // Create two SurfaceTag/Material mappings and add them to the collider.
     Terrain::TerrainPhysicsColliderConfig config;
 
-    const Physics::MaterialId defaultSurfaceMaterial = Physics::MaterialId::Create();
-    const Physics::MaterialId mat1 = Physics::MaterialId::Create();
+    const AZ::Data::Asset<Physics::MaterialAsset> defaultSurfaceMaterial(AZ::Data::AssetId(AZ::Uuid::CreateRandom()), nullptr);
+    const AZ::Data::Asset<Physics::MaterialAsset> mat1(AZ::Data::AssetId(AZ::Uuid::CreateRandom()), nullptr);
 
     const SurfaceData::SurfaceTag tag1 = SurfaceData::SurfaceTag("tag1");
     const SurfaceData::SurfaceTag tag2 = SurfaceData::SurfaceTag("tag2");
 
     Terrain::TerrainPhysicsSurfaceMaterialMapping mapping1;
-    mapping1.m_materialId = mat1;
+    mapping1.m_materialAsset = mat1;
     mapping1.m_surfaceTag = tag1;
     config.m_surfaceMaterialMappings.emplace_back(mapping1);
-    config.m_defaultMaterialSelection.SetMaterialId(defaultSurfaceMaterial);
+    config.m_defaultMaterialAsset = defaultSurfaceMaterial;
 
     // Intentionally don't set the mapping for "tag2". It's expected the default material will substitute.
     AddTerrainPhysicsColliderToEntity(config);
@@ -478,7 +478,7 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderDefaultMateria
 
     // Validate material list is generated with the default material
     {
-        AZStd::vector<Physics::MaterialId> materialList;
+        AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> materialList;
         Physics::HeightfieldProviderRequestsBus::EventResult(
             materialList, m_entity->GetId(), &Physics::HeightfieldProviderRequestsBus::Events::GetMaterialList);
 
@@ -510,8 +510,8 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderDefaultMateria
 {
     // Create only the default material with no mapping for the tags. It's expected the default material will be assigned to both tags.
     Terrain::TerrainPhysicsColliderConfig config;    
-    const Physics::MaterialId defaultSurfaceMaterial = Physics::MaterialId::Create();
-    config.m_defaultMaterialSelection.SetMaterialId(defaultSurfaceMaterial);
+    const AZ::Data::Asset<Physics::MaterialAsset> defaultSurfaceMaterial(AZ::Data::AssetId(AZ::Uuid::CreateRandom()), nullptr);
+    config.m_defaultMaterialAsset = defaultSurfaceMaterial;
     AddTerrainPhysicsColliderToEntity(config);
 
     const AZ::Vector3 boundsMin = AZ::Vector3(0.0f);
@@ -548,7 +548,7 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderDefaultMateria
 
     // Validate material list is generated with the default material
     {
-        AZStd::vector<Physics::MaterialId> materialList;
+        AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> materialList;
         Physics::HeightfieldProviderRequestsBus::EventResult(
             materialList, m_entity->GetId(), &Physics::HeightfieldProviderRequestsBus::Events::GetMaterialList);
 

--- a/Gems/Terrain/Code/Tests/TerrainPhysicsColliderTests.cpp
+++ b/Gems/Terrain/Code/Tests/TerrainPhysicsColliderTests.cpp
@@ -331,7 +331,7 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderReturnsMateria
     // The materialList should be 3 items long: the two materials we've added, plus a default material.
     EXPECT_EQ(materialList.size(), 3);
 
-    const AZ::Data::AssetId nullId; // Not having an asset in the slot lead to use the default material
+    const AZ::Data::AssetId nullId; // Select the default material by assigning a null ID to the slot
     EXPECT_EQ(materialList[0].GetId(), nullId);
     EXPECT_EQ(materialList[1], mat1);
     EXPECT_EQ(materialList[2], mat2);
@@ -350,7 +350,7 @@ TEST_F(TerrainPhysicsColliderComponentTest, TerrainPhysicsColliderReturnsMateria
     // The materialList should be 1 items long: which should be the default material.
     EXPECT_EQ(materialList.size(), 1);
 
-    const AZ::Data::AssetId nullId; // Not having an asset in the slot lead to use the default material
+    const AZ::Data::AssetId nullId; // Select the default material by assigning a null ID to the slot
     EXPECT_EQ(materialList[0].GetId(), nullId);
 }
 


### PR DESCRIPTION
**This PR is part of the work to refactoring physics materials. It's NOT merging to development branch.**

Physics materials doesn't have a library of materials, it works like render materials in the sense that 1 asset is 1 material, so in the terrain heightfield component now instead of a dropdown menu there is the typical asset field to assign a physics material. (similar to render materials)

All unit tests of Terrain pass.

Signed-off-by: moraaar <moraaar@amazon.com>