### PR TITLE
Asset Processor - Intermediate Assets - Various Fixes

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsFileUtils/ToolsFileUtils_generic.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsFileUtils/ToolsFileUtils_generic.cpp
@@ -39,7 +39,7 @@ namespace AzToolsFramework
         bool GetFreeDiskSpace(const QString& path, qint64& outFreeDiskSpace)
         {
             QStorageInfo storageInfo(path);
-            outFreeDiskSpace = storageInfo.bytesFree();
+            outFreeDiskSpace = storageInfo.bytesAvailable();
 
             return outFreeDiskSpace >= 0;
         }

--- a/Code/Tools/AssetProcessor/native/AssetManager/ProductAsset.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ProductAsset.cpp
@@ -139,13 +139,13 @@ namespace AssetProcessor
             });
     }
 
-    bool ProductAssetWrapper::ExistOnDisk() const
+    bool ProductAssetWrapper::ExistOnDisk(bool printErrorMessage) const
     {
         return AZStd::all_of(
             m_products.begin(), m_products.end(),
-            [](const AZStd::unique_ptr<ProductAsset>& productAsset)
+            [printErrorMessage](const AZStd::unique_ptr<ProductAsset>& productAsset)
             {
-                return productAsset->ExistsOnDisk(true);
+                return productAsset->ExistsOnDisk(printErrorMessage);
             });
     }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/ProductAsset.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/ProductAsset.h
@@ -39,7 +39,7 @@ namespace AssetProcessor
         ProductAssetWrapper(const AzToolsFramework::AssetDatabase::ProductDatabaseEntry& product, const AssetUtilities::ProductPath& productPath);
 
         bool IsValid() const;
-        bool ExistOnDisk() const;
+        bool ExistOnDisk(bool printErrorMessage) const;
         bool DeleteFiles(bool sendNotification) const;
         AZ::u64 ComputeHash() const;
         bool HasCacheProduct() const;

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -2952,7 +2952,7 @@ namespace AssetProcessor
             }
         }
 
-        if (!isDelete && IsInIntermediateAssetsFolder(normalizedFullFile) && !AZ::IO::SystemFile::IsDirectory(normalizedFullFile.toUtf8().constData()))
+        if (!isDelete && IsInIntermediateAssetsFolder(normalizedFullFile) && !m_knownFolders.contains(normalizedFullFile))
         {
             QString relativePath, scanfolderPath;
             m_platformConfig->ConvertToRelativePath(normalizedFullFile, relativePath, scanfolderPath);

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -1043,7 +1043,6 @@ namespace AssetProcessor
                                         // The product file path is always lower cased, we can't check that for existance.
                                         // Let rebuild a fs sensitive file path by replacing the cache path.
                                         // We assume any file paths normalized, ie no .. nor (back) slashes.
-                                        //const QString outputProductFilePath = m_cacheRootDir.filePath(outputProduct.m_productFileName.substr(m_normalizedCacheRootPath.length() + 1).c_str());
                                         AssetUtilities::ProductPath outputProductPath(outputProduct.m_productFileName, itProcessedAsset->m_entry.m_platformInfo.m_identifier);
                                         ProductAssetWrapper wrapper(outputProduct, outputProductPath);
 
@@ -1981,7 +1980,8 @@ namespace AssetProcessor
         QString normalizedRoot = AssetUtilities::NormalizeFilePath(root);
 
         // also track parent folders up to the specified root.
-        QString parentFolderName = QFileInfo(fullFile).absolutePath();
+        QFileInfo fullFileInfo(fullFile);
+        QString parentFolderName = fullFileInfo.isDir() ? fullFileInfo.absoluteFilePath() : fullFileInfo.absolutePath();
         QString normalizedParentFolder = AssetUtilities::NormalizeFilePath(parentFolderName);
 
         if (!normalizedParentFolder.startsWith(normalizedRoot, Qt::CaseInsensitive))
@@ -2948,10 +2948,9 @@ namespace AssetProcessor
                     m_metaFilesWhichActuallyExistOnDisk.clear(); // invalidate the map, force a recompuation later.
                 }
             }
-
         }
 
-        if (!isDelete &&  IsInIntermediateAssetsFolder(normalizedFullFile))
+        if (!isDelete && IsInIntermediateAssetsFolder(normalizedFullFile) && !AZ::IO::SystemFile::IsDirectory(normalizedFullFile.toUtf8().constData()))
         {
             QString relativePath, scanfolderPath;
             m_platformConfig->ConvertToRelativePath(normalizedFullFile, relativePath, scanfolderPath);
@@ -3081,6 +3080,16 @@ namespace AssetProcessor
         if (m_allowModtimeSkippingFeature)
         {
             AZ_TracePrintf(AssetProcessor::DebugChannel, "%d files reported from scanner.  %d unchanged files skipped, %d files processed\n", filePaths.size(), filePaths.size() - processedFileCount, processedFileCount);
+        }
+    }
+
+    void AssetProcessorManager::RecordFoldersFromScanner(QSet<AssetFileInfo> folderPaths)
+    {
+        // Record all the folders so we can differentiate between a folder delete and a file delete later on
+        // Sometimes a folder is empty, which is why its not sufficient to only record folders from the AssessFilesFromScanner event
+        for(const auto& folder : folderPaths)
+        {
+            AddKnownFoldersRecursivelyForFile(folder.m_filePath, folder.m_scanFolder->ScanPath());
         }
     }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -981,7 +981,7 @@ namespace AssetProcessor
                     continue;
                 }
 
-                if(!remove && !productWrapper.ExistOnDisk())
+                if(!remove && !productWrapper.ExistOnDisk(true))
                 {
                     remove = true;
                 }
@@ -2197,7 +2197,7 @@ namespace AssetProcessor
                     auto productPath = AssetUtilities::ProductPath::FromDatabasePath(product.m_productName);
                     ProductAssetWrapper wrapper{ product, productPath };
 
-                    if(!wrapper.ExistOnDisk())
+                    if(!wrapper.ExistOnDisk(true))
                     {
                         shouldProcessAsset = true;
                     }
@@ -2310,10 +2310,12 @@ namespace AssetProcessor
 
         for (const auto& product : products)
         {
-            QString fileFound = m_cacheRootDir.absoluteFilePath(product.m_productName.c_str());
-            if (!QFile::exists(fileFound))
+            auto productPath = AssetUtilities::ProductPath::FromDatabasePath(product.m_productName);
+            ProductAssetWrapper productWrapper{ product, productPath };
+
+            if (!productWrapper.ExistOnDisk(false))
             {
-                AssessDeletedFile(fileFound);
+                AssessDeletedFile(productPath.GetCachePath().c_str());
             }
         }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -271,6 +271,7 @@ namespace AssetProcessor
         void AssetCancelled(JobEntry jobEntry);
 
         void AssessFilesFromScanner(QSet<AssetFileInfo> filePaths);
+        void RecordFoldersFromScanner(QSet<AssetFileInfo> folderPaths);
 
         virtual void AssessModifiedFile(QString filePath);
         virtual void AssessAddedFile(QString filePath);

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -1755,8 +1755,10 @@ bool ApplicationManagerBase::CheckSufficientDiskSpace(const QString& savePath, q
     if (createdDirectory)
     {
         // Clean up the folder so we're not leaving empty folders all over the place
+        // We need to walk up the path and try to delete each folder along the way since savePath might have created a series of folders
+        // Just deleting savePath would only delete the last folder created
         AZ::IO::Path path(savePath.toUtf8().constData());
-        while(AZ::IO::SystemFile::DeleteDir(path.c_str()))
+        while(AZ::IO::SystemFile::DeleteDir(path.c_str())) // DeleteDir should fail if the directory is not empty
         {
             if (path.HasParentPath())
             {

--- a/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/ApplicationManagerBase.cpp
@@ -374,6 +374,7 @@ void ApplicationManagerBase::InitAssetScanner()
     // asset processor manager
     QObject::connect(m_assetScanner, &AssetScanner::AssetScanningStatusChanged, m_assetProcessorManager, &AssetProcessorManager::OnAssetScannerStatusChange);
     QObject::connect(m_assetScanner, &AssetScanner::FilesFound,                 m_assetProcessorManager, &AssetProcessorManager::AssessFilesFromScanner);
+    QObject::connect(m_assetScanner, &AssetScanner::FoldersFound,                 m_assetProcessorManager, &AssetProcessorManager::RecordFoldersFromScanner);
 
     QObject::connect(m_assetScanner, &AssetScanner::FilesFound, [this](QSet<AssetFileInfo> files) { m_fileStateCache->AddInfoSet(files); });
     QObject::connect(m_assetScanner, &AssetScanner::FoldersFound, [this](QSet<AssetFileInfo> files) { m_fileStateCache->AddInfoSet(files); });


### PR DESCRIPTION
Fixes various issues that came up from intermediate assets work.

- Fixes for dealing with deleted directories and incorrectly classifying copy jobs as intermediate asset loops
- Fix CheckDeletedCacheFolder not handling intermediate asset deletes correctly
- Fix GetFreeDiskSpace check generic platform version checking the total free amount instead of the amount available to the user. The windows API call was checking the amount available to the user, so this is now consistent
- Fix leaving behind a bunch of empty directories when preparing to copy outputs
- Fix issues with Intermediate cache folders not being recorded as folders, causing deletion to be handled incorrectly.
