### PR TITLE
Added bechmarks around overriding a prefab

### DIFF
--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.cpp
@@ -35,8 +35,6 @@ namespace Benchmark
 
             m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
         }
-
-        state.SetComplexityN(state.range());
     }
 
     void PropagationBenchmarkFixture::AddComponent(benchmark::State& state)
@@ -56,8 +54,6 @@ namespace Benchmark
             delete inspectorComponent;
             inspectorComponent = nullptr;
         }
-
-        state.SetComplexityN(state.range());
     }
 
     void PropagationBenchmarkFixture::RemoveComponent(benchmark::State& state)
@@ -79,8 +75,6 @@ namespace Benchmark
             // zero components to one component.
             m_entityToModify->CreateComponent(AZ::TransformComponentTypeId);
         }
-
-        state.SetComplexityN(state.range());
     }
 
     void PropagationBenchmarkFixture::AddEntity(benchmark::State& state)
@@ -99,15 +93,13 @@ namespace Benchmark
             // 'n' entities to 'n+1' entities.
             newEntity = m_instanceToModify->DetachEntity(newEntityId);
         }
-
-        state.SetComplexityN(state.range());
     }
 
     void PropagationBenchmarkFixture::RemoveEntity(benchmark::State& state)
     {
         for (auto _ : state)
         {
-            // Add an entity and update the template.
+            // Remove an entity and update the template.
             AZStd::unique_ptr<AZ::Entity> detachedEntity = m_instanceToModify->DetachEntity(m_entityToModify->GetId());
             UpdateTemplate();
 
@@ -117,15 +109,13 @@ namespace Benchmark
             // 'n' entities to 'n-1' entities.
             m_instanceToModify->AddEntity(AZStd::move(detachedEntity));
         }
-
-        state.SetComplexityN(state.range());
     }
 
     void PropagationBenchmarkFixture::AddNestedInstance(benchmark::State& state, TemplateId nestedPrefabTemplateId)
     {
         for (auto _ : state)
         {
-            // Add an entity and update the template.
+            // Add a nested instance and update the template.
             AZStd::unique_ptr<Instance> nestedInstance = AZStd::make_unique<Instance>("Added nested instance");
             Instance& addedInstance =
                 m_instanceToModify->AddInstance(AZStd::move(m_prefabSystemComponent->InstantiatePrefab(nestedPrefabTemplateId)));
@@ -138,8 +128,6 @@ namespace Benchmark
             // 'n' nested prefabs to 'n+1' nested prefabs.
             nestedInstance = m_instanceToModify->DetachNestedInstance(instanceAlias);
         }
-
-        state.SetComplexityN(state.range());
     }
 
     void PropagationBenchmarkFixture::RemoveNestedInstance(benchmark::State& state, TemplateId nestedPrefabTemplateId)
@@ -159,7 +147,6 @@ namespace Benchmark
 
         // After the last iteration, the template should be updated to avoid link deletion failures.
         UpdateTemplate();
-        state.SetComplexityN(state.range());
     }
 } // namespace Benchmark
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.cpp
@@ -27,10 +27,10 @@ namespace Benchmark
         for (auto _ : state)
         {
             float worldX = 0.0f;
-            AZ::TransformBus::EventResult(worldX, m_entityModify->GetId(), &AZ::TransformInterface::GetWorldX);
+            AZ::TransformBus::EventResult(worldX, m_entityToModify->GetId(), &AZ::TransformInterface::GetWorldX);
 
             // Move the entity and update the template to capture this transform component change.
-            AZ::TransformBus::Event(m_entityModify->GetId(), &AZ::TransformInterface::SetWorldX, worldX + 1);
+            AZ::TransformBus::Event(m_entityToModify->GetId(), &AZ::TransformInterface::SetWorldX, worldX + 1);
             UpdateTemplate();
 
             m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
@@ -41,18 +41,18 @@ namespace Benchmark
 
     void PropagationBenchmarkFixture::AddComponent(benchmark::State& state)
     {
-        m_entityModify->Deactivate();
+        m_entityToModify->Deactivate();
         for (auto _ : state)
         {
             // Add another component and update the template to capture this change.
-            AZ::Component* inspectorComponent = m_entityModify->CreateComponent<AzToolsFramework::Components::EditorInspectorComponent>();
+            AZ::Component* inspectorComponent = m_entityToModify->CreateComponent<AzToolsFramework::Components::EditorInspectorComponent>();
             UpdateTemplate();
 
             m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
 
             // Remove the second component added. This will make sure that when multiple iterations are done, we will always be going from
             // one components to two components.
-            m_entityModify->RemoveComponent(inspectorComponent);
+            m_entityToModify->RemoveComponent(inspectorComponent);
             delete inspectorComponent;
             inspectorComponent = nullptr;
         }
@@ -62,13 +62,13 @@ namespace Benchmark
 
     void PropagationBenchmarkFixture::RemoveComponent(benchmark::State& state)
     {
-        m_entityModify->Deactivate();
+        m_entityToModify->Deactivate();
 
         for (auto _ : state)
         {
-            const AZStd::vector<AZ::Component*>& components = m_entityModify->GetComponents();
+            const AZStd::vector<AZ::Component*>& components = m_entityToModify->GetComponents();
             AZ::Component* transformComponent = components.front();
-            m_entityModify->RemoveComponent(transformComponent);
+            m_entityToModify->RemoveComponent(transformComponent);
             delete transformComponent;
             transformComponent = nullptr;
             UpdateTemplate();
@@ -77,7 +77,7 @@ namespace Benchmark
 
             // Add the component back. This will make sure that when multiple iterations are done, we will always be going from
             // zero components to one component.
-            m_entityModify->CreateComponent(AZ::TransformComponentTypeId);
+            m_entityToModify->CreateComponent(AZ::TransformComponentTypeId);
         }
 
         state.SetComplexityN(state.range());
@@ -90,14 +90,14 @@ namespace Benchmark
             // Add an entity and update the template.
             AZStd::unique_ptr<AZ::Entity> newEntity = AZStd::make_unique<AZ::Entity>("Added Entity");
             AZ::EntityId newEntityId = newEntity->GetId();
-            m_instanceCreated->AddEntity(AZStd::move(newEntity));
+            m_instanceToModify->AddEntity(AZStd::move(newEntity));
             UpdateTemplate();
 
             m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
 
             // Remove the entityadded. This will make sure that when multiple iterations are done, we will always be going from
             // 'n' entities to 'n+1' entities.
-            newEntity = m_instanceCreated->DetachEntity(newEntityId);
+            newEntity = m_instanceToModify->DetachEntity(newEntityId);
         }
 
         state.SetComplexityN(state.range());
@@ -108,14 +108,14 @@ namespace Benchmark
         for (auto _ : state)
         {
             // Add an entity and update the template.
-            AZStd::unique_ptr<AZ::Entity> detachedEntity = m_instanceCreated->DetachEntity(m_entityModify->GetId());
+            AZStd::unique_ptr<AZ::Entity> detachedEntity = m_instanceToModify->DetachEntity(m_entityToModify->GetId());
             UpdateTemplate();
 
             m_instanceUpdateExecutorInterface->UpdateTemplateInstancesInQueue();
 
             // Add back the entity removed. This will make sure that when multiple iterations are done, we will always be going from
             // 'n' entities to 'n-1' entities.
-            m_instanceCreated->AddEntity(AZStd::move(detachedEntity));
+            m_instanceToModify->AddEntity(AZStd::move(detachedEntity));
         }
 
         state.SetComplexityN(state.range());
@@ -128,7 +128,7 @@ namespace Benchmark
             // Add an entity and update the template.
             AZStd::unique_ptr<Instance> nestedInstance = AZStd::make_unique<Instance>("Added nested instance");
             Instance& addedInstance =
-                m_instanceCreated->AddInstance(AZStd::move(m_prefabSystemComponent->InstantiatePrefab(nestedPrefabTemplateId)));
+                m_instanceToModify->AddInstance(AZStd::move(m_prefabSystemComponent->InstantiatePrefab(nestedPrefabTemplateId)));
             const InstanceAlias& instanceAlias = addedInstance.GetInstanceAlias();
             UpdateTemplate();
 
@@ -136,7 +136,7 @@ namespace Benchmark
 
             // Remove the nested prefab added. This will make sure that when multiple iterations are done, we will always be going from
             // 'n' nested prefabs to 'n+1' nested prefabs.
-            nestedInstance = m_instanceCreated->DetachNestedInstance(instanceAlias);
+            nestedInstance = m_instanceToModify->DetachNestedInstance(instanceAlias);
         }
 
         state.SetComplexityN(state.range());

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.h
@@ -30,8 +30,11 @@ namespace Benchmark
         void AddNestedInstance(benchmark::State& state, TemplateId nestedPrefabTemplateId);
         void RemoveNestedInstance(benchmark::State& state, TemplateId nestedPrefabTemplateId);
 
-        AZ::Entity* m_entityModify;
+        AZ::Entity* m_entityToModify = nullptr;
         AZStd::unique_ptr<Instance> m_instanceCreated;
+
+        // The prefab instance to modify for the benchmark test. This can be m_instanceCreated or any nested prefab instance within it.
+        Instance* m_instanceToModify = nullptr;
         AZStd::unique_ptr<Instance> m_instanceToUseForPropagation;
     };
 

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
@@ -33,11 +33,12 @@ namespace Benchmark
             entities.emplace_back(CreateEntity("Entity"));
         }
 
-        m_entityModify = CreateEntity("Entity", AZ::EntityId());
-        entities.emplace_back(m_entityModify);
+        m_entityToModify = CreateEntity("Entity", AZ::EntityId());
+        entities.emplace_back(m_entityToModify);
 
         m_instanceCreated = m_prefabSystemComponent->CreatePrefab(entities, {}, templatePath);
         TemplateId templateToInstantiateId = m_instanceCreated->GetTemplateId();
+        m_instanceToModify = m_instanceCreated.get();
 
         // We need 2 prefab instances: One to make the original change to; And one to propagate that change to.
         m_instanceToUseForPropagation = m_prefabSystemComponent->InstantiatePrefab(templateToInstantiateId);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
@@ -13,8 +13,7 @@
     BENCHMARK_REGISTER_F(BaseClass, Method)                                                                                                \
         ->RangeMultiplier(10)                                                                                                              \
         ->Range(100, 10000)                                                                                                                \
-        ->Unit(benchmark::kMillisecond)                                                                                                    \
-        ->Complexity();
+        ->Unit(benchmark::kMillisecond);
 
 namespace Benchmark
 {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleNestedInstancesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleNestedInstancesBenchmarks.cpp
@@ -56,12 +56,13 @@ namespace Benchmark
             nestedInstances.emplace_back(AZStd::move(m_prefabSystemComponent->InstantiatePrefab(m_nestedPrefabTemplateId)));
         }
 
-        m_entityModify = CreateEntity("Entity", AZ::EntityId());
-        entitiesInParentInstance.emplace_back(m_entityModify);
+        m_entityToModify = CreateEntity("Entity", AZ::EntityId());
+        entitiesInParentInstance.emplace_back(m_entityToModify);
 
         m_instanceCreated =
             m_prefabSystemComponent->CreatePrefab(entitiesInParentInstance, AZStd::move(nestedInstances), parentTemplatePath);
         TemplateId templateToInstantiateId = m_instanceCreated->GetTemplateId();
+        m_instanceToModify = m_instanceCreated.get();
 
         // We need 2 prefab instances: One to make the original change to; And one to propagate that change to.
         m_instanceToUseForPropagation = m_prefabSystemComponent->InstantiatePrefab(templateToInstantiateId);

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleNestedInstancesBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceMultipleNestedInstancesBenchmarks.cpp
@@ -19,8 +19,7 @@
         ->Args({ 1, 10000 })                                                                                                               \
         ->Args({ 10000, 1 })                                                                                                               \
         ->ArgNames({ "NestedPrefabs", "EntitiesInEachNestedPrefab" })                                                                      \
-        ->Unit(benchmark::kMillisecond)                                                                                                    \
-        ->Complexity();
+        ->Unit(benchmark::kMillisecond);
 
 namespace Benchmark
 {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.cpp
@@ -19,8 +19,7 @@
         ->Args({ 50, 20 })                                                                                                                 \
         ->Args({ 50, 200 })                                                                                                                \
         ->ArgNames({ "DepthOfNesting", "EntitiesInEachPrefab" })                                                                           \
-        ->Unit(benchmark::kMillisecond)                                                                                                    \
-        ->Complexity();
+        ->Unit(benchmark::kMillisecond);
 
 namespace Benchmark
 {

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#if defined(HAVE_BENCHMARK)
+
+#include <Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.h>
+
+#define REGISTER_OVERRIDE_INSTANCE_BENCHMARK(BaseClass, Method)                                                                            \
+    BENCHMARK_REGISTER_F(BaseClass, Method)                                                                                                \
+        ->Args({ 1, 500  })                                                                                                                \
+        ->Args({ 1, 5000 })                                                                                                                \
+        ->Args({ 10, 100 })                                                                                                                \
+        ->Args({ 10, 1000 })                                                                                                               \
+        ->Args({ 50, 20 })                                                                                                                 \
+        ->Args({ 50, 200 })                                                                                                                \
+        ->ArgNames({ "DepthOfNesting", "EntitiesInEachPrefab" })                                                                           \
+        ->Unit(benchmark::kMillisecond)                                                                                                    \
+        ->Complexity();
+
+namespace Benchmark
+{
+    using namespace AzToolsFramework::Prefab;
+
+    void SingleInstanceOverrideBenchmarks::SetupHarness(const benchmark::State& state)
+    {
+        BM_Prefab::SetupHarness(state);
+        
+        const unsigned int depthOfNesting = static_cast<unsigned int>(state.range(0));
+        const unsigned int entitiesCountInEachPrefab = static_cast<unsigned int>(state.range(1));
+
+        CreateFakePaths(depthOfNesting + 1); // The +1 is for the path of parent prefab
+        const auto& parentTemplatePath = m_paths.back();
+        const auto& templateToOverridePath = m_paths.front();
+
+        // Create the prefab instance that will act as the leaf instance that we will be overriding.
+        AZStd::vector<AZ::Entity*> entitiesInNestedPrefab = GetEntitiesToPutInNestedInstance(entitiesCountInEachPrefab);
+        m_entityToModify = CreateEntity("Entity", AZ::EntityId());
+        entitiesInNestedPrefab.emplace_back(m_entityToModify);
+        AZStd::unique_ptr<Instance> nestedInstance = m_prefabSystemComponent->CreatePrefab(entitiesInNestedPrefab, {}, templateToOverridePath);
+        m_instanceToModify = nestedInstance.get();
+
+        for (unsigned int nestedInstanceCounter = 1; nestedInstanceCounter < depthOfNesting; nestedInstanceCounter++)
+        {
+            nestedInstance = m_prefabSystemComponent->CreatePrefab(
+                GetEntitiesToPutInNestedInstance(entitiesCountInEachPrefab), MakeInstanceList(AZStd::move(nestedInstance)),
+                m_paths[nestedInstanceCounter]);
+        }
+
+        m_instanceCreated = m_prefabSystemComponent->CreatePrefab(
+            GetEntitiesToPutInNestedInstance(entitiesCountInEachPrefab), MakeInstanceList(AZStd::move(nestedInstance)), parentTemplatePath);
+
+        // We need 2 prefab instances: One to make the original change to; And one to propagate that change to.
+        m_instanceToUseForPropagation = m_prefabSystemComponent->InstantiatePrefab(m_instanceCreated->GetTemplateId());
+    }
+
+    void SingleInstanceOverrideBenchmarks::TeardownHarness(const benchmark::State& state)
+    {
+        m_instanceCreated.reset();
+        m_instanceToUseForPropagation.reset();
+        BM_Prefab::TeardownHarness(state);
+    }
+
+    AZStd::vector<AZ::Entity*> SingleInstanceOverrideBenchmarks::GetEntitiesToPutInNestedInstance(const unsigned int entityCount)
+    {
+        AZStd::vector<AZ::Entity*> entitiesInNestedInstance;
+        entitiesInNestedInstance.reserve(entityCount);
+        for (unsigned int entityCounter = 0; entityCounter < entityCount; entityCounter++)
+        {
+            entitiesInNestedInstance.emplace_back(CreateEntity("Entity"));
+        }
+        return AZStd::move(entitiesInNestedInstance);
+    }
+
+    BENCHMARK_DEFINE_F(SingleInstanceOverrideBenchmarks, PropagateOverrideComponent)(benchmark::State& state)
+    {
+        UpdateComponent(state);
+    }
+    REGISTER_OVERRIDE_INSTANCE_BENCHMARK(SingleInstanceOverrideBenchmarks, PropagateOverrideComponent);
+
+    BENCHMARK_DEFINE_F(SingleInstanceOverrideBenchmarks, PropagateOverrideAddComponent)(benchmark::State& state)
+    {
+        AddComponent(state);
+    }
+    REGISTER_OVERRIDE_INSTANCE_BENCHMARK(SingleInstanceOverrideBenchmarks, PropagateOverrideAddComponent);
+
+    BENCHMARK_DEFINE_F(SingleInstanceOverrideBenchmarks, PropagateOverrideRemoveComponent)(benchmark::State& state)
+    {
+        RemoveComponent(state);
+    }
+    REGISTER_OVERRIDE_INSTANCE_BENCHMARK(SingleInstanceOverrideBenchmarks, PropagateOverrideRemoveComponent);
+
+    BENCHMARK_DEFINE_F(SingleInstanceOverrideBenchmarks, PropagateOverrideAddEntity)(benchmark::State& state)
+    {
+        AddEntity(state);
+    }
+    REGISTER_OVERRIDE_INSTANCE_BENCHMARK(SingleInstanceOverrideBenchmarks, PropagateOverrideAddEntity);
+
+    BENCHMARK_DEFINE_F(SingleInstanceOverrideBenchmarks, PropagateOverrideRemoveEntity)(benchmark::State& state)
+    {
+        RemoveEntity(state);
+    }
+    REGISTER_OVERRIDE_INSTANCE_BENCHMARK(SingleInstanceOverrideBenchmarks, PropagateOverrideRemoveEntity);
+
+} // namespace Benchmark
+#endif

--- a/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.h
+++ b/Code/Framework/AzToolsFramework/Tests/Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+#if defined(HAVE_BENCHMARK)
+
+#pragma once
+
+#include <Prefab/Benchmark/Propagation/PropagationBenchmarkFixture.h>
+
+namespace Benchmark
+{
+    using namespace AzToolsFramework::Prefab;
+
+    //! This class captures benchmarks for overriding changes to a single prefab instance with a deeply nested prefab hierarchy inside it.
+    class SingleInstanceOverrideBenchmarks : public PropagationBenchmarkFixture
+    {
+    protected:
+        void SetupHarness(const benchmark::State& state) override;
+        void TeardownHarness(const benchmark::State& state) override;
+
+        AZStd::vector<AZ::Entity*> GetEntitiesToPutInNestedInstance(const unsigned int entityCount);
+    };
+} // namespace Benchmark
+#endif

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -75,6 +75,8 @@ set(FILES
     Prefab/Benchmark/Propagation/SingleInstanceMultipleNestedInstancesBenchmarks.h
     Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.cpp
     Prefab/Benchmark/Propagation/SingleInstanceMultipleEntityBenchmarks.h
+    Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.cpp
+    Prefab/Benchmark/Propagation/SingleInstanceOverrideBenchmarks.h
     Prefab/Benchmark/SpawnableCreateBenchmarks.cpp
     Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.h
     Prefab/Benchmark/Spawnable/SpawnableBenchmarkFixture.cpp


### PR DESCRIPTION
Added a few benchmarks around overriding a prefab in a deep nested hierarchy. This should give better numbers with selective deserialization since we should be only modifying the entity in the child instance overridden rather than the entire parent instance. There is scope for further optimizations after selective deserialization gets merged to dev. I'll create tickets for those. Here are the comparison numbers against dev.

Development:
```
--------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                                    Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:500                281 ms          281 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000              3403 ms         3406 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:100               312 ms          312 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000             4187 ms         4188 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:20                375 ms          375 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:200              4226 ms         4234 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent_BigO                                                    2130522916.66 (1)  2132812500.00 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent_RMS                                                             86 %            86 %
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:500             272 ms          273 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000           3484 ms         3484 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:100            316 ms          312 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000          4255 ms         4250 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:20             333 ms          336 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:200           4159 ms         4141 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent_BigO                                                 2136471241.66 (1)  2132812500.00 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent_RMS                                                          86 %            86 %
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:500          275 ms          276 ms            3
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000        3576 ms         3578 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:100         323 ms          320 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000       4197 ms         4188 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:20          355 ms          352 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:200        4075 ms         4078 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent_BigO                                              2133643138.90 (1)  2131944444.44 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent_RMS                                                       86 %            86 %
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:1/EntitiesInEachNestedPrefab:500                269 ms          271 ms            3
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000              3551 ms         3547 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:10/EntitiesInEachNestedPrefab:100               323 ms          320 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000             4478 ms         4484 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:50/EntitiesInEachNestedPrefab:20                367 ms          367 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:50/EntitiesInEachNestedPrefab:200              4131 ms         4125 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity_BigO                                                    2186535661.10 (1)  2185763888.89 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity_RMS                                                             86 %            86 %
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:1/EntitiesInEachNestedPrefab:500             259 ms          258 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000           3588 ms         3594 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:10/EntitiesInEachNestedPrefab:100            318 ms          320 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000          4285 ms         4297 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:50/EntitiesInEachNestedPrefab:20             341 ms          344 ms            2
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:50/EntitiesInEachNestedPrefab:200           4206 ms         4203 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity_BigO                                                 2166130825.00 (1)  2169270833.33 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity_RMS                                                          86 %            86 %
OKAY AzRunBenchmarks() returned 0
Returning code: 0
```

SelectiveDeserialization
```
--------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                                                                    Time             CPU   Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:500               42.8 ms         42.7 ms           15
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000               961 ms          953 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:100              78.4 ms         79.9 ms            9
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000             1233 ms         1234 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:20                186 ms          184 ms            4
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:200              2300 ms         2297 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent_BigO                                                    214353686.57 lgN  214104996.59 lgN
SingleInstanceOverrideBenchmarks/PropagateOverrideComponent_RMS                                                            100 %           100 %
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:500            44.6 ms         44.9 ms           16
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000           1092 ms         1094 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:100           69.6 ms         69.4 ms            9
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000          1266 ms         1266 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:20             184 ms          182 ms            3
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:200           2424 ms         2438 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent_BigO                                                 846831323.49 (1)  848922164.35 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideAddComponent_RMS                                                         101 %           102 %
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:500         38.0 ms         37.8 ms           19
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000        1106 ms         1109 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:100        37.9 ms         37.0 ms           19
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000       1265 ms         1266 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:20         53.0 ms         53.1 ms           10
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent/DepthOfNesting:50/EntitiesInEachNestedPrefab:200        2224 ms         2219 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent_BigO                                              787347616.75 (1)  786951754.39 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveComponent_RMS                                                      104 %           104 %
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:1/EntitiesInEachNestedPrefab:500               43.5 ms         43.2 ms           17
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000              1024 ms         1016 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:10/EntitiesInEachNestedPrefab:100              71.7 ms         71.2 ms            9
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000             1379 ms         1359 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:50/EntitiesInEachNestedPrefab:20                195 ms          198 ms            3
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity/DepthOfNesting:50/EntitiesInEachNestedPrefab:200              2261 ms         2266 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity_BigO                                                    828960915.33 (1)  825486791.94 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideAddEntity_RMS                                                             98 %            99 %
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:1/EntitiesInEachNestedPrefab:500            38.3 ms         38.7 ms           19
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:1/EntitiesInEachNestedPrefab:5000           1071 ms         1078 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:10/EntitiesInEachNestedPrefab:100           38.8 ms         37.8 ms           19
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:10/EntitiesInEachNestedPrefab:1000          1317 ms         1312 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:50/EntitiesInEachNestedPrefab:20            50.8 ms         50.5 ms           13
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity/DepthOfNesting:50/EntitiesInEachNestedPrefab:200           2346 ms         2344 ms            1
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity_BigO                                                 810305423.61 (1)  810222672.06 (1)
SingleInstanceOverrideBenchmarks/PropagateOverrideRemoveEntity_RMS                                                         106 %           106 %
OKAY AzRunBenchmarks() returned 0
Returning code: 0
```