### PR TITLE
Fixed undo parent transform bug and added regression test

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform.py
@@ -1,0 +1,118 @@
+"""
+Copyright (c) Contributors to the Open 3D Engine Project.
+For complete copyright and license terms please see the LICENSE at the root of this distribution.
+
+SPDX-License-Identifier: Apache-2.0 OR MIT
+"""
+
+class Tests:
+    create_entity_statuses = (
+        "Parent entity created successfully",
+        "Failed to create a parent entity"
+    )
+    create_child_entity_statuses = (
+        "Child entity created successfully",
+        "Failed to create a child entity"
+    )
+    move_parent_entity_statuses = (
+        "Parent entity moved successfully",
+        "Failed to move the parent entity"
+    )
+    move_child_entity_statuses = (
+        "Child entity moved successfully",
+        "Failed to move the child entity"
+    )
+    parent_entity_after_undo_statuses = (
+        "Parent entity moved back to original position after undo successfully",
+        "Failed to move the parent entity back to original position after undo"
+    )
+    child_entity_after_undo_statuses = (
+        "Child entity moved back to original position after undo successfully",
+        "Failed to move the child entity back to original position after undo"
+    )
+    parent_entity_after_redo_statuses = (
+        "Parent entity moved to desired position after redo successfully",
+        "Failed to move the parent entity to desired position after redo"
+    )
+    child_entity_after_redo_statuses = (
+        "Parent entity moved to desired position after redo successfully",
+        "Failed to move the parent entity to desired position after redo"
+    )
+
+
+def validate_translate_position(entity, expected_translation) -> bool:
+    is_entity_at_expected_position = entity.get_world_translation().IsClose(expected_translation)
+    assert is_entity_at_expected_position, \
+        f"Translation position of entity '{entity.get_name()}' : {entity.get_world_translation().ToString()} does not" \
+        f" match the expected value : {expected_translation.ToString()}"
+    return is_entity_at_expected_position
+
+def EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform():
+    """
+        Performing basic test in editor
+            01. Load base level
+            02. create parent entity and set name
+            03. create child entity and set a name
+            04. Update transform position of parent entity and verify that child got the same transform
+            05. Undo and verify both parent and child went back to original transform
+            06. Redo and verify that both parent and child moved again to new transform
+    """
+
+    import azlmbr.bus as bus
+    import azlmbr.editor as editor
+    import azlmbr.legacy.general as general
+    import azlmbr.globals as globals
+    import editor_python_test_tools.hydra_editor_utils as hydra
+
+    from editor_python_test_tools.editor_entity_utils import EditorEntity, EditorComponent
+    from editor_python_test_tools.prefab_utils import wait_for_propagation
+
+    expected_translate_position = azlmbr.math.Vector3(10.0, 0.0, 0.0)
+    default_translate_position = azlmbr.math.Vector3(0.0, 0.0, 0.0)
+
+    # 01. load an existing level
+    hydra.open_base_level()
+
+    # 02. create parent entity and set name
+    parent_entity = EditorEntity.create_editor_entity_at((0.0, 0.0, 0.0), name="Parent_Entity")
+    Report.result(Tests.create_entity_statuses, parent_entity.exists())
+
+    # 03. Create child Entity to above created parent entity and set a name
+    child_entity = EditorEntity.create_editor_entity("Child_Entity", parent_entity.id)
+    Report.result(Tests.create_child_entity_statuses, child_entity.exists())
+    wait_for_propagation()
+
+    # 04. Move the parent entity to a new postion.
+    get_transform_component_outcome = editor.EditorComponentAPIBus(
+        bus.Broadcast, "GetComponentOfType", parent_entity.id, globals.property.EditorTransformComponentTypeId
+    )
+    parent_transform_component = EditorComponent(globals.property.EditorTransformComponentTypeId)
+    parent_transform_component.id = get_transform_component_outcome.GetValue()
+    hydra.set_component_property_value(parent_transform_component.id, "Values|Translate", expected_translate_position)
+    wait_for_propagation()
+    Report.result(Tests.move_parent_entity_statuses,
+                  validate_translate_position(parent_entity, expected_translate_position))
+    Report.result(Tests.move_child_entity_statuses,
+                  validate_translate_position(child_entity, expected_translate_position))
+
+    # 05. Undo the translation of parent entity.
+    general.undo()
+    wait_for_propagation()
+    Report.result(Tests.parent_entity_after_undo_statuses,
+                  validate_translate_position(parent_entity, default_translate_position))
+    Report.result(Tests.child_entity_after_undo_statuses,
+                  validate_translate_position(child_entity, default_translate_position))
+
+    # 06. Redo the translation of parent entity.
+    general.redo()
+    wait_for_propagation()
+    Report.result(Tests.parent_entity_after_redo_statuses,
+                  validate_translate_position(parent_entity, expected_translate_position))
+    Report.result(Tests.child_entity_after_redo_statuses,
+                  validate_translate_position(child_entity, expected_translate_position))
+
+
+if __name__ == "__main__":
+    from editor_python_test_tools.utils import Report
+
+    Report.start_test(EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform)

--- a/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
@@ -27,6 +27,9 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
     class test_BasicEditorWorkflows_ExistingLevel_EntityComponentCRUD(EditorSharedTest):
         from .EditorScripts import BasicEditorWorkflows_ExistingLevel_EntityComponentCRUD as test_module
 
+    class test_EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform(EditorSharedTest):
+        from .EditorScripts import EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform as test_module
+
     class test_BasicEditorWorkflows_LevelEntityComponentCRUD(EditorSingleTest):
         # Custom teardown to remove level created during test
         def teardown(self, request, workspace, editor, editor_test_results, launcher_platform):

--- a/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Components/TransformComponent.cpp
@@ -760,7 +760,9 @@ namespace AzFramework
                 ;
 
             behaviorContext->Constant("TransformComponentTypeId", BehaviorConstant(AZ::TransformComponentTypeId));
-            behaviorContext->Constant("EditorTransformComponentTypeId", BehaviorConstant(AZ::EditorTransformComponentTypeId));
+            behaviorContext->ConstantProperty("EditorTransformComponentTypeId", BehaviorConstant(AZ::EditorTransformComponentTypeId))
+                ->Attribute(AZ::Script::Attributes::Scope, AZ::Script::Attributes::ScopeFlags::Automation)
+                ;
 
             behaviorContext->Class<AZ::TransformConfig>()
                 ->Attribute(AZ::Script::Attributes::ConstructorOverride, &AZ::TransformConfigConstructor)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/EditorEntityModel.cpp
@@ -425,18 +425,7 @@ namespace AzToolsFramework
 
         childInfo.SetParentId(parentId);
 
-        bool isDuringUndoRedo = false;
-        AzToolsFramework::ToolsApplicationRequestBus::BroadcastResult(isDuringUndoRedo, &AzToolsFramework::ToolsApplicationRequestBus::Events::IsDuringUndoRedo);
-        if (isDuringUndoRedo)
-        {
-            // Undoing the parent entity's transform will first delete the parent entity and then re-create it with its
-            // old transform. Keep child entities' local transform so they stay put in their parent's space after undo actions.
-            AZ::TransformBus::Event(childId, &AZ::TransformBus::Events::SetParentRelative, parentId);
-        }
-        else
-        {
-            AZ::TransformBus::Event(childId, &AZ::TransformBus::Events::SetParent, parentId);
-        }
+        AZ::TransformBus::Event(childId, &AZ::TransformBus::Events::SetParentRelative, parentId);
 
         //creating/pushing slices doesn't always destroy/de-register the original entity before adding the replacement
         if (!parentInfo.HasChild(childId))


### PR DESCRIPTION
One of the changes that selective deserialization avoids is the need to reload the entire prefab when only 1 entity inside it changed. Because of this change, there was a bug introduced where undoing a parent transform doesn't update the child correctly. The root cause of this issue is actually due to some legacy undo/redo logic in EditorEntityModel that is no longer required and applicable for prefabs. The selective deserialization work unearthed this existing issue. I've checked with @AMZN-daimini and @NicholasVanSickle from editor team that this change to the EditorEntityModel is safe to do so.

I've added a regression test, which proved to be more challenging than I thought because I realized that there aren't any tests that modify the transform component in the inspector. The test fails before this fix and passes after this fix. 