### PR TITLE
Asset Processor - Intermediate Assets - Unit Test Common Builder Info Handler class

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -2706,7 +2706,7 @@ namespace AssetProcessor
                 // note that "ConvertToRelativePath" does add output prefix to it.
                 if (!m_platformConfig->ConvertToRelativePath(normalizedPath, databasePathToFile, scanFolderName))
                 {
-                    AZ_TracePrintf(AssetProcessor::DebugChannel, "ProcessFilesToExamineQueue: Unable to find the relative path.\n");
+                    AZ_TracePrintf(AssetProcessor::DebugChannel, "ProcessFilesToExamineQueue: Unable to find the relative path for %s.\n", normalizedPath.toUtf8().constData());
                     continue;
                 }
 

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -5333,21 +5333,23 @@ namespace AssetProcessor
         {
             reprocessList.push_back(normalizedSourcePath.toUtf8().constData());
         }
+
         return RequestReprocess(reprocessList);
     }
 
-    AZ::u64 AssetProcessorManager::RequestReprocess(const QStringList& reprocessList)
+    AZ::u64 AssetProcessorManager::RequestReprocess(const AZStd::list<AZStd::string>& reprocessList)
     {
         AZ::u64 filesFound{ 0 };
-        for (QString sourcePath : reprocessList)
+        for (const AZStd::string& entry : reprocessList)
         {
             // Remove invalid characters
+            QString sourcePath = entry.c_str();
             sourcePath.remove(QRegExp("[\\n\\r]"));
 
             QString scanFolderName;
             QString relativePathToFile;
 
-            if (!m_platformConfig->ConvertToRelativePath(sourcePath.c_str(), relativePathToFile, scanFolderName))
+            if (!m_platformConfig->ConvertToRelativePath(sourcePath, relativePathToFile, scanFolderName))
             {
                 continue;
             }
@@ -5366,7 +5368,7 @@ namespace AssetProcessor
                 if (jobs.size())
                 {
                     filesFound++;
-                    AssessModifiedFile(sourcePath.c_str());
+                    AssessModifiedFile(sourcePath);
                 }
             }
         }

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -223,7 +223,7 @@ namespace AssetProcessor
 
         //! Request to invalidate and reprocess a source asset or folder containing source assets
         AZ::u64 RequestReprocess(const QString& sourcePath);
-        AZ::u64 RequestReprocess(const QStringList& reprocessList);
+        AZ::u64 RequestReprocess(const AZStd::list<AZStd::string>& reprocessList);
     Q_SIGNALS:
         void NumRemainingJobsChanged(int newNumJobs);
 

--- a/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
+++ b/Code/Tools/AssetProcessor/native/tests/UnitTestUtilities.h
@@ -9,30 +9,60 @@
 #pragma once
 
 #include <utilities/AssetUtilEBusHelper.h>
+#include <utilities/assetUtils.h>
 
 namespace UnitTests
 {
-    struct MockBuilderInfoHandler : public AssetProcessor::AssetBuilderInfoBus::Handler
+    struct MockMultiBuilderInfoHandler : public AssetProcessor::AssetBuilderInfoBus::Handler
     {
-        ~MockBuilderInfoHandler();
+        ~MockMultiBuilderInfoHandler() override;
+
+        struct AssetBuilderExtraInfo
+        {
+            QString m_jobFingerprint;
+            QString m_dependencyFilePath;
+            QString m_jobDependencyFilePath;
+            QString m_analysisFingerprint;
+            AZStd::vector<AZ::u32> m_subIdDependencies;
+        };
 
         //! AssetProcessor::AssetBuilderInfoBus Interface
         void GetMatchingBuildersInfo(const AZStd::string& assetPath, AssetProcessor::BuilderInfoList& builderInfoList) override;
         void GetAllBuildersInfo(AssetProcessor::BuilderInfoList& builderInfoList) override;
 
-        void CreateJobs(const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response);
-        void ProcessJob(const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response);
+        void CreateJobs(
+            AssetBuilderExtraInfo extraInfo,
+            const AssetBuilderSDK::CreateJobsRequest& request,
+            AssetBuilderSDK::CreateJobsResponse& response);
+        void ProcessJob(
+            AssetBuilderExtraInfo extraInfo,
+            const AssetBuilderSDK::ProcessJobRequest& request,
+            AssetBuilderSDK::ProcessJobResponse& response);
 
-        AssetBuilderSDK::AssetBuilderDesc CreateBuilderDesc(
+        void CreateBuilderDesc(
             const QString& builderName,
             const QString& builderId,
-            const AZStd::vector<AssetBuilderSDK::AssetBuilderPattern>& builderPatterns);
+            const AZStd::vector<AssetBuilderSDK::AssetBuilderPattern>& builderPatterns,
+            const AssetBuilderExtraInfo& extraInfo);
 
-        AssetBuilderSDK::AssetBuilderDesc m_builderDesc;
-        QString m_jobFingerprint;
-        QString m_dependencyFilePath;
-        QString m_jobDependencyFilePath;
-        AZStd::vector<AZ::u32> m_subIdDependencies;
+        // Use this version if you intend to update the extraInfo struct dynamically (be sure extraInfo does not go out of scope)
+        void CreateBuilderDescInfoRef(
+            const QString& builderName,
+            const QString& builderId,
+            const AZStd::vector<AssetBuilderSDK::AssetBuilderPattern>& builderPatterns,
+            const AssetBuilderExtraInfo& extraInfo);
+
+        void CreateBuilderDesc(
+            const QString& builderName,
+            const QString& builderId,
+            const AZStd::vector<AssetBuilderSDK::AssetBuilderPattern>& builderPatterns,
+            const AssetBuilderSDK::CreateJobFunction& createJobsFunction,
+            const AssetBuilderSDK::ProcessJobFunction& processJobFunction,
+            AZStd::optional<QString> analysisFingerprint = AZStd::nullopt);
+
+        AZStd::vector<AssetUtilities::BuilderFilePatternMatcher> m_matcherBuilderPatterns;
+        AZStd::unordered_map<AZ::Uuid, AssetBuilderSDK::AssetBuilderDesc> m_builderDescMap;
+
         int m_createJobsCount = 0;
     };
 }

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -3685,9 +3685,6 @@ void FingerprintTest::SetUp()
     // We don't want the mock application manager to provide builder descriptors, mockBuilderInfoHandler will provide our own
     m_mockApplicationManager->BusDisconnect();
 
-    m_mockBuilderInfoHandler.m_builderDesc = m_mockBuilderInfoHandler.CreateBuilderDesc("test builder", "{DF09DDC0-FD22-43B6-9E22-22C8574A6E1E}", { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) });
-    m_mockBuilderInfoHandler.BusConnect();
-
     // Create the test file
     const auto& scanFolder = m_config->GetScanFolderAt(1);
     QString relativePathFromWatchFolder("fingerprintTest.txt");
@@ -3711,8 +3708,12 @@ void FingerprintTest::TearDown()
 
 void FingerprintTest::RunFingerprintTest(QString builderFingerprint, QString jobFingerprint, bool expectedResult)
 {
-    m_mockBuilderInfoHandler.m_builderDesc.m_analysisFingerprint = builderFingerprint.toUtf8().data();
-    m_mockBuilderInfoHandler.m_jobFingerprint = jobFingerprint;
+    m_mockBuilderInfoHandler.CreateBuilderDesc(
+        "test builder", "{DF09DDC0-FD22-43B6-9E22-22C8574A6E1E}",
+        { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) },
+        UnitTests::MockMultiBuilderInfoHandler::AssetBuilderExtraInfo{ jobFingerprint, "", "", builderFingerprint, {} });
+    m_mockBuilderInfoHandler.BusConnect();
+
     QMetaObject::invokeMethod(m_assetProcessorManager.get(), "AssessModifiedFile", Qt::QueuedConnection, Q_ARG(QString, m_absolutePath));
 
     ASSERT_TRUE(BlockUntilIdle(5000));
@@ -4086,7 +4087,7 @@ void JobDependencyTest::SetUp()
     // We don't want the mock application manager to provide builder descriptors, mockBuilderInfoHandler will provide our own
     m_mockApplicationManager->BusDisconnect();
 
-    m_data->m_mockBuilderInfoHandler.m_builderDesc = m_data->m_mockBuilderInfoHandler.CreateBuilderDesc("test builder", m_data->m_builderUuid.ToString<QString>(), { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) });
+    m_data->m_mockBuilderInfoHandler.CreateBuilderDescInfoRef("test builder", m_data->m_builderUuid.ToString<QString>(), { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) }, m_data->m_assetBuilderConfig);
     m_data->m_mockBuilderInfoHandler.BusConnect();
 
     QDir tempPath(m_tempDir.path());
@@ -4129,7 +4130,7 @@ TEST_F(JobDependencyTest, JobDependency_ThatWasPreviouslyRun_IsFound)
     AZStd::vector<JobDetails> capturedDetails;
 
     capturedDetails.clear();
-    m_data->m_mockBuilderInfoHandler.m_jobDependencyFilePath = "a.txt";
+    m_data->m_assetBuilderConfig.m_jobDependencyFilePath = "a.txt";
     CaptureJobs(capturedDetails, "subfolder1/b.txt");
 
     ASSERT_EQ(capturedDetails.size(), 1);
@@ -4143,7 +4144,7 @@ TEST_F(JobDependencyTest, JobDependency_ThatWasJustRun_IsFound)
     CaptureJobs(capturedDetails, "subfolder1/c.txt");
 
     capturedDetails.clear();
-    m_data->m_mockBuilderInfoHandler.m_jobDependencyFilePath = "c.txt";
+    m_data->m_assetBuilderConfig.m_jobDependencyFilePath = "c.txt";
     CaptureJobs(capturedDetails, "subfolder1/b.txt");
 
     ASSERT_EQ(capturedDetails.size(), 1);
@@ -4156,7 +4157,7 @@ TEST_F(JobDependencyTest, JobDependency_ThatHasNotRun_IsNotFound)
     AZStd::vector<JobDetails> capturedDetails;
 
     capturedDetails.clear();
-    m_data->m_mockBuilderInfoHandler.m_jobDependencyFilePath = "c.txt";
+    m_data->m_assetBuilderConfig.m_jobDependencyFilePath = "c.txt";
     CaptureJobs(capturedDetails, "subfolder1/b.txt");
 
     ASSERT_EQ(capturedDetails.size(), 1);
@@ -4188,7 +4189,7 @@ void ChainJobDependencyTest::SetUp()
         }
 
         m_data->m_mockBuilderInfoHandler.CreateBuilderDesc(QString("test builder %1").arg(i), AZ::Uuid::CreateRandom().ToString<QString>(), { AssetBuilderSDK::AssetBuilderPattern(AZStd::string::format("*%d.txt", i), AssetBuilderSDK::AssetBuilderPattern::Wildcard) },
-            MockMultiBuilderInfoHandler::AssetBuilderExtraInfo{ jobDependencyPath });
+            UnitTests::MockMultiBuilderInfoHandler::AssetBuilderExtraInfo{ "", "", jobDependencyPath, "", {} });
     }
 
     m_data->m_mockBuilderInfoHandler.BusConnect();
@@ -4199,84 +4200,6 @@ void ChainJobDependencyTest::TearDown()
     m_data = nullptr;
 
     AssetProcessorManagerTest::TearDown();
-}
-
-MockMultiBuilderInfoHandler::~MockMultiBuilderInfoHandler()
-{
-    BusDisconnect();
-}
-
-void MockMultiBuilderInfoHandler::GetMatchingBuildersInfo(const AZStd::string& assetPath, AssetProcessor::BuilderInfoList& builderInfoList)
-{
-    AZStd::set<AZ::Uuid>  uniqueBuilderDescIDs;
-
-    for (AssetUtilities::BuilderFilePatternMatcher& matcherPair : m_matcherBuilderPatterns)
-    {
-        if (uniqueBuilderDescIDs.find(matcherPair.GetBuilderDescID()) != uniqueBuilderDescIDs.end())
-        {
-            continue;
-        }
-        if (matcherPair.MatchesPath(assetPath))
-        {
-            const AssetBuilderSDK::AssetBuilderDesc& builderDesc = m_builderDescMap[matcherPair.GetBuilderDescID()];
-            uniqueBuilderDescIDs.insert(matcherPair.GetBuilderDescID());
-            builderInfoList.push_back(builderDesc);
-        }
-    }
-}
-
-void MockMultiBuilderInfoHandler::GetAllBuildersInfo([[maybe_unused]] AssetProcessor::BuilderInfoList& builderInfoList)
-{
-    // Only here to fulfill the interface requirement, this won't be called as part of the test
-    ASSERT_TRUE(false) << "Not implemented";
-}
-
-void MockMultiBuilderInfoHandler::CreateJobs(AssetBuilderExtraInfo extraInfo, const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response)
-{
-    response.m_result = AssetBuilderSDK::CreateJobsResultCode::Success;
-
-    for (const auto& platform : request.m_enabledPlatforms)
-    {
-        AssetBuilderSDK::JobDescriptor jobDescriptor;
-        jobDescriptor.m_priority = 0;
-        jobDescriptor.m_critical = true;
-        jobDescriptor.m_jobKey = "Mock Job";
-        jobDescriptor.SetPlatformIdentifier(platform.m_identifier.c_str());
-
-        if (!extraInfo.m_jobDependencyFilePath.isEmpty())
-        {
-            jobDescriptor.m_jobDependencyList.push_back(AssetBuilderSDK::JobDependency("Mock Job", "pc", AssetBuilderSDK::JobDependencyType::Order,
-                AssetBuilderSDK::SourceFileDependency(extraInfo.m_jobDependencyFilePath.toUtf8().constData(), AZ::Uuid::CreateNull())));
-        }
-
-        response.m_createJobOutputs.push_back(jobDescriptor);
-        m_createJobsCount++;
-    }
-}
-
-void MockMultiBuilderInfoHandler::ProcessJob(AssetBuilderExtraInfo extraInfo, [[maybe_unused]] const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response)
-{
-    response.m_resultCode = AssetBuilderSDK::ProcessJobResultCode::ProcessJobResult_Success;
-}
-
-void MockMultiBuilderInfoHandler::CreateBuilderDesc(const QString& builderName, const QString& builderId, const AZStd::vector<AssetBuilderSDK::AssetBuilderPattern>& builderPatterns, AssetBuilderExtraInfo extraInfo)
-{
-    AssetBuilderSDK::AssetBuilderDesc builderDesc;
-
-    builderDesc.m_name = builderName.toUtf8().data();
-    builderDesc.m_patterns = builderPatterns;
-    builderDesc.m_busId = AZ::Uuid::CreateString(builderId.toUtf8().data());
-    builderDesc.m_builderType = AssetBuilderSDK::AssetBuilderDesc::AssetBuilderType::Internal;
-    builderDesc.m_createJobFunction = AZStd::bind(&MockMultiBuilderInfoHandler::CreateJobs, this, extraInfo, AZStd::placeholders::_1, AZStd::placeholders::_2);
-    builderDesc.m_processJobFunction = AZStd::bind(&MockMultiBuilderInfoHandler::ProcessJob, this, extraInfo, AZStd::placeholders::_1, AZStd::placeholders::_2);
-
-    m_builderDescMap[builderDesc.m_busId] = builderDesc;
-
-    for (const AssetBuilderSDK::AssetBuilderPattern& pattern : builderDesc.m_patterns)
-    {
-        AssetUtilities::BuilderFilePatternMatcher patternMatcher(pattern, builderDesc.m_busId);
-        m_matcherBuilderPatterns.push_back(patternMatcher);
-    }
 }
 
 TEST_F(ChainJobDependencyTest, ChainDependency_EndCaseHasNoDependency)

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.h
@@ -307,7 +307,7 @@ struct FingerprintTest
     void RunFingerprintTest(QString builderFingerprint, QString jobFingerprint, bool expectedResult);
 
     QString m_absolutePath;
-    UnitTests::MockBuilderInfoHandler m_mockBuilderInfoHandler;
+    UnitTests::MockMultiBuilderInfoHandler m_mockBuilderInfoHandler;
     AZStd::vector<AssetProcessor::JobDetails> m_jobResults;
 };
 
@@ -319,37 +319,12 @@ struct JobDependencyTest
 
     struct StaticData
     {
-        UnitTests::MockBuilderInfoHandler m_mockBuilderInfoHandler;
+        UnitTests::MockMultiBuilderInfoHandler m_mockBuilderInfoHandler;
+        UnitTests::MockMultiBuilderInfoHandler::AssetBuilderExtraInfo m_assetBuilderConfig;
         AZ::Uuid m_builderUuid;
     };
 
     AZStd::unique_ptr<StaticData> m_data;
-};
-
-struct MockMultiBuilderInfoHandler
-    : public AssetProcessor::AssetBuilderInfoBus::Handler
-{
-    ~MockMultiBuilderInfoHandler();
-
-    struct AssetBuilderExtraInfo
-    {
-        QString m_jobDependencyFilePath;
-    };
-
-    //! AssetProcessor::AssetBuilderInfoBus Interface
-    void GetMatchingBuildersInfo(const AZStd::string& assetPath, AssetProcessor::BuilderInfoList& builderInfoList) override;
-    void GetAllBuildersInfo(AssetProcessor::BuilderInfoList& builderInfoList) override;
-
-    void CreateJobs(AssetBuilderExtraInfo extraInfo, const AssetBuilderSDK::CreateJobsRequest& request, AssetBuilderSDK::CreateJobsResponse& response);
-    void ProcessJob(AssetBuilderExtraInfo extraInfo, const AssetBuilderSDK::ProcessJobRequest& request, AssetBuilderSDK::ProcessJobResponse& response);
-
-    void CreateBuilderDesc(const QString& builderName, const QString& builderId, const AZStd::vector<AssetBuilderSDK::AssetBuilderPattern>& builderPatterns, AssetBuilderExtraInfo extraInfo);
-
-    AZStd::vector<AssetBuilderSDK::AssetBuilderDesc> m_builderDesc;
-    AZStd::vector<AssetUtilities::BuilderFilePatternMatcher> m_matcherBuilderPatterns;
-    AZStd::unordered_map<AZ::Uuid, AssetBuilderSDK::AssetBuilderDesc> m_builderDescMap;
-
-    int m_createJobsCount = 0;
 };
 
 struct ChainJobDependencyTest
@@ -360,7 +335,7 @@ struct ChainJobDependencyTest
 
     struct StaticData
     {
-        MockMultiBuilderInfoHandler m_mockBuilderInfoHandler;
+        UnitTests::MockMultiBuilderInfoHandler m_mockBuilderInfoHandler;
         AZStd::unique_ptr<AssetProcessor::RCController> m_rcController;
     };
 

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/JobDependencySubIdTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/JobDependencySubIdTests.cpp
@@ -84,8 +84,11 @@ namespace UnitTests
         // Cache the db pointer because the TEST_F generates a subclass which can't access this private member
         m_stateData = m_assetProcessorManager->m_stateData;
 
+        // Cache the scanfolder db entry, for convenience
+        ASSERT_TRUE(m_stateData->GetScanFolderByPortableKey("folder", m_scanfolder));
+
         // Configure our mock builder so APM can find the builder and run CreateJobs
-        m_builderInfoHandler.m_builderDesc = m_builderInfoHandler.CreateBuilderDesc("test", AZ::Uuid::CreateRandom().ToString<QString>(), { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) });
+        m_builderInfoHandler.CreateBuilderDesc("test", AZ::Uuid::CreateRandom().ToString<QString>(), { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) }, {});
         m_builderInfoHandler.BusConnect();
     }
 
@@ -110,9 +113,7 @@ namespace UnitTests
         using namespace AzToolsFramework::AssetDatabase;
 
         AZ::IO::Path tempDir(m_tempDir.GetDirectory());
-        m_scanfolder = { (tempDir / "folder").c_str(), "folder", "folder", 0 };
 
-        ASSERT_TRUE(m_stateData->SetScanFolder(m_scanfolder));
 
         SourceDatabaseEntry source1{ m_scanfolder.m_scanFolderID, "parent.txt", AZ::Uuid::CreateRandom(), "fingerprint" };
         SourceDatabaseEntry source2{ m_scanfolder.m_scanFolderID, "child.txt", AZ::Uuid::CreateRandom(), "fingerprint" };
@@ -126,7 +127,7 @@ namespace UnitTests
         ASSERT_TRUE(m_stateData->SetSource(source2));
 
         JobDatabaseEntry job1{
-            source1.m_sourceID, "Mock Job", 1234, "pc", m_builderInfoHandler.m_builderDesc.m_busId, AzToolsFramework::AssetSystem::JobStatus::Completed, 999
+            source1.m_sourceID, "Mock Job", 1234, "pc", m_builderInfoHandler.m_builderDescMap.begin()->second.m_busId, AzToolsFramework::AssetSystem::JobStatus::Completed, 999
         };
 
         ASSERT_TRUE(m_stateData->SetJob(job1));

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/JobDependencySubIdTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/JobDependencySubIdTests.h
@@ -63,7 +63,7 @@ namespace UnitTests
         JobDependencyDatabaseLocationListener m_databaseLocationListener;
         AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry m_scanfolder;
         AZ::IO::Path m_parentFile, m_childFile;
-        MockBuilderInfoHandler m_builderInfoHandler;
+        MockMultiBuilderInfoHandler m_builderInfoHandler;
         AZ::IO::LocalFileIO* m_localFileIo;
 
         AZ::Uuid m_assetType = AZ::Uuid::CreateName("test");

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/ModtimeScanningTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/ModtimeScanningTests.cpp
@@ -52,18 +52,6 @@ namespace UnitTests
 
         m_data = AZStd::make_unique<StaticData>();
 
-        // We don't want the mock application manager to provide builder descriptors, mockBuilderInfoHandler will provide our own
-        m_mockApplicationManager->BusDisconnect();
-
-        m_data->m_mockBuilderInfoHandler.m_builderDesc = m_data->m_mockBuilderInfoHandler.CreateBuilderDesc(
-            "test builder", "{DF09DDC0-FD22-43B6-9E22-22C8574A6E1E}",
-            { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) });
-        m_data->m_mockBuilderInfoHandler.BusConnect();
-
-        ASSERT_TRUE(m_mockApplicationManager->GetBuilderByID("txt files", m_data->m_builderTxtBuilder));
-
-        SetUpAssetProcessorManager();
-
         // Create the test file
         const auto& scanFolder = m_config->GetScanFolderAt(1);
         m_data->m_relativePathFromWatchFolder[0] = "modtimeTestFile.txt";
@@ -80,7 +68,18 @@ namespace UnitTests
             ASSERT_TRUE(UnitTestUtils::CreateDummyFile(path, ""));
         }
 
-        m_data->m_mockBuilderInfoHandler.m_dependencyFilePath = m_data->m_absolutePath[1].toUtf8().data();
+        // We don't want the mock application manager to provide builder descriptors, mockBuilderInfoHandler will provide our own
+        m_mockApplicationManager->BusDisconnect();
+
+        m_data->m_mockBuilderInfoHandler.CreateBuilderDesc(
+            "test builder", "{DF09DDC0-FD22-43B6-9E22-22C8574A6E1E}",
+            { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) },
+            MockMultiBuilderInfoHandler::AssetBuilderExtraInfo{ "", m_data->m_absolutePath[1].toUtf8().data(), "", "", {} });
+        m_data->m_mockBuilderInfoHandler.BusConnect();
+
+        ASSERT_TRUE(m_mockApplicationManager->GetBuilderByID("txt files", m_data->m_builderTxtBuilder));
+
+        SetUpAssetProcessorManager();
 
         // Add file to database with no modtime
         {
@@ -596,9 +595,9 @@ namespace UnitTests
         // We don't want the mock application manager to provide builder descriptors, mockBuilderInfoHandler will provide our own
         m_mockApplicationManager->BusDisconnect();
 
-        m_data->m_mockBuilderInfoHandler.m_builderDesc = m_data->m_mockBuilderInfoHandler.CreateBuilderDesc(
+        m_data->m_mockBuilderInfoHandler.CreateBuilderDesc(
             "test builder", "{DF09DDC0-FD22-43B6-9E22-22C8574A6E1E}",
-            { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) });
+            { AssetBuilderSDK::AssetBuilderPattern("*.txt", AssetBuilderSDK::AssetBuilderPattern::Wildcard) }, {});
         m_data->m_mockBuilderInfoHandler.BusConnect();
 
         ASSERT_TRUE(m_mockApplicationManager->GetBuilderByID("txt files", m_data->m_builderTxtBuilder));

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/ModtimeScanningTests.h
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/ModtimeScanningTests.h
@@ -33,7 +33,7 @@ namespace UnitTests
             AZStd::unordered_multimap<AZStd::string, QString> m_productPaths;
             AZStd::vector<QString> m_deletedSources;
             AZStd::shared_ptr<AssetProcessor::InternalMockBuilder> m_builderTxtBuilder;
-            MockBuilderInfoHandler m_mockBuilderInfoHandler;
+            MockMultiBuilderInfoHandler m_mockBuilderInfoHandler;
         };
 
         AZStd::unique_ptr<StaticData> m_data;


### PR DESCRIPTION
Moves the MockMultiBuilderInfoHandler out of AssetProcessorManagerTest and into the common UnitTestUtilities, replacing the existing MockBuilderInfoHandler.  This should serve as a generic builder handler that is flexible enough to be shared between more unit tests