### PR TITLE
Fix prefabs and fbx manifests in o3de that referenced legacy physics materials.

### DIFF
--- a/AutomatedTesting/Levels/Blast/Blast_ActorSplitsAfterCollision/Blast_ActorSplitsAfterCollision.prefab
+++ b/AutomatedTesting/Levels/Blast/Blast_ActorSplitsAfterCollision/Blast_ActorSplitsAfterCollision.prefab
@@ -62,6 +62,13 @@
                         "CollisionGroupId": {
                             "GroupId": "{45EBDE87-10BA-405B-9118-1FE9C750E5A3}"
                         },
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -240,8 +247,12 @@
                         },
                         "assetHint": "assets/destruction/brittle.blastmaterial"
                     },
-                    "PhysicsMaterial": {
-                        "MaterialId": "{34AD1046-240B-448C-A694-AE80F595C431}"
+                    "PhysicsMaterialAsset": {
+                        "assetId": {
+                            "guid": "{B9100A77-5ACF-5FCC-B9DD-2DAF8EF82F9E}",
+                            "subId": 1
+                        },
+                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/to_change_static_friction_1.physicsmaterial"
                     }
                 },
                 "Component_[7159608037522336146]": {

--- a/AutomatedTesting/Levels/Blast/Blast_ActorSplitsAfterDamage/Blast_ActorSplitsAfterDamage.prefab
+++ b/AutomatedTesting/Levels/Blast/Blast_ActorSplitsAfterDamage/Blast_ActorSplitsAfterDamage.prefab
@@ -132,8 +132,12 @@
                         },
                         "assetHint": "assets/destruction/brittle.blastmaterial"
                     },
-                    "PhysicsMaterial": {
-                        "MaterialId": "{34AD1046-240B-448C-A694-AE80F595C431}"
+                    "PhysicsMaterialAsset": {
+                        "assetId": {
+                            "guid": "{B9100A77-5ACF-5FCC-B9DD-2DAF8EF82F9E}",
+                            "subId": 1
+                        },
+                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/to_change_static_friction_1.physicsmaterial"
                     }
                 },
                 "Component_[7159608037522336146]": {

--- a/AutomatedTesting/Levels/Physics/ForceRegion_NoQuiverOnHighLinearDampingForce/ForceRegion_NoQuiverOnHighLinearDampingForce.prefab
+++ b/AutomatedTesting/Levels/Physics/ForceRegion_NoQuiverOnHighLinearDampingForce/ForceRegion_NoQuiverOnHighLinearDampingForce.prefab
@@ -134,6 +134,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -165,10 +172,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14201257298044574572,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{B072A405-BAFA-4B0A-9164-B3A424E642A9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{03568CB1-7F6B-5455-915E-F6EFA9EF7BDF}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "physicssurfaces.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Joints_BallNoLimitsConstrained/Joints_BallNoLimitsConstrained.prefab
+++ b/AutomatedTesting/Levels/Physics/Joints_BallNoLimitsConstrained/Joints_BallNoLimitsConstrained.prefab
@@ -93,6 +93,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17363654757392362489,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -236,6 +243,13 @@
                     "Id": 7429624549406958440,
                     "ColliderConfiguration": {
                         "Trigger": true,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -303,10 +317,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 1322277184770581793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{B072A405-BAFA-4B0A-9164-B3A424E642A9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{03568CB1-7F6B-5455-915E-F6EFA9EF7BDF}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "physicssurfaces.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -372,6 +393,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 5053986797366085195,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}

--- a/AutomatedTesting/Levels/Physics/Material_CharacterController/Material_CharacterController.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_CharacterController/Material_CharacterController.prefab
@@ -118,6 +118,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -294,10 +301,17 @@
                     "Id": 5825233234536327293,
                     "Configuration": {
                         "entityId": "",
-                        "Material": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{81BA7879-C15D-4A32-B1DC-BFC459FA6DDF}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{B69BD3B6-D669-5578-9478-0193E14D4BC8}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_charactercontroller/rubber.physicsmaterial"
+                                    }
                                 }
                             ]
                         },
@@ -401,10 +415,17 @@
                     "Id": 5825233234536327293,
                     "Configuration": {
                         "entityId": "",
-                        "Material": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{7F2847AA-8DF5-441F-9121-4B1EC722AB8D}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{C29A93D5-4280-5C9D-818A-A29910D3616E}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_charactercontroller/rock.physicsmaterial"
+                                    }
                                 }
                             ]
                         },
@@ -508,10 +529,17 @@
                     "Id": 5825233234536327293,
                     "Configuration": {
                         "entityId": "",
-                        "Material": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{C48AC5E7-DC4B-41D9-8063-06EFA3296E2B}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6F67BD41-AFEC-5692-B759-19EF7FCD76BA}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_charactercontroller/glass.physicsmaterial"
+                                    }
                                 }
                             ]
                         },
@@ -545,6 +573,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 13079754507717223587,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -724,6 +759,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -826,6 +868,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -869,6 +918,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 13079754507717223587,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -989,6 +1045,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 13079754507717223587,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}

--- a/AutomatedTesting/Levels/Physics/Material_ComponentsInSyncWithLibrary/Material_ComponentsInSyncWithLibrary.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_ComponentsInSyncWithLibrary/Material_ComponentsInSyncWithLibrary.prefab
@@ -113,6 +113,13 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 4434530361734934283,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -276,6 +283,13 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 4434530361734934283,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -506,10 +520,17 @@
                     "Id": 2223745084206416722,
                     "Configuration": {
                         "entityId": "",
-                        "Material": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                    }
                                 }
                             ]
                         },
@@ -613,10 +634,17 @@
                     "$type": "EditorShapeColliderComponent",
                     "Id": 4434530361734934283,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_ComponentsInSyncWithLibrary/ragdoll_modified/rin_skeleton_newgeo.fbx.assetinfo
+++ b/AutomatedTesting/Levels/Physics/Material_ComponentsInSyncWithLibrary/ragdoll_modified/rin_skeleton_newgeo.fbx.assetinfo
@@ -320,16 +320,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -337,7 +338,7 @@
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
                                                         "Height": 0.4000000059604645,
-                                                        "Radius": 0.15000000596046449
+                                                        "Radius": 0.15000000596046448
                                                     }
                                                 ]
                                             ]
@@ -358,16 +359,17 @@
                                                             0.0,
                                                             0.7132986783981323
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -396,16 +398,17 @@
                                                             0.0,
                                                             0.725512683391571
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -424,7 +427,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.20000000298023225,
+                                                            0.20000000298023224,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -434,16 +437,17 @@
                                                             0.0,
                                                             0.7008591294288635
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -462,7 +466,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.20000000298023225,
+                                                            -0.20000000298023224,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -472,16 +476,17 @@
                                                             0.0,
                                                             0.6881973743438721
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -501,7 +506,7 @@
                                                     {
                                                         "Position": [
                                                             0.10000000149011612,
-                                                            -0.019999999552965165,
+                                                            -0.019999999552965164,
                                                             0.0
                                                         ],
                                                         "Rotation": [
@@ -510,16 +515,17 @@
                                                             0.2755587100982666,
                                                             0.9615697264671326
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -542,7 +548,7 @@
                                                     {
                                                         "Position": [
                                                             -0.10000000149011612,
-                                                            0.019999999552965165,
+                                                            0.019999999552965164,
                                                             0.0
                                                         ],
                                                         "Rotation": [
@@ -551,16 +557,17 @@
                                                             0.2755587100982666,
                                                             0.9615697264671326
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -569,7 +576,7 @@
                                                         "$type": "BoxShapeConfiguration",
                                                         "Configuration": [
                                                             0.25,
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.10000000149011612
                                                         ]
                                                     }
@@ -581,23 +588,24 @@
                                             "shapes": [
                                                 [
                                                     {
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.33000001311302187,
+                                                        "Height": 0.33000001311302185,
                                                         "Radius": 0.10000000149011612
                                                     }
                                                 ]
@@ -613,24 +621,25 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
-                                                        "Radius": 0.07000000029802323
+                                                        "Height": 0.30000001192092896,
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -645,24 +654,25 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
-                                                        "Radius": 0.07000000029802323
+                                                        "Height": 0.30000001192092896,
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -673,20 +683,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -694,7 +705,7 @@
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
                                                         "Height": 0.25,
-                                                        "Radius": 0.07000000029802323
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -705,26 +716,27 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.15000000596046449,
+                                                            0.15000000596046448,
                                                             0.0,
                                                             0.0
                                                         ],
                                                         "Rotation": [
-                                                            -2.0000000233721949e-7,
+                                                            -2.0000000233721948e-7,
                                                             -0.7075905203819275,
-                                                            2.0000000233721949e-7,
+                                                            2.0000000233721948e-7,
                                                             0.7066226005554199
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -743,20 +755,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.0,
-                                                            -0.019999999552965165
+                                                            -0.019999999552965164
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -785,16 +798,17 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -817,16 +831,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -844,26 +859,27 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.009999999776482582,
                                                             0.0
                                                         ],
                                                         "Rotation": [
                                                             0.6727613806724548,
-                                                            0.21843160688877107,
-                                                            0.21843160688877107,
+                                                            0.21843160688877106,
+                                                            0.21843160688877106,
                                                             0.6727614998817444
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -882,17 +898,16 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.07000000029802323,
+                                                            -0.07000000029802322,
                                                             0.0,
-                                                            0.019999999552965165
+                                                            0.019999999552965164
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            }
+                                                        "MaterialSlots": {
+                                                            "Slots": [
+                                                                {
+                                                                    "Name": "Entire object"
+                                                                }
+                                                            ]
                                                         }
                                                     },
                                                     {
@@ -909,7 +924,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.15000000596046449,
+                                                            -0.15000000596046448,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -919,16 +934,17 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -957,23 +973,24 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
+                                                        "Height": 0.30000001192092896,
                                                         "Radius": 0.05000000074505806
                                                     }
                                                 ]
@@ -989,16 +1006,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1008,7 +1026,7 @@
                                                         "Configuration": [
                                                             0.11999999731779099,
                                                             0.07999999821186066,
-                                                            0.029999999329447748
+                                                            0.029999999329447746
                                                         ]
                                                     }
                                                 ]
@@ -1030,23 +1048,24 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
+                                                        "Height": 0.30000001192092896,
                                                         "Radius": 0.05000000074505806
                                                     }
                                                 ]
@@ -1062,16 +1081,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1081,7 +1101,7 @@
                                                         "Configuration": [
                                                             0.11999999731779099,
                                                             0.07999999821186066,
-                                                            0.029999999329447748
+                                                            0.029999999329447746
                                                         ]
                                                     }
                                                 ]
@@ -1101,448 +1121,127 @@
                                             "name": "L_leg_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -0.20254400372505189,
-                                                    -0.6249864101409912,
-                                                    0.7367693781852722,
-                                                    0.1618904024362564
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.7375792264938355,
-                                                    0.0,
-                                                    0.0,
-                                                    0.6753178238868713
-                                                ],
-                                                "SwingLimitY": 50.0,
-                                                "SwingLimitZ": 30.0,
-                                                "TwistLowerLimit": -21.0,
-                                                "TwistUpperLimit": 23.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_leg_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.18296609818935395,
-                                                    0.6832081079483032,
-                                                    -0.6832082271575928,
-                                                    -0.18296639621257783
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.0,
-                                                    0.7255232930183411,
-                                                    0.6882146000862122,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 50.0,
-                                                "SwingLimitZ": 30.0,
-                                                "TwistLowerLimit": -16.0,
-                                                "TwistUpperLimit": 17.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_knee_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.6036934852600098,
-                                                    -0.36913779377937319,
-                                                    -0.36888980865478518,
-                                                    0.60325688123703
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0100685004144907,
-                                                    -0.01671529933810234,
-                                                    -0.07859530299901962,
-                                                    0.9967455863952637
-                                                ],
-                                                "SwingLimitY": 70.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -98.0,
-                                                "TwistUpperLimit": -75.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_knee_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -0.3260999023914337,
-                                                    -0.6149802207946777,
-                                                    0.6509910821914673,
-                                                    0.30416950583457949
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9999656081199646,
-                                                    -0.008921699598431588
-                                                ],
-                                                "SwingLimitY": 69.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": 77.0,
-                                                "TwistUpperLimit": 102.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_foot_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.09583680331707001,
-                                                    0.995438814163208
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    -0.514680027961731,
-                                                    0.8578065037727356
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 20.0,
-                                                "TwistLowerLimit": -34.0,
-                                                "TwistUpperLimit": 50.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_foot_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9909648895263672,
-                                                    -0.13970449566841126
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.0267730001360178,
-                                                    -0.024081699550151826,
-                                                    0.8836833834648132,
-                                                    0.46900999546051028
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 20.0,
-                                                "TwistLowerLimit": -29.0,
-                                                "TwistUpperLimit": 28.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_01_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.7071067094802856,
-                                                    0.0,
-                                                    0.0,
-                                                    0.7071068286895752
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_02_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_03_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_04_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_arm_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    -0.3254435956478119,
-                                                    0.0,
-                                                    0.9459221959114075
-                                                ],
-                                                "SwingLimitY": 25.0,
-                                                "SwingLimitZ": 85.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_clavicle_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    -0.6882243752479553,
-                                                    0.0,
-                                                    0.725512683391571
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    -0.01745240017771721,
-                                                    0.9998490810394287
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_neck_01_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.07845719903707504,
-                                                    0.9969456791877747
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_neck_02_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_head_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 25.0,
-                                                "TwistLowerLimit": -30.0,
-                                                "TwistUpperLimit": 30.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_clavicle_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    3.000000106112566e-7,
-                                                    0.6944776773452759,
-                                                    3.000000106112566e-7,
-                                                    0.7195212244987488
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_arm_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.9351276159286499,
-                                                    0.0,
-                                                    0.35854610800743105
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.008921699598431588,
-                                                    0.999965488910675,
-                                                    -0.0,
-                                                    -0.0
-                                                ],
-                                                "SwingLimitY": 25.0,
-                                                "SwingLimitZ": 85.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_elbow_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.040344301611185077,
-                                                    -0.016693100333213807,
-                                                    0.38212141394615176,
-                                                    0.9235191941261292
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "TwistLowerLimit": -25.0,
-                                                "TwistUpperLimit": 25.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_wrist_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitZ": 15.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_elbow_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9186229109764099,
-                                                    -0.3986668884754181
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 15.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_wrist_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -1.0000000116860974e-7,
-                                                    -0.0,
-                                                    0.9999998807907105,
-                                                    2.0000000233721949e-7
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitZ": 15.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         }
                                     ],
                                     "colliders": {
@@ -1557,16 +1256,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1574,7 +1274,7 @@
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
                                                             "Height": 0.4000000059604645,
-                                                            "Radius": 0.15000000596046449
+                                                            "Radius": 0.15000000596046448
                                                         }
                                                     ]
                                                 ]
@@ -1595,16 +1295,17 @@
                                                                 0.0,
                                                                 0.7132986783981323
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1633,16 +1334,17 @@
                                                                 0.0,
                                                                 0.725512683391571
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1661,7 +1363,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.20000000298023225,
+                                                                0.20000000298023224,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -1671,16 +1373,17 @@
                                                                 0.0,
                                                                 0.7008591294288635
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1699,7 +1402,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.20000000298023225,
+                                                                -0.20000000298023224,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -1709,16 +1412,17 @@
                                                                 0.0,
                                                                 0.6881973743438721
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1738,7 +1442,7 @@
                                                         {
                                                             "Position": [
                                                                 0.10000000149011612,
-                                                                -0.019999999552965165,
+                                                                -0.019999999552965164,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
@@ -1747,16 +1451,17 @@
                                                                 0.2755587100982666,
                                                                 0.9615697264671326
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1779,7 +1484,7 @@
                                                         {
                                                             "Position": [
                                                                 -0.10000000149011612,
-                                                                0.019999999552965165,
+                                                                0.019999999552965164,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
@@ -1788,16 +1493,17 @@
                                                                 0.2755587100982666,
                                                                 0.9615697264671326
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1806,7 +1512,7 @@
                                                             "$type": "BoxShapeConfiguration",
                                                             "Configuration": [
                                                                 0.25,
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.10000000149011612
                                                             ]
                                                         }
@@ -1818,23 +1524,24 @@
                                                 "shapes": [
                                                     [
                                                         {
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.33000001311302187,
+                                                            "Height": 0.33000001311302185,
                                                             "Radius": 0.10000000149011612
                                                         }
                                                     ]
@@ -1850,24 +1557,25 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.30000001192092896,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1882,24 +1590,25 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.20000000298023225,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.20000000298023224,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1910,28 +1619,29 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.15000000596046449,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.15000000596046448,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1942,26 +1652,27 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.15000000596046449,
+                                                                0.15000000596046448,
                                                                 0.0,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
-                                                                -2.0000000233721949e-7,
+                                                                -2.0000000233721948e-7,
                                                                 -0.7075905203819275,
-                                                                2.0000000233721949e-7,
+                                                                2.0000000233721948e-7,
                                                                 0.7066226005554199
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1980,20 +1691,21 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.0,
-                                                                -0.019999999552965165
+                                                                -0.019999999552965164
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2022,16 +1734,17 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2054,16 +1767,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2081,26 +1795,27 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.009999999776482582,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
                                                                 0.6727613806724548,
-                                                                0.21843160688877107,
-                                                                0.21843160688877107,
+                                                                0.21843160688877106,
+                                                                0.21843160688877106,
                                                                 0.6727614998817444
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2119,20 +1834,21 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.07000000029802323,
+                                                                -0.07000000029802322,
                                                                 0.0,
-                                                                0.019999999552965165
+                                                                0.019999999552965164
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2151,7 +1867,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.15000000596046449,
+                                                                -0.15000000596046448,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -2161,16 +1877,17 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2199,23 +1916,24 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
+                                                            "Height": 0.30000001192092896,
                                                             "Radius": 0.05000000074505806
                                                         }
                                                     ]
@@ -2231,16 +1949,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2250,7 +1969,7 @@
                                                             "Configuration": [
                                                                 0.11999999731779099,
                                                                 0.07999999821186066,
-                                                                0.029999999329447748
+                                                                0.029999999329447746
                                                             ]
                                                         }
                                                     ]
@@ -2272,23 +1991,24 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
+                                                            "Height": 0.30000001192092896,
                                                             "Radius": 0.05000000074505806
                                                         }
                                                     ]
@@ -2304,16 +2024,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{25E48A63-2092-5B95-84A3-2F609F97AAA6}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15308221_material_componentsinsyncwithlibrary/c15308221_material_componentsinsyncwithlibrary.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2323,7 +2044,7 @@
                                                             "Configuration": [
                                                                 0.11999999731779099,
                                                                 0.07999999821186066,
-                                                                0.029999999329447748
+                                                                0.029999999329447746
                                                             ]
                                                         }
                                                     ]
@@ -2340,10 +2061,17 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.022891199216246606,
+                                                            0.022891199216246605,
                                                             0.03267350047826767,
-                                                            0.0029446000698953869
+                                                            0.0029446000698953867
                                                         ],
+                                                        "MaterialSlots": {
+                                                            "Slots": [
+                                                                {
+                                                                    "Name": "Entire object"
+                                                                }
+                                                            ]
+                                                        },
                                                         "propertyVisibilityFlags": 248
                                                     },
                                                     {

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/Material_DefaultLibraryConsistentOnAllFeatures.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/Material_DefaultLibraryConsistentOnAllFeatures.prefab
@@ -98,6 +98,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -212,6 +219,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -438,6 +452,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 2521242760918763980,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -564,6 +585,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 2521242760918763980,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -806,10 +834,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9893204879060929949,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{7D4BE734-81B5-4271-B41B-340F4D77F3D0}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{7EA5B740-C52F-5D74-B762-11265A8A96DF}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_defaultlibraryconsistentonallfeatures/rubber.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -881,6 +916,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -1098,10 +1140,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9893204879060929949,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{92DC3AA3-AD2D-4DBC-9036-BC5E880A921B}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{27AA3F30-8BEF-576A-8054-C65B98EB3699}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_defaultlibraryconsistentonallfeatures/concrete.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -1173,6 +1222,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -1287,6 +1343,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -1401,6 +1464,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -1559,6 +1629,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9893204879060929949,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -1672,6 +1749,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9893204879060929949,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -1870,6 +1954,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -2024,6 +2115,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9893204879060929949,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -2059,10 +2157,17 @@
                     "Id": 1093548322450453329,
                     "Configuration": {
                         "entityId": "",
-                        "Material": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{7D4BE734-81B5-4271-B41B-340F4D77F3D0}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{7EA5B740-C52F-5D74-B762-11265A8A96DF}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_defaultlibraryconsistentonallfeatures/rubber.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -2223,10 +2328,17 @@
                     "Id": 1093548322450453329,
                     "Configuration": {
                         "entityId": "",
-                        "Material": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{92DC3AA3-AD2D-4DBC-9036-BC5E880A921B}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{27AA3F30-8BEF-576A-8054-C65B98EB3699}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_defaultlibraryconsistentonallfeatures/concrete.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -2425,6 +2537,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -2539,6 +2658,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -2653,6 +2779,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -2767,6 +2900,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -2925,6 +3065,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9893204879060929949,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -2998,6 +3145,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -3112,6 +3266,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -3226,6 +3387,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -3340,6 +3508,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -3494,6 +3669,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9893204879060929949,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -3567,6 +3749,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -3721,6 +3910,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9893204879060929949,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/ragdoll/concrete/rin_skeleton_newgeo.fbx.assetinfo
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/ragdoll/concrete/rin_skeleton_newgeo.fbx.assetinfo
@@ -321,16 +321,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{E6D6DBB9-38FA-560E-B328-B40DE06FBE95}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/c15096735_materials_defaultlibraryconsistency.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{92DC3AA3-AD2D-4DBC-9036-BC5E880A921B}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{27AA3F30-8BEF-576A-8054-C65B98EB3699}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_defaultlibraryconsistentonallfeatures/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -360,16 +361,17 @@
                                                     [
                                                         {
                                                             "Visible": true,
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{E6D6DBB9-38FA-560E-B328-B40DE06FBE95}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/c15096735_materials_defaultlibraryconsistency.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{92DC3AA3-AD2D-4DBC-9036-BC5E880A921B}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{27AA3F30-8BEF-576A-8054-C65B98EB3699}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_defaultlibraryconsistentonallfeatures/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -391,10 +393,17 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.022891199216246606,
+                                                            0.022891199216246605,
                                                             0.03267350047826767,
-                                                            0.0029446000698953869
+                                                            0.0029446000698953867
                                                         ],
+                                                        "MaterialSlots": {
+                                                            "Slots": [
+                                                                {
+                                                                    "Name": "Entire object"
+                                                                }
+                                                            ]
+                                                        },
                                                         "propertyVisibilityFlags": 248
                                                     },
                                                     {

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/ragdoll/rubber/rin_skeleton_newgeo.fbx.assetinfo
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryConsistentOnAllFeatures/ragdoll/rubber/rin_skeleton_newgeo.fbx.assetinfo
@@ -321,16 +321,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{E6D6DBB9-38FA-560E-B328-B40DE06FBE95}"
-                                                                },
-                                                                "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/c15096735_materials_defaultlibraryconsistency.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{7D4BE734-81B5-4271-B41B-340F4D77F3D0}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{7EA5B740-C52F-5D74-B762-11265A8A96DF}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_defaultlibraryconsistentonallfeatures/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -360,16 +361,17 @@
                                                     [
                                                         {
                                                             "Visible": true,
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{E6D6DBB9-38FA-560E-B328-B40DE06FBE95}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c15096735_materials_defaultlibraryconsistency/c15096735_materials_defaultlibraryconsistency.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{7D4BE734-81B5-4271-B41B-340F4D77F3D0}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{7EA5B740-C52F-5D74-B762-11265A8A96DF}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_defaultlibraryconsistentonallfeatures/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -391,10 +393,17 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.022891199216246606,
+                                                            0.022891199216246605,
                                                             0.03267350047826767,
-                                                            0.0029446000698953869
+                                                            0.0029446000698953867
                                                         ],
+                                                        "MaterialSlots": {
+                                                            "Slots": [
+                                                                {
+                                                                    "Name": "Entire object"
+                                                                }
+                                                            ]
+                                                        },
                                                         "propertyVisibilityFlags": 248
                                                     },
                                                     {

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/0/0.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/0/0.prefab
@@ -183,10 +183,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4540728435480896449,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{A9E990B3-4EA5-4108-8569-B4CC54D37527}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{DA91BA55-C7CD-57AB-9C64-E4045D239B39}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_defaultlibraryupdatedacrosslevels/bounce_0.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -242,6 +249,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 15842267116631028419,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -349,6 +363,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}

--- a/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/1/1.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DefaultLibraryUpdatedAcrossLevels/1/1.prefab
@@ -63,10 +63,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 11906722936407481270,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{A9E990B3-4EA5-4108-8569-B4CC54D37527}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{DA91BA55-C7CD-57AB-9C64-E4045D239B39}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_defaultlibraryupdatedacrosslevels/bounce_0.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -258,6 +265,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18005002941285960013,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -353,6 +367,13 @@
                     "ColliderConfiguration": {
                         "Trigger": true,
                         "InSceneQueries": false,
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}

--- a/AutomatedTesting/Levels/Physics/Material_DynamicFriction/Material_DynamicFriction.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_DynamicFriction/Material_DynamicFriction.prefab
@@ -140,6 +140,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -267,10 +274,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -377,10 +391,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{5DC7FE5B-E7D3-5FD4-9256-002980439C65}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/low_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -487,10 +508,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{FDC9696F-EF9A-5BA1-9F48-258DC91CCE6D}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/mid_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -597,10 +625,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6E61FDAB-07D1-5B86-87F0-7D32E24D586B}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/box_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_FrictionCombine/Material_FrictionCombine.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_FrictionCombine/Material_FrictionCombine.prefab
@@ -140,10 +140,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{05A7DE35-5FD6-4496-B93B-FAF78262FEEC}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{7D320D01-0BD3-5AF1-B341-0049F2CCA675}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombine/ramp.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -269,10 +276,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6E61FDAB-07D1-5B86-87F0-7D32E24D586B}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/box_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -379,10 +393,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -489,10 +510,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{FDC9696F-EF9A-5BA1-9F48-258DC91CCE6D}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/mid_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -599,10 +627,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{5DC7FE5B-E7D3-5FD4-9256-002980439C65}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/low_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_FrictionCombinePriorityOrder/Material_FrictionCombinePriorityOrder.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_FrictionCombinePriorityOrder/Material_FrictionCombinePriorityOrder.prefab
@@ -140,10 +140,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{05A7DE35-5FD6-4496-B93B-FAF78262FEEC}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{7D320D01-0BD3-5AF1-B341-0049F2CCA675}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombine/ramp.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -269,10 +276,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{FDC9696F-EF9A-5BA1-9F48-258DC91CCE6D}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/mid_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -406,10 +420,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{AAAADE4F-9A35-476B-9424-20D40CBD8E59}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{4A8ACFB8-79C9-573D-82DC-4A4017E6E279}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/ramp_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -562,10 +583,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{C0067490-4214-4ADC-857A-FA978B6609D8}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{BCE0CBE4-F89D-5522-B7C3-02C6D5BA7E33}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_frictioncombinepriorityorder/ramp_multiply.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -718,10 +746,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EC70218A-5C2F-4E4C-A606-DB0985D80BD9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{B4D50C0C-AF2A-5A2A-8098-2FA0537E2664}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_frictioncombinepriorityorder/ramp_maximum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -847,10 +882,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6E61FDAB-07D1-5B86-87F0-7D32E24D586B}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/box_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -957,10 +999,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -1067,10 +1116,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{5DC7FE5B-E7D3-5FD4-9256-002980439C65}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/low_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_LibraryChangesReflectInstantly/Material_LibraryChangesReflectInstantly.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryChangesReflectInstantly/Material_LibraryChangesReflectInstantly.prefab
@@ -130,6 +130,13 @@
                             0.0,
                             0.9999622702598572
                         ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -317,10 +324,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 5742240157833915092,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{990FB3E0-0F65-46E0-9D91-FD948263D204}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{9E9E926C-A302-52B1-87D2-4DF1029B56A1}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/to_change_restitution_1.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -413,10 +427,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9243168508986239530,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{4CE235BC-9483-4C13-8A3A-D9DF0DEB34BE}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{C460F722-202D-5CC1-B97B-ED7628C74162}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/to_change_restitution_combine.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -516,10 +537,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 8037889069626634204,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{DE5438E9-52CE-4294-B2EE-250BB4D45A30}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{12074E27-08A6-5F88-8741-C319B79E0B8C}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/to_delete_1.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -595,10 +623,17 @@
                             0.0,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{34AD1046-240B-448C-A694-AE80F595C431}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{B9100A77-5ACF-5FCC-B9DD-2DAF8EF82F9E}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/to_change_static_friction_1.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -745,10 +780,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 8062409581128028241,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{6DB5BFA8-8D3F-4A62-BB00-80CD20DE4FC3}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{AE1F51C6-F885-5231-8358-1E5167F2116C}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/to_change_dynamic_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -840,10 +882,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 17055748108217384148,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{C4EE226F-2344-48EB-855C-5E7DC1FF30DE}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{17B0E089-8DE5-55FA-8F93-6EA9B986BF97}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/to_change_friction_combine.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -958,10 +1007,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 9873641921497409447,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{C05FBCC0-F28E-49CD-92BC-F317B50BD459}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{1614E284-833F-5D37-AB39-63717EA8B97E}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarychangesreflectinstantly/ramp_1.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnCharacterController/Material_LibraryCrudOperationsReflectOnCharacterController.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnCharacterController/Material_LibraryCrudOperationsReflectOnCharacterController.prefab
@@ -126,6 +126,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18441975369007490586,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -180,6 +187,13 @@
                     "Id": 14399102793718028065,
                     "Configuration": {
                         "entityId": "",
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "Material": {
                             "MaterialIds": [
                                 {}
@@ -284,10 +298,17 @@
                     "Id": 14399102793718028065,
                     "Configuration": {
                         "entityId": "",
-                        "Material": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{C9E8CE58-FC4F-4498-B502-21B87CE7321E}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{10A1AF01-04B2-5175-AD29-E01B84452DC4}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectoncharactercontroller/modified.physicsmaterial"
+                                    }
                                 }
                             ]
                         },
@@ -448,6 +469,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18441975369007490586,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}

--- a/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnCollider/Material_LibraryCrudOperationsReflectOnCollider.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnCollider/Material_LibraryCrudOperationsReflectOnCollider.prefab
@@ -196,6 +196,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18082739249556167219,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -303,10 +310,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 18082739249556167219,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{BC7E0096-0D0E-452E-8D3C-E239B4DC6D42}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{99DF9D52-C1E9-54B3-B136-9DF3EB625805}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectoncollider/modified.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnRagdollBones/ragdoll_modified/rin_skeleton_newgeo.fbx.assetinfo
+++ b/AutomatedTesting/Levels/Physics/Material_LibraryCrudOperationsReflectOnRagdollBones/ragdoll_modified/rin_skeleton_newgeo.fbx.assetinfo
@@ -320,16 +320,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -337,7 +338,7 @@
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
                                                         "Height": 0.4000000059604645,
-                                                        "Radius": 0.15000000596046449
+                                                        "Radius": 0.15000000596046448
                                                     }
                                                 ]
                                             ]
@@ -358,16 +359,17 @@
                                                             0.0,
                                                             0.7132986783981323
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -396,16 +398,17 @@
                                                             0.0,
                                                             0.725512683391571
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -424,7 +427,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.20000000298023225,
+                                                            0.20000000298023224,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -434,16 +437,17 @@
                                                             0.0,
                                                             0.7008591294288635
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -462,7 +466,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.20000000298023225,
+                                                            -0.20000000298023224,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -472,16 +476,17 @@
                                                             0.0,
                                                             0.6881973743438721
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -501,7 +506,7 @@
                                                     {
                                                         "Position": [
                                                             0.10000000149011612,
-                                                            -0.019999999552965165,
+                                                            -0.019999999552965164,
                                                             0.0
                                                         ],
                                                         "Rotation": [
@@ -510,16 +515,17 @@
                                                             0.2755587100982666,
                                                             0.9615697264671326
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -542,7 +548,7 @@
                                                     {
                                                         "Position": [
                                                             -0.10000000149011612,
-                                                            0.019999999552965165,
+                                                            0.019999999552965164,
                                                             0.0
                                                         ],
                                                         "Rotation": [
@@ -551,16 +557,17 @@
                                                             0.2755587100982666,
                                                             0.9615697264671326
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -569,7 +576,7 @@
                                                         "$type": "BoxShapeConfiguration",
                                                         "Configuration": [
                                                             0.25,
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.10000000149011612
                                                         ]
                                                     }
@@ -581,23 +588,24 @@
                                             "shapes": [
                                                 [
                                                     {
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.33000001311302187,
+                                                        "Height": 0.33000001311302185,
                                                         "Radius": 0.10000000149011612
                                                     }
                                                 ]
@@ -613,24 +621,25 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
-                                                        "Radius": 0.07000000029802323
+                                                        "Height": 0.30000001192092896,
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -645,24 +654,25 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
-                                                        "Radius": 0.07000000029802323
+                                                        "Height": 0.30000001192092896,
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -673,20 +683,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -694,7 +705,7 @@
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
                                                         "Height": 0.25,
-                                                        "Radius": 0.07000000029802323
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -705,26 +716,27 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.15000000596046449,
+                                                            0.15000000596046448,
                                                             0.0,
                                                             0.0
                                                         ],
                                                         "Rotation": [
-                                                            -2.0000000233721949e-7,
+                                                            -2.0000000233721948e-7,
                                                             -0.7075905203819275,
-                                                            2.0000000233721949e-7,
+                                                            2.0000000233721948e-7,
                                                             0.7066226005554199
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -743,20 +755,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.0,
-                                                            -0.019999999552965165
+                                                            -0.019999999552965164
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -785,16 +798,17 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -817,16 +831,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -844,26 +859,27 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.009999999776482582,
                                                             0.0
                                                         ],
                                                         "Rotation": [
                                                             0.6727613806724548,
-                                                            0.21843160688877107,
-                                                            0.21843160688877107,
+                                                            0.21843160688877106,
+                                                            0.21843160688877106,
                                                             0.6727614998817444
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -882,20 +898,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.07000000029802323,
+                                                            -0.07000000029802322,
                                                             0.0,
-                                                            0.019999999552965165
+                                                            0.019999999552965164
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -914,7 +931,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.15000000596046449,
+                                                            -0.15000000596046448,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -924,16 +941,17 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -962,23 +980,24 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
+                                                        "Height": 0.30000001192092896,
                                                         "Radius": 0.05000000074505806
                                                     }
                                                 ]
@@ -994,16 +1013,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1013,7 +1033,7 @@
                                                         "Configuration": [
                                                             0.11999999731779099,
                                                             0.07999999821186066,
-                                                            0.029999999329447748
+                                                            0.029999999329447746
                                                         ]
                                                     }
                                                 ]
@@ -1035,23 +1055,24 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
+                                                        "Height": 0.30000001192092896,
                                                         "Radius": 0.05000000074505806
                                                     }
                                                 ]
@@ -1067,16 +1088,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1086,7 +1108,7 @@
                                                         "Configuration": [
                                                             0.11999999731779099,
                                                             0.07999999821186066,
-                                                            0.029999999329447748
+                                                            0.029999999329447746
                                                         ]
                                                     }
                                                 ]
@@ -1106,448 +1128,127 @@
                                             "name": "L_leg_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -0.20254400372505189,
-                                                    -0.6249864101409912,
-                                                    0.7367693781852722,
-                                                    0.1618904024362564
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.7375792264938355,
-                                                    0.0,
-                                                    0.0,
-                                                    0.6753178238868713
-                                                ],
-                                                "SwingLimitY": 50.0,
-                                                "SwingLimitZ": 30.0,
-                                                "TwistLowerLimit": -21.0,
-                                                "TwistUpperLimit": 23.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_leg_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.18296609818935395,
-                                                    0.6832081079483032,
-                                                    -0.6832082271575928,
-                                                    -0.18296639621257783
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.0,
-                                                    0.7255232930183411,
-                                                    0.6882146000862122,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 50.0,
-                                                "SwingLimitZ": 30.0,
-                                                "TwistLowerLimit": -16.0,
-                                                "TwistUpperLimit": 17.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_knee_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.6036934852600098,
-                                                    -0.36913779377937319,
-                                                    -0.36888980865478518,
-                                                    0.60325688123703
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0100685004144907,
-                                                    -0.01671529933810234,
-                                                    -0.07859530299901962,
-                                                    0.9967455863952637
-                                                ],
-                                                "SwingLimitY": 70.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -98.0,
-                                                "TwistUpperLimit": -75.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_knee_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -0.3260999023914337,
-                                                    -0.6149802207946777,
-                                                    0.6509910821914673,
-                                                    0.30416950583457949
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9999656081199646,
-                                                    -0.008921699598431588
-                                                ],
-                                                "SwingLimitY": 69.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": 77.0,
-                                                "TwistUpperLimit": 102.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_foot_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.09583680331707001,
-                                                    0.995438814163208
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    -0.514680027961731,
-                                                    0.8578065037727356
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 20.0,
-                                                "TwistLowerLimit": -34.0,
-                                                "TwistUpperLimit": 50.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_foot_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9909648895263672,
-                                                    -0.13970449566841126
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.0267730001360178,
-                                                    -0.024081699550151826,
-                                                    0.8836833834648132,
-                                                    0.46900999546051028
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 20.0,
-                                                "TwistLowerLimit": -29.0,
-                                                "TwistUpperLimit": 28.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_01_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.7071067094802856,
-                                                    0.0,
-                                                    0.0,
-                                                    0.7071068286895752
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_02_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_03_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_04_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_arm_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    -0.3254435956478119,
-                                                    0.0,
-                                                    0.9459221959114075
-                                                ],
-                                                "SwingLimitY": 25.0,
-                                                "SwingLimitZ": 85.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_clavicle_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    -0.6882243752479553,
-                                                    0.0,
-                                                    0.725512683391571
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    -0.01745240017771721,
-                                                    0.9998490810394287
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_neck_01_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.07845719903707504,
-                                                    0.9969456791877747
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_neck_02_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_head_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 25.0,
-                                                "TwistLowerLimit": -30.0,
-                                                "TwistUpperLimit": 30.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_clavicle_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    3.000000106112566e-7,
-                                                    0.6944776773452759,
-                                                    3.000000106112566e-7,
-                                                    0.7195212244987488
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_arm_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.9351276159286499,
-                                                    0.0,
-                                                    0.35854610800743105
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.008921699598431588,
-                                                    0.999965488910675,
-                                                    -0.0,
-                                                    -0.0
-                                                ],
-                                                "SwingLimitY": 25.0,
-                                                "SwingLimitZ": 85.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_elbow_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.040344301611185077,
-                                                    -0.016693100333213807,
-                                                    0.38212141394615176,
-                                                    0.9235191941261292
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "TwistLowerLimit": -25.0,
-                                                "TwistUpperLimit": 25.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_wrist_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitZ": 15.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_elbow_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9186229109764099,
-                                                    -0.3986668884754181
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 15.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_wrist_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -1.0000000116860974e-7,
-                                                    -0.0,
-                                                    0.9999998807907105,
-                                                    2.0000000233721949e-7
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitZ": 15.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         }
                                     ],
                                     "colliders": {
@@ -1562,16 +1263,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1579,7 +1281,7 @@
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
                                                             "Height": 0.4000000059604645,
-                                                            "Radius": 0.15000000596046449
+                                                            "Radius": 0.15000000596046448
                                                         }
                                                     ]
                                                 ]
@@ -1600,16 +1302,17 @@
                                                                 0.0,
                                                                 0.7132986783981323
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1638,16 +1341,17 @@
                                                                 0.0,
                                                                 0.725512683391571
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1666,7 +1370,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.20000000298023225,
+                                                                0.20000000298023224,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -1676,16 +1380,17 @@
                                                                 0.0,
                                                                 0.7008591294288635
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1704,7 +1409,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.20000000298023225,
+                                                                -0.20000000298023224,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -1714,16 +1419,17 @@
                                                                 0.0,
                                                                 0.6881973743438721
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1743,7 +1449,7 @@
                                                         {
                                                             "Position": [
                                                                 0.10000000149011612,
-                                                                -0.019999999552965165,
+                                                                -0.019999999552965164,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
@@ -1752,16 +1458,17 @@
                                                                 0.2755587100982666,
                                                                 0.9615697264671326
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1784,7 +1491,7 @@
                                                         {
                                                             "Position": [
                                                                 -0.10000000149011612,
-                                                                0.019999999552965165,
+                                                                0.019999999552965164,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
@@ -1793,16 +1500,17 @@
                                                                 0.2755587100982666,
                                                                 0.9615697264671326
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1811,7 +1519,7 @@
                                                             "$type": "BoxShapeConfiguration",
                                                             "Configuration": [
                                                                 0.25,
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.10000000149011612
                                                             ]
                                                         }
@@ -1823,23 +1531,24 @@
                                                 "shapes": [
                                                     [
                                                         {
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.33000001311302187,
+                                                            "Height": 0.33000001311302185,
                                                             "Radius": 0.10000000149011612
                                                         }
                                                     ]
@@ -1855,24 +1564,25 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.30000001192092896,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1887,24 +1597,25 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.20000000298023225,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.20000000298023224,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1915,28 +1626,29 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.15000000596046449,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.15000000596046448,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1947,26 +1659,27 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.15000000596046449,
+                                                                0.15000000596046448,
                                                                 0.0,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
-                                                                -2.0000000233721949e-7,
+                                                                -2.0000000233721948e-7,
                                                                 -0.7075905203819275,
-                                                                2.0000000233721949e-7,
+                                                                2.0000000233721948e-7,
                                                                 0.7066226005554199
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1985,20 +1698,21 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.0,
-                                                                -0.019999999552965165
+                                                                -0.019999999552965164
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2027,16 +1741,17 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2059,16 +1774,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2086,26 +1802,27 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.009999999776482582,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
                                                                 0.6727613806724548,
-                                                                0.21843160688877107,
-                                                                0.21843160688877107,
+                                                                0.21843160688877106,
+                                                                0.21843160688877106,
                                                                 0.6727614998817444
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2124,20 +1841,21 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.07000000029802323,
+                                                                -0.07000000029802322,
                                                                 0.0,
-                                                                0.019999999552965165
+                                                                0.019999999552965164
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2156,7 +1874,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.15000000596046449,
+                                                                -0.15000000596046448,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -2166,16 +1884,17 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2204,23 +1923,24 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
+                                                            "Height": 0.30000001192092896,
                                                             "Radius": 0.05000000074505806
                                                         }
                                                     ]
@@ -2236,16 +1956,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2255,7 +1976,7 @@
                                                             "Configuration": [
                                                                 0.11999999731779099,
                                                                 0.07999999821186066,
-                                                                0.029999999329447748
+                                                                0.029999999329447746
                                                             ]
                                                         }
                                                     ]
@@ -2277,23 +1998,24 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
+                                                            "Height": 0.30000001192092896,
                                                             "Radius": 0.05000000074505806
                                                         }
                                                     ]
@@ -2309,16 +2031,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{716DED56-5A2A-5D96-94EF-2646AD76ED8A}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925582_material_addmodifydeleteonragdollbones/ragdollbones.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{A68F207B-4082-4CC7-B574-72881BCA16E9}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{F3DDE5D6-00C4-5766-A2E2-3141386AE294}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_librarycrudoperationsreflectonragdollbones/modified.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2328,7 +2051,7 @@
                                                             "Configuration": [
                                                                 0.11999999731779099,
                                                                 0.07999999821186066,
-                                                                0.029999999329447748
+                                                                0.029999999329447746
                                                             ]
                                                         }
                                                     ]
@@ -2345,10 +2068,17 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.022891199216246606,
+                                                            0.022891199216246605,
                                                             0.03267350047826767,
-                                                            0.0029446000698953869
+                                                            0.0029446000698953867
                                                         ],
+                                                        "MaterialSlots": {
+                                                            "Slots": [
+                                                                {
+                                                                    "Name": "Entire object"
+                                                                }
+                                                            ]
+                                                        },
                                                         "propertyVisibilityFlags": 248
                                                     },
                                                     {

--- a/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/Material_PerFaceMaterialGetsCorrectMaterial.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_PerFaceMaterialGetsCorrectMaterial/Material_PerFaceMaterialGetsCorrectMaterial.prefab
@@ -80,19 +80,47 @@
                     "$type": "EditorColliderComponent",
                     "Id": 14094829544062915163,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{DBC444ED-4809-4EB3-A0B7-3E5608816C57}"
+                                    "Name": "Material 1",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{19D8D9AA-7E34-5A74-946A-D82CD0E714C1}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_perfacematerialgetscorrectmaterial/partialbounce.physicsmaterial"
+                                    }
                                 },
                                 {
-                                    "MaterialId": "{1342C732-E45A-48FA-92DD-BDCE5E29B498}"
+                                    "Name": "Material 2",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{579E2294-E545-5DD3-AA05-3DCF28049FF4}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_perfacematerialgetscorrectmaterial/bounce.physicsmaterial"
+                                    }
                                 },
                                 {
-                                    "MaterialId": "{F529C9BA-5534-4E17-8232-076F4C2A85F1}"
+                                    "Name": "Material 3",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{C2DC9FDF-8415-5A77-9382-A9C26E425DBC}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_perfacematerialgetscorrectmaterial/nobounce.physicsmaterial"
+                                    }
                                 },
                                 {
-                                    "MaterialId": "{F529C9BA-5534-4E17-8232-076F4C2A85F1}"
+                                    "Name": "Material 4",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{C2DC9FDF-8415-5A77-9382-A9C26E425DBC}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_perfacematerialgetscorrectmaterial/nobounce.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -261,10 +289,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 8555372987471605395,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{1342C732-E45A-48FA-92DD-BDCE5E29B498}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{579E2294-E545-5DD3-AA05-3DCF28049FF4}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_perfacematerialgetscorrectmaterial/bounce.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -284,10 +319,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10149587071258241793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{1342C732-E45A-48FA-92DD-BDCE5E29B498}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{579E2294-E545-5DD3-AA05-3DCF28049FF4}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_perfacematerialgetscorrectmaterial/bounce.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -398,10 +440,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10149587071258241793,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{1342C732-E45A-48FA-92DD-BDCE5E29B498}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{579E2294-E545-5DD3-AA05-3DCF28049FF4}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_perfacematerialgetscorrectmaterial/bounce.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_RagdollBones/ragdoll_concrete/rin_skeleton_newgeo.fbx.assetinfo
+++ b/AutomatedTesting/Levels/Physics/Material_RagdollBones/ragdoll_concrete/rin_skeleton_newgeo.fbx.assetinfo
@@ -320,16 +320,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -337,7 +338,7 @@
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
                                                         "Height": 0.4000000059604645,
-                                                        "Radius": 0.15000000596046449
+                                                        "Radius": 0.15000000596046448
                                                     }
                                                 ]
                                             ]
@@ -358,16 +359,17 @@
                                                             0.0,
                                                             0.7132986783981323
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -396,16 +398,17 @@
                                                             0.0,
                                                             0.725512683391571
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -424,7 +427,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.20000000298023225,
+                                                            0.20000000298023224,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -434,16 +437,17 @@
                                                             0.0,
                                                             0.7008591294288635
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -462,7 +466,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.20000000298023225,
+                                                            -0.20000000298023224,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -472,16 +476,17 @@
                                                             0.0,
                                                             0.6881973743438721
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -501,7 +506,7 @@
                                                     {
                                                         "Position": [
                                                             0.10000000149011612,
-                                                            -0.019999999552965165,
+                                                            -0.019999999552965164,
                                                             0.0
                                                         ],
                                                         "Rotation": [
@@ -510,16 +515,17 @@
                                                             0.2755587100982666,
                                                             0.9615697264671326
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -542,7 +548,7 @@
                                                     {
                                                         "Position": [
                                                             -0.10000000149011612,
-                                                            0.019999999552965165,
+                                                            0.019999999552965164,
                                                             0.0
                                                         ],
                                                         "Rotation": [
@@ -551,16 +557,17 @@
                                                             0.2755587100982666,
                                                             0.9615697264671326
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -569,7 +576,7 @@
                                                         "$type": "BoxShapeConfiguration",
                                                         "Configuration": [
                                                             0.25,
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.10000000149011612
                                                         ]
                                                     }
@@ -581,23 +588,24 @@
                                             "shapes": [
                                                 [
                                                     {
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.33000001311302187,
+                                                        "Height": 0.33000001311302185,
                                                         "Radius": 0.10000000149011612
                                                     }
                                                 ]
@@ -613,24 +621,25 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
-                                                        "Radius": 0.07000000029802323
+                                                        "Height": 0.30000001192092896,
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -645,24 +654,25 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
-                                                        "Radius": 0.07000000029802323
+                                                        "Height": 0.30000001192092896,
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -673,20 +683,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -694,7 +705,7 @@
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
                                                         "Height": 0.25,
-                                                        "Radius": 0.07000000029802323
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -705,26 +716,27 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.15000000596046449,
+                                                            0.15000000596046448,
                                                             0.0,
                                                             0.0
                                                         ],
                                                         "Rotation": [
-                                                            -2.0000000233721949e-7,
+                                                            -2.0000000233721948e-7,
                                                             -0.7075905203819275,
-                                                            2.0000000233721949e-7,
+                                                            2.0000000233721948e-7,
                                                             0.7066226005554199
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -743,20 +755,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.0,
-                                                            -0.019999999552965165
+                                                            -0.019999999552965164
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -785,16 +798,17 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -817,16 +831,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -844,26 +859,27 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.009999999776482582,
                                                             0.0
                                                         ],
                                                         "Rotation": [
                                                             0.6727613806724548,
-                                                            0.21843160688877107,
-                                                            0.21843160688877107,
+                                                            0.21843160688877106,
+                                                            0.21843160688877106,
                                                             0.6727614998817444
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -882,20 +898,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.07000000029802323,
+                                                            -0.07000000029802322,
                                                             0.0,
-                                                            0.019999999552965165
+                                                            0.019999999552965164
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -914,7 +931,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.15000000596046449,
+                                                            -0.15000000596046448,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -924,16 +941,17 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -962,23 +980,24 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
+                                                        "Height": 0.30000001192092896,
                                                         "Radius": 0.05000000074505806
                                                     }
                                                 ]
@@ -994,16 +1013,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1013,7 +1033,7 @@
                                                         "Configuration": [
                                                             0.11999999731779099,
                                                             0.07999999821186066,
-                                                            0.029999999329447748
+                                                            0.029999999329447746
                                                         ]
                                                     }
                                                 ]
@@ -1035,23 +1055,24 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
+                                                        "Height": 0.30000001192092896,
                                                         "Radius": 0.05000000074505806
                                                     }
                                                 ]
@@ -1067,16 +1088,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1086,7 +1108,7 @@
                                                         "Configuration": [
                                                             0.11999999731779099,
                                                             0.07999999821186066,
-                                                            0.029999999329447748
+                                                            0.029999999329447746
                                                         ]
                                                     }
                                                 ]
@@ -1106,448 +1128,127 @@
                                             "name": "L_leg_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -0.20254400372505189,
-                                                    -0.6249864101409912,
-                                                    0.7367693781852722,
-                                                    0.1618904024362564
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.7375792264938355,
-                                                    0.0,
-                                                    0.0,
-                                                    0.6753178238868713
-                                                ],
-                                                "SwingLimitY": 50.0,
-                                                "SwingLimitZ": 30.0,
-                                                "TwistLowerLimit": -21.0,
-                                                "TwistUpperLimit": 23.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_leg_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.18296609818935395,
-                                                    0.6832081079483032,
-                                                    -0.6832082271575928,
-                                                    -0.18296639621257783
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.0,
-                                                    0.7255232930183411,
-                                                    0.6882146000862122,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 50.0,
-                                                "SwingLimitZ": 30.0,
-                                                "TwistLowerLimit": -16.0,
-                                                "TwistUpperLimit": 17.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_knee_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.6036934852600098,
-                                                    -0.36913779377937319,
-                                                    -0.36888980865478518,
-                                                    0.60325688123703
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0100685004144907,
-                                                    -0.01671529933810234,
-                                                    -0.07859530299901962,
-                                                    0.9967455863952637
-                                                ],
-                                                "SwingLimitY": 70.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -98.0,
-                                                "TwistUpperLimit": -75.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_knee_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -0.3260999023914337,
-                                                    -0.6149802207946777,
-                                                    0.6509910821914673,
-                                                    0.30416950583457949
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9999656081199646,
-                                                    -0.008921699598431588
-                                                ],
-                                                "SwingLimitY": 69.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": 77.0,
-                                                "TwistUpperLimit": 102.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_foot_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.09583680331707001,
-                                                    0.995438814163208
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    -0.514680027961731,
-                                                    0.8578065037727356
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 20.0,
-                                                "TwistLowerLimit": -34.0,
-                                                "TwistUpperLimit": 50.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_foot_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9909648895263672,
-                                                    -0.13970449566841126
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.0267730001360178,
-                                                    -0.024081699550151826,
-                                                    0.8836833834648132,
-                                                    0.46900999546051028
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 20.0,
-                                                "TwistLowerLimit": -29.0,
-                                                "TwistUpperLimit": 28.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_01_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.7071067094802856,
-                                                    0.0,
-                                                    0.0,
-                                                    0.7071068286895752
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_02_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_03_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_04_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_arm_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    -0.3254435956478119,
-                                                    0.0,
-                                                    0.9459221959114075
-                                                ],
-                                                "SwingLimitY": 25.0,
-                                                "SwingLimitZ": 85.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_clavicle_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    -0.6882243752479553,
-                                                    0.0,
-                                                    0.725512683391571
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    -0.01745240017771721,
-                                                    0.9998490810394287
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_neck_01_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.07845719903707504,
-                                                    0.9969456791877747
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_neck_02_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_head_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 25.0,
-                                                "TwistLowerLimit": -30.0,
-                                                "TwistUpperLimit": 30.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_clavicle_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    3.000000106112566e-7,
-                                                    0.6944776773452759,
-                                                    3.000000106112566e-7,
-                                                    0.7195212244987488
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_arm_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.9351276159286499,
-                                                    0.0,
-                                                    0.35854610800743105
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.008921699598431588,
-                                                    0.999965488910675,
-                                                    -0.0,
-                                                    -0.0
-                                                ],
-                                                "SwingLimitY": 25.0,
-                                                "SwingLimitZ": 85.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_elbow_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.040344301611185077,
-                                                    -0.016693100333213807,
-                                                    0.38212141394615176,
-                                                    0.9235191941261292
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "TwistLowerLimit": -25.0,
-                                                "TwistUpperLimit": 25.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_wrist_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitZ": 15.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_elbow_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9186229109764099,
-                                                    -0.3986668884754181
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 15.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_wrist_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -1.0000000116860974e-7,
-                                                    -0.0,
-                                                    0.9999998807907105,
-                                                    2.0000000233721949e-7
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitZ": 15.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         }
                                     ],
                                     "colliders": {
@@ -1562,16 +1263,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1579,7 +1281,7 @@
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
                                                             "Height": 0.4000000059604645,
-                                                            "Radius": 0.15000000596046449
+                                                            "Radius": 0.15000000596046448
                                                         }
                                                     ]
                                                 ]
@@ -1600,16 +1302,17 @@
                                                                 0.0,
                                                                 0.7132986783981323
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1638,16 +1341,17 @@
                                                                 0.0,
                                                                 0.725512683391571
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1666,7 +1370,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.20000000298023225,
+                                                                0.20000000298023224,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -1676,16 +1380,17 @@
                                                                 0.0,
                                                                 0.7008591294288635
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1704,7 +1409,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.20000000298023225,
+                                                                -0.20000000298023224,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -1714,16 +1419,17 @@
                                                                 0.0,
                                                                 0.6881973743438721
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1743,7 +1449,7 @@
                                                         {
                                                             "Position": [
                                                                 0.10000000149011612,
-                                                                -0.019999999552965165,
+                                                                -0.019999999552965164,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
@@ -1752,16 +1458,17 @@
                                                                 0.2755587100982666,
                                                                 0.9615697264671326
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1784,7 +1491,7 @@
                                                         {
                                                             "Position": [
                                                                 -0.10000000149011612,
-                                                                0.019999999552965165,
+                                                                0.019999999552965164,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
@@ -1793,16 +1500,17 @@
                                                                 0.2755587100982666,
                                                                 0.9615697264671326
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1811,7 +1519,7 @@
                                                             "$type": "BoxShapeConfiguration",
                                                             "Configuration": [
                                                                 0.25,
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.10000000149011612
                                                             ]
                                                         }
@@ -1823,23 +1531,24 @@
                                                 "shapes": [
                                                     [
                                                         {
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.33000001311302187,
+                                                            "Height": 0.33000001311302185,
                                                             "Radius": 0.10000000149011612
                                                         }
                                                     ]
@@ -1855,24 +1564,25 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.30000001192092896,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1887,24 +1597,25 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.20000000298023225,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.20000000298023224,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1915,28 +1626,29 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.15000000596046449,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.15000000596046448,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1947,26 +1659,27 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.15000000596046449,
+                                                                0.15000000596046448,
                                                                 0.0,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
-                                                                -2.0000000233721949e-7,
+                                                                -2.0000000233721948e-7,
                                                                 -0.7075905203819275,
-                                                                2.0000000233721949e-7,
+                                                                2.0000000233721948e-7,
                                                                 0.7066226005554199
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1985,20 +1698,21 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.0,
-                                                                -0.019999999552965165
+                                                                -0.019999999552965164
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2027,16 +1741,17 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2059,16 +1774,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2086,26 +1802,27 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.009999999776482582,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
                                                                 0.6727613806724548,
-                                                                0.21843160688877107,
-                                                                0.21843160688877107,
+                                                                0.21843160688877106,
+                                                                0.21843160688877106,
                                                                 0.6727614998817444
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2124,20 +1841,21 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.07000000029802323,
+                                                                -0.07000000029802322,
                                                                 0.0,
-                                                                0.019999999552965165
+                                                                0.019999999552965164
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2156,7 +1874,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.15000000596046449,
+                                                                -0.15000000596046448,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -2166,16 +1884,17 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2204,23 +1923,24 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
+                                                            "Height": 0.30000001192092896,
                                                             "Radius": 0.05000000074505806
                                                         }
                                                     ]
@@ -2236,16 +1956,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2255,7 +1976,7 @@
                                                             "Configuration": [
                                                                 0.11999999731779099,
                                                                 0.07999999821186066,
-                                                                0.029999999329447748
+                                                                0.029999999329447746
                                                             ]
                                                         }
                                                     ]
@@ -2277,23 +1998,24 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
+                                                            "Height": 0.30000001192092896,
                                                             "Radius": 0.05000000074505806
                                                         }
                                                     ]
@@ -2309,16 +2031,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{F17DFF59-6ED6-4F8B-A8C1-35EF03EAD06C}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{12274790-A69A-597F-8772-B0A61198512F}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/concrete.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2328,7 +2051,7 @@
                                                             "Configuration": [
                                                                 0.11999999731779099,
                                                                 0.07999999821186066,
-                                                                0.029999999329447748
+                                                                0.029999999329447746
                                                             ]
                                                         }
                                                     ]
@@ -2345,10 +2068,17 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.022891199216246606,
+                                                            0.022891199216246605,
                                                             0.03267350047826767,
-                                                            0.0029446000698953869
+                                                            0.0029446000698953867
                                                         ],
+                                                        "MaterialSlots": {
+                                                            "Slots": [
+                                                                {
+                                                                    "Name": "Entire object"
+                                                                }
+                                                            ]
+                                                        },
                                                         "propertyVisibilityFlags": 248
                                                     },
                                                     {

--- a/AutomatedTesting/Levels/Physics/Material_RagdollBones/ragdoll_rubber/rin_skeleton_newgeo.fbx.assetinfo
+++ b/AutomatedTesting/Levels/Physics/Material_RagdollBones/ragdoll_rubber/rin_skeleton_newgeo.fbx.assetinfo
@@ -320,16 +320,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -337,7 +338,7 @@
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
                                                         "Height": 0.4000000059604645,
-                                                        "Radius": 0.15000000596046449
+                                                        "Radius": 0.15000000596046448
                                                     }
                                                 ]
                                             ]
@@ -358,16 +359,17 @@
                                                             0.0,
                                                             0.7132986783981323
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -396,16 +398,17 @@
                                                             0.0,
                                                             0.725512683391571
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -424,7 +427,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.20000000298023225,
+                                                            0.20000000298023224,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -434,16 +437,17 @@
                                                             0.0,
                                                             0.7008591294288635
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -462,7 +466,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.20000000298023225,
+                                                            -0.20000000298023224,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -472,16 +476,17 @@
                                                             0.0,
                                                             0.6881973743438721
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -501,7 +506,7 @@
                                                     {
                                                         "Position": [
                                                             0.10000000149011612,
-                                                            -0.019999999552965165,
+                                                            -0.019999999552965164,
                                                             0.0
                                                         ],
                                                         "Rotation": [
@@ -510,16 +515,17 @@
                                                             0.2755587100982666,
                                                             0.9615697264671326
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -542,7 +548,7 @@
                                                     {
                                                         "Position": [
                                                             -0.10000000149011612,
-                                                            0.019999999552965165,
+                                                            0.019999999552965164,
                                                             0.0
                                                         ],
                                                         "Rotation": [
@@ -551,16 +557,17 @@
                                                             0.2755587100982666,
                                                             0.9615697264671326
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -569,7 +576,7 @@
                                                         "$type": "BoxShapeConfiguration",
                                                         "Configuration": [
                                                             0.25,
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.10000000149011612
                                                         ]
                                                     }
@@ -581,23 +588,24 @@
                                             "shapes": [
                                                 [
                                                     {
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.33000001311302187,
+                                                        "Height": 0.33000001311302185,
                                                         "Radius": 0.10000000149011612
                                                     }
                                                 ]
@@ -613,24 +621,25 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
-                                                        "Radius": 0.07000000029802323
+                                                        "Height": 0.30000001192092896,
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -645,24 +654,25 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
-                                                        "Radius": 0.07000000029802323
+                                                        "Height": 0.30000001192092896,
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -673,20 +683,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -694,7 +705,7 @@
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
                                                         "Height": 0.25,
-                                                        "Radius": 0.07000000029802323
+                                                        "Radius": 0.07000000029802322
                                                     }
                                                 ]
                                             ]
@@ -705,26 +716,27 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.15000000596046449,
+                                                            0.15000000596046448,
                                                             0.0,
                                                             0.0
                                                         ],
                                                         "Rotation": [
-                                                            -2.0000000233721949e-7,
+                                                            -2.0000000233721948e-7,
                                                             -0.7075905203819275,
-                                                            2.0000000233721949e-7,
+                                                            2.0000000233721948e-7,
                                                             0.7066226005554199
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -743,20 +755,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.0,
-                                                            -0.019999999552965165
+                                                            -0.019999999552965164
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -785,16 +798,17 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -817,16 +831,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -844,26 +859,27 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.07000000029802323,
+                                                            0.07000000029802322,
                                                             0.009999999776482582,
                                                             0.0
                                                         ],
                                                         "Rotation": [
                                                             0.6727613806724548,
-                                                            0.21843160688877107,
-                                                            0.21843160688877107,
+                                                            0.21843160688877106,
+                                                            0.21843160688877106,
                                                             0.6727614998817444
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -882,20 +898,21 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.07000000029802323,
+                                                            -0.07000000029802322,
                                                             0.0,
-                                                            0.019999999552965165
+                                                            0.019999999552965164
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -914,7 +931,7 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            -0.15000000596046449,
+                                                            -0.15000000596046448,
                                                             0.0,
                                                             0.0
                                                         ],
@@ -924,16 +941,17 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -962,23 +980,24 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
+                                                        "Height": 0.30000001192092896,
                                                         "Radius": 0.05000000074505806
                                                     }
                                                 ]
@@ -994,16 +1013,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1013,7 +1033,7 @@
                                                         "Configuration": [
                                                             0.11999999731779099,
                                                             0.07999999821186066,
-                                                            0.029999999329447748
+                                                            0.029999999329447746
                                                         ]
                                                     }
                                                 ]
@@ -1035,23 +1055,24 @@
                                                             0.0,
                                                             0.7071068286895752
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
                                                     },
                                                     {
                                                         "$type": "CapsuleShapeConfiguration",
-                                                        "Height": 0.30000001192092898,
+                                                        "Height": 0.30000001192092896,
                                                         "Radius": 0.05000000074505806
                                                     }
                                                 ]
@@ -1067,16 +1088,17 @@
                                                             0.0,
                                                             0.0
                                                         ],
-                                                        "MaterialSelection": {
-                                                            "Material": {
-                                                                "assetId": {
-                                                                    "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                },
-                                                                "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                            },
-                                                            "MaterialIds": [
+                                                        "MaterialSlots": {
+                                                            "Slots": [
                                                                 {
-                                                                    "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                    "Name": "Entire object",
+                                                                    "MaterialAsset": {
+                                                                        "assetId": {
+                                                                            "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                            "subId": 1
+                                                                        },
+                                                                        "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                    }
                                                                 }
                                                             ]
                                                         }
@@ -1086,7 +1108,7 @@
                                                         "Configuration": [
                                                             0.11999999731779099,
                                                             0.07999999821186066,
-                                                            0.029999999329447748
+                                                            0.029999999329447746
                                                         ]
                                                     }
                                                 ]
@@ -1106,448 +1128,127 @@
                                             "name": "L_leg_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -0.20254400372505189,
-                                                    -0.6249864101409912,
-                                                    0.7367693781852722,
-                                                    0.1618904024362564
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.7375792264938355,
-                                                    0.0,
-                                                    0.0,
-                                                    0.6753178238868713
-                                                ],
-                                                "SwingLimitY": 50.0,
-                                                "SwingLimitZ": 30.0,
-                                                "TwistLowerLimit": -21.0,
-                                                "TwistUpperLimit": 23.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_leg_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.18296609818935395,
-                                                    0.6832081079483032,
-                                                    -0.6832082271575928,
-                                                    -0.18296639621257783
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.0,
-                                                    0.7255232930183411,
-                                                    0.6882146000862122,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 50.0,
-                                                "SwingLimitZ": 30.0,
-                                                "TwistLowerLimit": -16.0,
-                                                "TwistUpperLimit": 17.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_knee_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.6036934852600098,
-                                                    -0.36913779377937319,
-                                                    -0.36888980865478518,
-                                                    0.60325688123703
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0100685004144907,
-                                                    -0.01671529933810234,
-                                                    -0.07859530299901962,
-                                                    0.9967455863952637
-                                                ],
-                                                "SwingLimitY": 70.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -98.0,
-                                                "TwistUpperLimit": -75.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_knee_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -0.3260999023914337,
-                                                    -0.6149802207946777,
-                                                    0.6509910821914673,
-                                                    0.30416950583457949
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9999656081199646,
-                                                    -0.008921699598431588
-                                                ],
-                                                "SwingLimitY": 69.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": 77.0,
-                                                "TwistUpperLimit": 102.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_foot_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.09583680331707001,
-                                                    0.995438814163208
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    -0.514680027961731,
-                                                    0.8578065037727356
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 20.0,
-                                                "TwistLowerLimit": -34.0,
-                                                "TwistUpperLimit": 50.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_foot_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9909648895263672,
-                                                    -0.13970449566841126
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.0267730001360178,
-                                                    -0.024081699550151826,
-                                                    0.8836833834648132,
-                                                    0.46900999546051028
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 20.0,
-                                                "TwistLowerLimit": -29.0,
-                                                "TwistUpperLimit": 28.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_01_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.7071067094802856,
-                                                    0.0,
-                                                    0.0,
-                                                    0.7071068286895752
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_02_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_03_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_spine_04_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.704440712928772,
-                                                    0.06162650138139725,
-                                                    0.06162650138139725,
-                                                    0.704440712928772
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "SwingLimitZ": 5.0,
-                                                "TwistLowerLimit": -100.0,
-                                                "TwistUpperLimit": -80.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_arm_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    -0.3254435956478119,
-                                                    0.0,
-                                                    0.9459221959114075
-                                                ],
-                                                "SwingLimitY": 25.0,
-                                                "SwingLimitZ": 85.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_clavicle_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    -0.6882243752479553,
-                                                    0.0,
-                                                    0.725512683391571
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    -0.01745240017771721,
-                                                    0.9998490810394287
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_neck_01_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.07845719903707504,
-                                                    0.9969456791877747
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_neck_02_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "C_head_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 25.0,
-                                                "TwistLowerLimit": -30.0,
-                                                "TwistUpperLimit": 30.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_clavicle_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    3.000000106112566e-7,
-                                                    0.6944776773452759,
-                                                    3.000000106112566e-7,
-                                                    0.7195212244987488
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 10.0,
-                                                "SwingLimitZ": 10.0,
-                                                "TwistLowerLimit": -10.0,
-                                                "TwistUpperLimit": 10.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_arm_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.9351276159286499,
-                                                    0.0,
-                                                    0.35854610800743105
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    -0.008921699598431588,
-                                                    0.999965488910675,
-                                                    -0.0,
-                                                    -0.0
-                                                ],
-                                                "SwingLimitY": 25.0,
-                                                "SwingLimitZ": 85.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_elbow_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.040344301611185077,
-                                                    -0.016693100333213807,
-                                                    0.38212141394615176,
-                                                    0.9235191941261292
-                                                ],
-                                                "SwingLimitY": 15.0,
-                                                "TwistLowerLimit": -25.0,
-                                                "TwistUpperLimit": 25.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "L_wrist_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "SwingLimitZ": 15.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_elbow_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.9186229109764099,
-                                                    -0.3986668884754181
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitY": 15.0
-                                            }
+                                            "Compute inertia": false
                                         },
                                         {
                                             "name": "R_wrist_JNT",
                                             "Sleep threshold": 0.5,
                                             "Compute Mass": false,
-                                            "Compute inertia": false,
-                                            "JointLimit": {
-                                                "$type": "D6JointLimitConfiguration",
-                                                "ParentLocalRotation": [
-                                                    -1.0000000116860974e-7,
-                                                    -0.0,
-                                                    0.9999998807907105,
-                                                    2.0000000233721949e-7
-                                                ],
-                                                "ChildLocalRotation": [
-                                                    0.0,
-                                                    0.0,
-                                                    1.0,
-                                                    0.0
-                                                ],
-                                                "SwingLimitZ": 15.0,
-                                                "TwistLowerLimit": -20.0,
-                                                "TwistUpperLimit": 20.0
-                                            }
+                                            "Compute inertia": false
                                         }
                                     ],
                                     "colliders": {
@@ -1562,16 +1263,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1579,7 +1281,7 @@
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
                                                             "Height": 0.4000000059604645,
-                                                            "Radius": 0.15000000596046449
+                                                            "Radius": 0.15000000596046448
                                                         }
                                                     ]
                                                 ]
@@ -1600,16 +1302,17 @@
                                                                 0.0,
                                                                 0.7132986783981323
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1638,16 +1341,17 @@
                                                                 0.0,
                                                                 0.725512683391571
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1666,7 +1370,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.20000000298023225,
+                                                                0.20000000298023224,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -1676,16 +1380,17 @@
                                                                 0.0,
                                                                 0.7008591294288635
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1704,7 +1409,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.20000000298023225,
+                                                                -0.20000000298023224,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -1714,16 +1419,17 @@
                                                                 0.0,
                                                                 0.6881973743438721
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1743,7 +1449,7 @@
                                                         {
                                                             "Position": [
                                                                 0.10000000149011612,
-                                                                -0.019999999552965165,
+                                                                -0.019999999552965164,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
@@ -1752,16 +1458,17 @@
                                                                 0.2755587100982666,
                                                                 0.9615697264671326
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1784,7 +1491,7 @@
                                                         {
                                                             "Position": [
                                                                 -0.10000000149011612,
-                                                                0.019999999552965165,
+                                                                0.019999999552965164,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
@@ -1793,16 +1500,17 @@
                                                                 0.2755587100982666,
                                                                 0.9615697264671326
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1811,7 +1519,7 @@
                                                             "$type": "BoxShapeConfiguration",
                                                             "Configuration": [
                                                                 0.25,
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.10000000149011612
                                                             ]
                                                         }
@@ -1823,23 +1531,24 @@
                                                 "shapes": [
                                                     [
                                                         {
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.33000001311302187,
+                                                            "Height": 0.33000001311302185,
                                                             "Radius": 0.10000000149011612
                                                         }
                                                     ]
@@ -1855,24 +1564,25 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.30000001192092896,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1887,24 +1597,25 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.20000000298023225,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.20000000298023224,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1915,28 +1626,29 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.15000000596046449,
-                                                            "Radius": 0.07000000029802323
+                                                            "Height": 0.15000000596046448,
+                                                            "Radius": 0.07000000029802322
                                                         }
                                                     ]
                                                 ]
@@ -1947,26 +1659,27 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.15000000596046449,
+                                                                0.15000000596046448,
                                                                 0.0,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
-                                                                -2.0000000233721949e-7,
+                                                                -2.0000000233721948e-7,
                                                                 -0.7075905203819275,
-                                                                2.0000000233721949e-7,
+                                                                2.0000000233721948e-7,
                                                                 0.7066226005554199
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -1985,20 +1698,21 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.0,
-                                                                -0.019999999552965165
+                                                                -0.019999999552965164
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2027,16 +1741,17 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2059,16 +1774,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2086,26 +1802,27 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                0.07000000029802323,
+                                                                0.07000000029802322,
                                                                 0.009999999776482582,
                                                                 0.0
                                                             ],
                                                             "Rotation": [
                                                                 0.6727613806724548,
-                                                                0.21843160688877107,
-                                                                0.21843160688877107,
+                                                                0.21843160688877106,
+                                                                0.21843160688877106,
                                                                 0.6727614998817444
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2124,20 +1841,21 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.07000000029802323,
+                                                                -0.07000000029802322,
                                                                 0.0,
-                                                                0.019999999552965165
+                                                                0.019999999552965164
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2156,7 +1874,7 @@
                                                     [
                                                         {
                                                             "Position": [
-                                                                -0.15000000596046449,
+                                                                -0.15000000596046448,
                                                                 0.0,
                                                                 0.0
                                                             ],
@@ -2166,16 +1884,17 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2204,23 +1923,24 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
+                                                            "Height": 0.30000001192092896,
                                                             "Radius": 0.05000000074505806
                                                         }
                                                     ]
@@ -2236,16 +1956,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2255,7 +1976,7 @@
                                                             "Configuration": [
                                                                 0.11999999731779099,
                                                                 0.07999999821186066,
-                                                                0.029999999329447748
+                                                                0.029999999329447746
                                                             ]
                                                         }
                                                     ]
@@ -2277,23 +1998,24 @@
                                                                 0.0,
                                                                 0.7071068286895752
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
                                                         },
                                                         {
                                                             "$type": "CapsuleShapeConfiguration",
-                                                            "Height": 0.30000001192092898,
+                                                            "Height": 0.30000001192092896,
                                                             "Radius": 0.05000000074505806
                                                         }
                                                     ]
@@ -2309,16 +2031,17 @@
                                                                 0.0,
                                                                 0.0
                                                             ],
-                                                            "MaterialSelection": {
-                                                                "Material": {
-                                                                    "assetId": {
-                                                                        "guid": "{49D81C0E-872B-5954-B9B1-13D873728AAD}"
-                                                                    },
-                                                                    "assetHint": "levels/physics/c4925580_material_ragdollbonesmaterial/c4925580_material_ragdollbonesmaterial.physmaterial"
-                                                                },
-                                                                "MaterialIds": [
+                                                            "MaterialSlots": {
+                                                                "Slots": [
                                                                     {
-                                                                        "MaterialId": "{E9BF3E6A-71C2-4A42-847C-8CA6C93B73D7}"
+                                                                        "Name": "Entire object",
+                                                                        "MaterialAsset": {
+                                                                            "assetId": {
+                                                                                "guid": "{72396F74-E9B7-5082-ACA8-F8B110C779E2}",
+                                                                                "subId": 1
+                                                                            },
+                                                                            "assetHint": "levels/physics/material_ragdollbones/rubber.physicsmaterial"
+                                                                        }
                                                                     }
                                                                 ]
                                                             }
@@ -2328,7 +2051,7 @@
                                                             "Configuration": [
                                                                 0.11999999731779099,
                                                                 0.07999999821186066,
-                                                                0.029999999329447748
+                                                                0.029999999329447746
                                                             ]
                                                         }
                                                     ]
@@ -2345,10 +2068,17 @@
                                                 [
                                                     {
                                                         "Position": [
-                                                            0.022891199216246606,
+                                                            0.022891199216246605,
                                                             0.03267350047826767,
-                                                            0.0029446000698953869
+                                                            0.0029446000698953867
                                                         ],
+                                                        "MaterialSlots": {
+                                                            "Slots": [
+                                                                {
+                                                                    "Name": "Entire object"
+                                                                }
+                                                            ]
+                                                        },
                                                         "propertyVisibilityFlags": 248
                                                     },
                                                     {

--- a/AutomatedTesting/Levels/Physics/Material_Restitution/Material_Restitution.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_Restitution/Material_Restitution.prefab
@@ -141,10 +141,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -263,10 +270,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -366,10 +380,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{5DC7FE5B-E7D3-5FD4-9256-002980439C65}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/low_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -469,10 +490,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{FDC9696F-EF9A-5BA1-9F48-258DC91CCE6D}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/mid_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -572,10 +600,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6E61FDAB-07D1-5B86-87F0-7D32E24D586B}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/box_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_RestitutionCombine/Material_RestitutionCombine.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_RestitutionCombine/Material_RestitutionCombine.prefab
@@ -140,10 +140,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{05A7DE35-5FD6-4496-B93B-FAF78262FEEC}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{7D320D01-0BD3-5AF1-B341-0049F2CCA675}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombine/ramp.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -269,10 +276,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6E61FDAB-07D1-5B86-87F0-7D32E24D586B}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/box_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -379,10 +393,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -489,10 +510,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{FDC9696F-EF9A-5BA1-9F48-258DC91CCE6D}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/mid_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -599,10 +627,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{5DC7FE5B-E7D3-5FD4-9256-002980439C65}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/low_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_RestitutionCombinePriorityOrder/Material_RestitutionCombinePriorityOrder.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_RestitutionCombinePriorityOrder/Material_RestitutionCombinePriorityOrder.prefab
@@ -126,10 +126,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{05A7DE35-5FD6-4496-B93B-FAF78262FEEC}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{7D320D01-0BD3-5AF1-B341-0049F2CCA675}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombine/ramp.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -255,10 +262,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{FDC9696F-EF9A-5BA1-9F48-258DC91CCE6D}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/mid_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -378,10 +392,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{AAAADE4F-9A35-476B-9424-20D40CBD8E59}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{4A8ACFB8-79C9-573D-82DC-4A4017E6E279}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/ramp_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -520,10 +541,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{C0067490-4214-4ADC-857A-FA978B6609D8}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{BCE0CBE4-F89D-5522-B7C3-02C6D5BA7E33}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_frictioncombinepriorityorder/ramp_multiply.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -662,10 +690,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EC70218A-5C2F-4E4C-A606-DB0985D80BD9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{B4D50C0C-AF2A-5A2A-8098-2FA0537E2664}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_frictioncombinepriorityorder/ramp_maximum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -791,10 +826,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6E61FDAB-07D1-5B86-87F0-7D32E24D586B}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/box_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -901,10 +943,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -1011,10 +1060,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{5DC7FE5B-E7D3-5FD4-9256-002980439C65}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/low_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/Material_StaticFriction/Material_StaticFriction.prefab
+++ b/AutomatedTesting/Levels/Physics/Material_StaticFriction/Material_StaticFriction.prefab
@@ -140,10 +140,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 4637782058154060578,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -270,10 +277,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{EE923310-0BAE-4F41-8784-DD8DC0D1DD4A}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{410F7B84-0F8F-5BCF-AD90-E3B2C2E8FD25}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitution/zero_restitution.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -381,10 +395,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{34DA60BA-CE15-4205-AF43-3F44CFACB165}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{5DC7FE5B-E7D3-5FD4-9256-002980439C65}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/low_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -492,10 +513,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{2A116DF5-FD14-4A6C-B3B2-5068AE83C9EF}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{FDC9696F-EF9A-5BA1-9F48-258DC91CCE6D}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_staticfriction/mid_static_friction.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -603,10 +631,17 @@
                     "$type": "EditorColliderComponent",
                     "Id": 16270212748521211284,
                     "ColliderConfiguration": {
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{777C0A7E-ADF9-48EA-B6C5-7AF8247B2467}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{6E61FDAB-07D1-5B86-87F0-7D32E24D586B}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "levels/physics/material_restitutioncombinepriorityorder/box_minimum.physicsmaterial"
+                                    }
                                 }
                             ]
                         }

--- a/AutomatedTesting/Levels/Physics/NameNode_Prints/NameNode_Prints.prefab
+++ b/AutomatedTesting/Levels/Physics/NameNode_Prints/NameNode_Prints.prefab
@@ -140,6 +140,13 @@
                         "CollisionGroupId": {
                             "GroupId": "{C0082271-F0B0-40D7-BD3D-57764336382F}"
                         },
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -161,16 +168,16 @@
                 "Component_[13910212585951705274]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 13910212585951705274,
-                    "m_name": "C19536274_NameNode_Prints",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{71B90B3C-7EFB-5F42-9FDE-7B2CAD7135E5}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{71B90B3C-7EFB-5F42-9FDE-7B2CAD7135E5}",
+                            "path": "scriptcanvas/c19536274_namenode_prints.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{71B90B3C-7EFB-5F42-9FDE-7B2CAD7135E5}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{71B90B3C-7EFB-5F42-9FDE-7B2CAD7135E5}",
-                        "path": "scriptcanvas/c19536274_namenode_prints.scriptcanvas"
                     }
                 },
                 "Component_[1534629704230734412]": {
@@ -243,6 +250,13 @@
                         "CollisionGroupId": {
                             "GroupId": "{C0082271-F0B0-40D7-BD3D-57764336382F}"
                         },
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -264,16 +278,16 @@
                 "Component_[13910212585951705274]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 13910212585951705274,
-                    "m_name": "C19536273_NameNode_Prints",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{9D36B9D1-F1E6-58AA-8B52-0788EECF0743}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{9D36B9D1-F1E6-58AA-8B52-0788EECF0743}",
+                            "path": "scriptcanvas/c19536273_namenode_prints.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{9D36B9D1-F1E6-58AA-8B52-0788EECF0743}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{9D36B9D1-F1E6-58AA-8B52-0788EECF0743}",
-                        "path": "scriptcanvas/c19536273_namenode_prints.scriptcanvas"
                     }
                 },
                 "Component_[1534629704230734412]": {
@@ -338,6 +352,13 @@
                         "CollisionGroupId": {
                             "GroupId": "{C7177D1A-7AA0-4C65-AA17-AEEAE6CF27DC}"
                         },
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -367,16 +388,16 @@
                 "Component_[14808834262172119539]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 14808834262172119539,
-                    "m_name": "C19536277_NameNode_NothingPrints",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{38FF2ADB-9B86-561C-B110-A8B83B3D0122}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{38FF2ADB-9B86-561C-B110-A8B83B3D0122}",
+                            "path": "scriptcanvas/c19536277_namenode_nothingprints.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{38FF2ADB-9B86-561C-B110-A8B83B3D0122}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{38FF2ADB-9B86-561C-B110-A8B83B3D0122}",
-                        "path": "scriptcanvas/c19536277_namenode_nothingprints.scriptcanvas"
                     }
                 },
                 "Component_[15332433319673356377]": {
@@ -441,10 +462,17 @@
                         "CollisionGroupId": {
                             "GroupId": "{C7177D1A-7AA0-4C65-AA17-AEEAE6CF27DC}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{B072A405-BAFA-4B0A-9164-B3A424E642A9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{03568CB1-7F6B-5455-915E-F6EFA9EF7BDF}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "physicssurfaces.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -472,16 +500,16 @@
                 "Component_[14808834262172119539]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 14808834262172119539,
-                    "m_name": "C19536275_SetCollisionGroupEmpty_PrintsWarning",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{C899C0FA-BC99-585C-99DC-BFF98C8CDD29}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{C899C0FA-BC99-585C-99DC-BFF98C8CDD29}",
+                            "path": "scriptcanvas/c19536275_setcollisiongroupempty_printswarning.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{C899C0FA-BC99-585C-99DC-BFF98C8CDD29}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{C899C0FA-BC99-585C-99DC-BFF98C8CDD29}",
-                        "path": "scriptcanvas/c19536275_setcollisiongroupempty_printswarning.scriptcanvas"
                     }
                 },
                 "Component_[15332433319673356377]": {
@@ -546,10 +574,17 @@
                         "CollisionGroupId": {
                             "GroupId": "{C7177D1A-7AA0-4C65-AA17-AEEAE6CF27DC}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{B072A405-BAFA-4B0A-9164-B3A424E642A9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{03568CB1-7F6B-5455-915E-F6EFA9EF7BDF}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "physicssurfaces.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -577,16 +612,16 @@
                 "Component_[14808834262172119539]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 14808834262172119539,
-                    "m_name": "C19536275_SetCollisionGroupInvalid_PrintsWarning",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{307DC8EA-6D9E-5026-940C-F81D1D24F69D}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{307DC8EA-6D9E-5026-940C-F81D1D24F69D}",
+                            "path": "scriptcanvas/c19536275_setcollisiongroupinvalid_printswarning.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{307DC8EA-6D9E-5026-940C-F81D1D24F69D}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{307DC8EA-6D9E-5026-940C-F81D1D24F69D}",
-                        "path": "scriptcanvas/c19536275_setcollisiongroupinvalid_printswarning.scriptcanvas"
                     }
                 },
                 "Component_[15332433319673356377]": {
@@ -651,10 +686,17 @@
                         "CollisionGroupId": {
                             "GroupId": "{C7177D1A-7AA0-4C65-AA17-AEEAE6CF27DC}"
                         },
-                        "MaterialSelection": {
-                            "MaterialIds": [
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{B072A405-BAFA-4B0A-9164-B3A424E642A9}"
+                                    "Name": "Entire object",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{03568CB1-7F6B-5455-915E-F6EFA9EF7BDF}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "physicssurfaces.physicsmaterial"
+                                    }
                                 }
                             ]
                         }
@@ -682,16 +724,16 @@
                 "Component_[14808834262172119539]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 14808834262172119539,
-                    "m_name": "C19536276_SetCollisionLayer_PrintsWarning",
-                    "runtimeDataIsValid": true,
-                    "runtimeDataOverrides": {
-                        "source": {
-                            "id": "{07A8A7CB-F6F3-5D1F-B6EB-BF673CBD121D}"
+                    "configuration": {
+                        "sourceHandle": {
+                            "id": "{07A8A7CB-F6F3-5D1F-B6EB-BF673CBD121D}",
+                            "path": "scriptcanvas/c19536276_setcollisionlayer_printswarning.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{07A8A7CB-F6F3-5D1F-B6EB-BF673CBD121D}"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{07A8A7CB-F6F3-5D1F-B6EB-BF673CBD121D}",
-                        "path": "scriptcanvas/c19536276_setcollisionlayer_printswarning.scriptcanvas"
                     }
                 },
                 "Component_[15332433319673356377]": {

--- a/AutomatedTesting/Levels/Physics/ScriptCanvas_SpawnEntityWithPhysComponents/ScriptCanvas_SpawnEntityWithPhysComponents.prefab
+++ b/AutomatedTesting/Levels/Physics/ScriptCanvas_SpawnEntityWithPhysComponents/ScriptCanvas_SpawnEntityWithPhysComponents.prefab
@@ -64,12 +64,12 @@
                     "$type": "EditorTerrainPhysicsColliderComponent",
                     "Id": 11285817845582785960,
                     "Configuration": {
-                        "DefaultMaterial": {
-                            "MaterialIds": [
-                                {
-                                    "MaterialId": "{303C5A49-22F2-45A8-B24C-9F2C3CA13402}"
-                                }
-                            ]
+                        "DefaultMaterialAsset": {
+                            "assetId": {
+                                "guid": "{A207A84E-310F-5BDE-9A1E-637DA2DC6223}",
+                                "subId": 1
+                            },
+                            "assetHint": "assets/physics/terrain_dirt.physicsmaterial"
                         }
                     }
                 },
@@ -85,6 +85,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 12634607739724875702,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -173,16 +180,17 @@
                 "Component_[1281440710466199957]": {
                     "$type": "EditorScriptCanvasComponent",
                     "Id": 1281440710466199957,
-                    "m_name": "ScriptCanvas_SpawnEntityWithPhysComponents.scriptcanvas",
-                    "runtimeDataOverrides": {
-                        "source": {
+                    "configuration": {
+                        "sourceHandle": {
                             "id": "{D45DEDB9-C827-5569-9565-5B182F747193}",
                             "path": "git/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_SpawnEntityWithPhysComponents.scriptcanvas"
+                        },
+                        "propertyOverrides": {
+                            "source": {
+                                "id": "{D45DEDB9-C827-5569-9565-5B182F747193}",
+                                "path": "git/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_SpawnEntityWithPhysComponents.scriptcanvas"
+                            }
                         }
-                    },
-                    "sourceHandle": {
-                        "id": "{D45DEDB9-C827-5569-9565-5B182F747193}",
-                        "path": "git/o3de/AutomatedTesting/ScriptCanvas/ScriptCanvas_SpawnEntityWithPhysComponents.scriptcanvas"
                     }
                 },
                 "Component_[13297798007423143323]": {

--- a/AutomatedTesting/Levels/Terrain/TerrainPhysicsCollider_MaterialMapping_Works/TerrainPhysicsCollider_MaterialMapping_Works.prefab
+++ b/AutomatedTesting/Levels/Terrain/TerrainPhysicsCollider_MaterialMapping_Works/TerrainPhysicsCollider_MaterialMapping_Works.prefab
@@ -367,6 +367,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10744220290655785341,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -504,18 +511,33 @@
                             0.43792724609375,
                             0.0
                         ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {},
+                        "MaterialSlots": {
+                            "Slots": [
                                 {
-                                    "MaterialId": "{FD59CBE9-D1C4-4119-81CB-CD7AD72FC295}"
+                                    "Name": "Material 1"
                                 },
                                 {
-                                    "MaterialId": "{8C7A6011-61C2-46B7-9BF4-8D4DD2A624F1}"
+                                    "Name": "Material 2",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{00880607-87E1-5178-8C30-37B3220D6149}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "assets/physics/glass.physicsmaterial"
+                                    }
+                                },
+                                {
+                                    "Name": "Material 3",
+                                    "MaterialAsset": {
+                                        "assetId": {
+                                            "guid": "{418485F0-20D0-5819-BC6D-22E89145B6AA}",
+                                            "subId": 1
+                                        },
+                                        "assetHint": "assets/physics/rubber.physicsmaterial"
+                                    }
                                 }
                             ]
-                        },
-                        "propertyVisibilityFlags": 233
+                        }
                     },
                     "DebugDrawSettings": {
                         "LocallyEnabled": true
@@ -633,16 +655,24 @@
                                 "Surface": {
                                     "SurfaceTagCrc": 2062838596
                                 },
-                                "Material": {
-                                    "MaterialId": "{FD59CBE9-D1C4-4119-81CB-CD7AD72FC295}"
+                                "MaterialAsset": {
+                                    "assetId": {
+                                        "guid": "{00880607-87E1-5178-8C30-37B3220D6149}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "assets/physics/glass.physicsmaterial"
                                 }
                             },
                             {
                                 "Surface": {
                                     "SurfaceTagCrc": 1797181423
                                 },
-                                "Material": {
-                                    "MaterialId": "{8C7A6011-61C2-46B7-9BF4-8D4DD2A624F1}"
+                                "MaterialAsset": {
+                                    "assetId": {
+                                        "guid": "{418485F0-20D0-5819-BC6D-22E89145B6AA}",
+                                        "subId": 1
+                                    },
+                                    "assetHint": "assets/physics/rubber.physicsmaterial"
                                 }
                             }
                         ]
@@ -895,6 +925,13 @@
                     "$type": "EditorColliderComponent",
                     "Id": 10744220290655785341,
                     "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}


### PR DESCRIPTION
Log: [ConversionLog.txt](https://github.com/aws-lumberyard-dev/o3de/files/8805190/ConversionLog.txt)

Signed-off-by: moraaar <moraaar@amazon.com>