### PR TITLE
Fix properties from refreshing continuously as a result of propagating to the instance being edited 

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -14,6 +14,7 @@
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h>
 #include <AzToolsFramework/Prefab/Instance/InstanceUpdateExecutorInterface.h>
 #include <AzToolsFramework/Prefab/PrefabIdTypes.h>
+#include <AzToolsFramework/UI/PropertyEditor/PropertyEditorAPI.h>
 
 namespace AzToolsFramework
 {
@@ -25,6 +26,7 @@ namespace AzToolsFramework
 
         class InstanceUpdateExecutor
             : public InstanceUpdateExecutorInterface
+            , private PropertyEditorGUIMessages::Bus::Handler
         {
         public:
             AZ_RTTI(InstanceUpdateExecutor, "{E21DB0D4-0478-4DA9-9011-31BC96F55837}", InstanceUpdateExecutorInterface);
@@ -41,6 +43,14 @@ namespace AzToolsFramework
 
         private:
 
+            ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+            // PropertyEditorGUIMessages::Bus::Handler
+            //! When making property changes in the editor, listening to the below notifications and pausing propagation accordingly will
+            //! prevent the user from losing control of the properties they are editng.
+            void RequestWrite(QWidget* editorGUI) override;
+            void OnEditingFinished(QWidget* editorGUI) override;
+            ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+            
             //! Connect the game mode event handler in a lazy fashion rather than at construction of this class.
             //! This is required because the event won't be ready for connection during construction as EditorEntityContextComponent
             //! gets initialized after the PrefabSystemComponent
@@ -52,7 +62,7 @@ namespace AzToolsFramework
             AZ::Event<GameModeState>::Handler m_GameModeEventHandler;
             int m_instanceCountToUpdateInBatch = 0;
             bool m_updatingTemplateInstancesInQueue { false };
-            bool m_isGameModeInProgress = false;
+            bool m_shouldPausePropagation = false;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceUpdateExecutor.h
@@ -46,7 +46,7 @@ namespace AzToolsFramework
             ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // PropertyEditorGUIMessages::Bus::Handler
             //! When making property changes in the editor, listening to the below notifications and pausing propagation accordingly will
-            //! prevent the user from losing control of the properties they are editng.
+            //! prevent the user from losing control of the properties they are editing.
             void RequestWrite(QWidget* editorGUI) override;
             void OnEditingFinished(QWidget* editorGUI) override;
             ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
@@ -199,7 +199,7 @@ namespace AzToolsFramework
                 if (applyPatchResult.GetOutcome() == AZ::JsonSerializationResult::Outcomes::PartialSkip ||
                     applyPatchResult.GetOutcome() == AZ::JsonSerializationResult::Outcomes::Skipped)
                 {
-                    AZ_Error(
+                    AZ_Warning(
                         "Prefab", false,
                         "Link::UpdateTarget - Some of the patches couldn't be applied on the source template '%s' present under the  "
                         "target Template '%s'.",

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabPublicHandler.cpp
@@ -1391,7 +1391,7 @@ namespace AzToolsFramework
                     command->SetParent(undoBatch.GetUndoBatch());
                     {
                         AZ_PROFILE_SCOPE(AzToolsFramework, "Internal::DetachPrefab:RunRedo");
-                        command->Redo(parentInstance);
+                        command->Redo();
                     }
 
                     instancePtr->DetachNestedInstances(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndo.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabUndo.cpp
@@ -268,7 +268,7 @@ namespace AzToolsFramework
             //apply the patch to the template within the target
             [[maybe_unused]] AZ::JsonSerializationResult::ResultCode result = PrefabDomUtils::ApplyPatches(instanceDom, instanceDom.GetAllocator(), patch);
 
-            AZ_Error(
+            AZ_Warning(
                 "Prefab",
                 (result.GetOutcome() != AZ::JsonSerializationResult::Outcomes::Skipped) &&
                 (result.GetOutcome() != AZ::JsonSerializationResult::Outcomes::PartialSkip),


### PR DESCRIPTION
Fixes LYN 12822

SelectiveDeserialization work removes the 'InstanceToExclude' paradigm so that the actual c++ instances (views) are upto date with the underlying DOM values (models). This introduce a previously known issue where properties currently being updated by the user (like sliders, color pickers, etc.) will immediately refresh due to propagation, resulting in the user losing control of the thing they are editing. Previously, this was fixed using the 'instanceToExclude' paradigm. Since that's removed now, we connect to the PropertyEditorGUIMessages bus now to get notified about the start of an edit and a finish of the edit. Thanks to @NicholasVanSickle for pointing me to the bus.

Other minor changes :
1. Renamed m_isGameModeInProgress to m_shouldPausePropagation so that it can be reused for different use cases
2. Changed AZ_Error to AZ_Warning for partial patch application failures to keep it in line with the warnings from json serializaton and best effort patching
3. Removed instanceToExclude from detach prefab function in PrefabPublicHandler, which is the last remaining piece.