### PR TITLE
Fixed a bug where the child entity transforms don't persist after parent is transformed

### DIFF
--- a/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
+++ b/AutomatedTesting/Gem/PythonTests/EditorPythonTestTools/editor_python_test_tools/editor_entity_utils.py
@@ -682,6 +682,18 @@ class EditorEntity:
         new_translation = convert_to_azvector3(new_translation)
         azlmbr.components.TransformBus(azlmbr.bus.Event, "SetLocalTranslation", self.id, new_translation)
 
+    def validate_world_translate_position(self, expected_translation) -> bool:
+        """
+        Validates whether the actual world translation of the entity matches the provided translation value.
+        :param expected_translation: The math.Vector3 value to compare against the world translation on the entity.
+        :return: The bool indicating whether the translate position matched or not.
+        """
+        is_entity_at_expected_position = self.get_world_translation().IsClose(expected_translation)
+        assert is_entity_at_expected_position, \
+            f"Translation position of entity '{self.get_name()}' : {self.get_world_translation().ToString()} does not" \
+            f" match the expected value : {expected_translation.ToString()}"
+        return is_entity_at_expected_position
+
     # Use this only when prefab system is enabled as it will fail otherwise.
     def focus_on_owning_prefab(self) -> None:
         """

--- a/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_ChildEntityTransform_Persists_After_ParentEntityTransform.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/EditorScripts/EditorWorkflow_ChildEntityTransform_Persists_After_ParentEntityTransform.py
@@ -39,15 +39,17 @@ class Tests:
         "Failed to move the parent entity to desired position after redo"
     )
 
-def EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform():
+def EditorWorkflow_ChildEntityTransform_Persists_After_ParentEntityTransform():
     """
         Performing basic test in editor
             01. Load base level
             02. create parent entity and set name
             03. create child entity and set a name
-            04. Update transform position of parent entity and verify that child got the same transform
-            05. Undo and verify both parent and child went back to original transform
-            06. Redo and verify that both parent and child moved again to new transform
+            04. Update transform position of child entity and verify that it moved.
+            05. Update transform position of parent entity and verify that the child moved along with parent while
+                maintaining it's relative position.
+            06. Undo and verify both parent and child went back to original transform
+            07. Redo and verify that both parent and child moved again to new transform
     """
 
     import azlmbr.bus as bus
@@ -59,7 +61,9 @@ def EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform():
     from editor_python_test_tools.editor_entity_utils import EditorEntity, EditorComponent
     from editor_python_test_tools.prefab_utils import wait_for_propagation
 
-    expected_translate_position = azlmbr.math.Vector3(10.0, 0.0, 0.0)
+    parent_translate_position = azlmbr.math.Vector3(10.0, 0.0, 0.0)
+    child_translate_position_before_parent_moves = azlmbr.math.Vector3(10.0, 0.0, 0.0)
+    child_translate_position_after_parent_moves = azlmbr.math.Vector3(20.0, 0.0, 0.0)
     default_translate_position = azlmbr.math.Vector3(0.0, 0.0, 0.0)
 
     # 01. load an existing level
@@ -74,37 +78,49 @@ def EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform():
     Report.result(Tests.create_child_entity_statuses, child_entity.exists())
     wait_for_propagation()
 
-    # 04. Move the parent entity to a new postion.
+    # 04. Move the child entity to a new postion.
+    get_transform_component_outcome = editor.EditorComponentAPIBus(
+        bus.Broadcast, "GetComponentOfType", child_entity.id, globals.property.EditorTransformComponentTypeId
+    )
+    child_transform_component = EditorComponent(globals.property.EditorTransformComponentTypeId)
+    child_transform_component.id = get_transform_component_outcome.GetValue()
+    hydra.set_component_property_value(child_transform_component.id, "Values|Translate",
+                                       child_translate_position_before_parent_moves)
+    wait_for_propagation()
+    Report.result(Tests.move_child_entity_statuses,
+                  child_entity.validate_world_translate_position(child_translate_position_before_parent_moves))
+
+    # 05. Move the parent entity to a new postion.
     get_transform_component_outcome = editor.EditorComponentAPIBus(
         bus.Broadcast, "GetComponentOfType", parent_entity.id, globals.property.EditorTransformComponentTypeId
     )
     parent_transform_component = EditorComponent(globals.property.EditorTransformComponentTypeId)
     parent_transform_component.id = get_transform_component_outcome.GetValue()
-    hydra.set_component_property_value(parent_transform_component.id, "Values|Translate", expected_translate_position)
+    hydra.set_component_property_value(parent_transform_component.id, "Values|Translate", parent_translate_position)
     wait_for_propagation()
     Report.result(Tests.move_parent_entity_statuses,
-                  parent_entity.validate_world_translate_position(expected_translate_position))
+                  parent_entity.validate_world_translate_position(parent_translate_position))
     Report.result(Tests.move_child_entity_statuses,
-                  child_entity.validate_world_translate_position(expected_translate_position))
+                  child_entity.validate_world_translate_position(child_translate_position_after_parent_moves))
 
-    # 05. Undo the translation of parent entity.
+    # 06. Undo the translation of parent entity.
     general.undo()
     wait_for_propagation()
-    Report.result(Tests.move_parent_entity_statuses,
+    Report.result(Tests.parent_entity_after_undo_statuses,
                   parent_entity.validate_world_translate_position(default_translate_position))
-    Report.result(Tests.move_child_entity_statuses,
-                  child_entity.validate_world_translate_position(default_translate_position))
+    Report.result(Tests.child_entity_after_undo_statuses,
+                  child_entity.validate_world_translate_position(child_translate_position_before_parent_moves))
 
-    # 06. Redo the translation of parent entity.
+    # 07. Redo the translation of parent entity.
     general.redo()
     wait_for_propagation()
-    Report.result(Tests.move_parent_entity_statuses,
-                  parent_entity.validate_world_translate_position(expected_translate_position))
-    Report.result(Tests.move_child_entity_statuses,
-                  child_entity.validate_world_translate_position(expected_translate_position))
+    Report.result(Tests.parent_entity_after_redo_statuses,
+                  parent_entity.validate_world_translate_position(parent_translate_position))
+    Report.result(Tests.child_entity_after_redo_statuses,
+                  child_entity.validate_world_translate_position(child_translate_position_after_parent_moves))
 
 
 if __name__ == "__main__":
     from editor_python_test_tools.utils import Report
 
-    Report.start_test(EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform)
+    Report.start_test(EditorWorkflow_ChildEntityTransform_Persists_After_ParentEntityTransform)

--- a/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
+++ b/AutomatedTesting/Gem/PythonTests/editor/TestSuite_Main.py
@@ -30,6 +30,9 @@ class TestAutomationNoAutoTestMode(EditorTestSuite):
     class test_EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform(EditorSharedTest):
         from .EditorScripts import EditorWorkflow_ParentEntityTransform_Affects_ChildEntityTransform as test_module
 
+    class test_EditorWorkflow_ChildEntityTransform_Persists_After_ParentEntityTransform(EditorSharedTest):
+        from .EditorScripts import EditorWorkflow_ChildEntityTransform_Persists_After_ParentEntityTransform as test_module
+
     class test_BasicEditorWorkflows_LevelEntityComponentCRUD(EditorSingleTest):
         # Custom teardown to remove level created during test
         def teardown(self, request, workspace, editor, editor_test_results, launcher_platform):

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabSystemComponent.cpp
@@ -734,6 +734,7 @@ namespace AzToolsFramework
                 instancesValue->get().AddMember(
                     rapidjson::Value(instanceAlias.c_str(), targetTemplateDom.GetAllocator()), PrefabDomValue(),
                     targetTemplateDom.GetAllocator());
+                SetTemplateDirtyFlag(linkTargetId, true);
             }
 
             Template& sourceTemplate = sourceTemplateRef->get();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/TransformComponent.cpp
@@ -285,7 +285,12 @@ namespace AzToolsFramework
                 const auto& localTM = GetLocalTM();
                 const auto worldTM = world * localTM;
 
-                UpdateCachedWorldTransform();
+                if (m_parentEntityId.IsValid())
+                {
+                    // If the parent entity is invalid, the world position of the entity shouldn't be cached as this can be later used in
+                    // calculating the local translation of the entity when activated under a different parent.
+                    UpdateCachedWorldTransform();
+                }
 
                 AZ::TransformNotificationBus::Event(
                     GetEntityId(), &TransformNotification::OnTransformChanged, localTM, worldTM);


### PR DESCRIPTION
Changes in this PR:
1. Fix for lyn-12917. 
2. Marking template as dirty when a link is created(since that does modify a prefab template)

Testing:
1. Added a regression test for lyn-12917
2. Also tested that fix for lyn-12753 still works
