### PR TITLE
Fix bug where physx collider material list was not saved correctly in a prefab level.

### DIFF
--- a/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorColliderComponent.cpp
@@ -700,6 +700,19 @@ namespace PhysX
 
         AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(&AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_EntireTree);
 
+        // By refreshing the entire tree the component's properties reflected on edit context
+        // will get updated correctly and show the right material slots list.
+        // Unfortunately, the level prefab did its check against the dirty entity before
+        // this and it will save old data to file (the previous material slots list).
+        // To workaround this issue we mark the entity as dirty again so the prefab
+        // will save the most current data.
+        // There is a side effect to this fix though, the undo stack needs to be amended and there is
+        // no good way to do that at the moment. This means a user will have to hit Ctrl+Z twice
+        // to revert its last change, which is not good, but not as bad as losing data.
+        // GHI #9780 to provide a better mechanism to handle this case better.
+        AzToolsFramework::ScopedUndoBatch undoBatch("PhysX editor collider component material slots updated");
+        undoBatch.MarkEntityDirty(GetEntityId());
+
         ValidateAssetMaterials();
     }
 


### PR DESCRIPTION
NOTE: This fix is going to a staging branch, not to development, that's why sigs cannot be asked to be reviewed unfortunately, only people can be added to reviewers.

Marking entity as dirty to fix the issue.

There is a side effect to this fix though, the undo stack needs to be amended and there is no good way to do that at the moment. This means a user will have to hit Ctrl+Z twice to revert its last change, which is not good, but not as bad as losing data. GHI #9780 created to provide a better mechanism to handle this case better.

Signed-off-by: moraaar <moraaar@amazon.com>