### PR TITLE
PhysX material refactor improvements and fixes

### DIFF
--- a/Code/Framework/AzCore/AzCore/IO/IOUtils.h
+++ b/Code/Framework/AzCore/AzCore/IO/IOUtils.h
@@ -7,12 +7,12 @@
  */
 #pragma once
 
+#include <AzCore/IO/FileIO.h>
+
 namespace AZ
 {
     namespace IO
-    {        
-        class FileIOStream;
-
+    {
         int TranslateOpenModeToSystemFileMode(const char* path, OpenMode mode);
 
         /**

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <AzCore/RTTI/RTTI.h>
-#include <AzCore/Math/Vector4.h>
+#include <AzCore/Asset/AssetCommon.h>
 #include <AzFramework/Physics/Configuration/CollisionConfiguration.h>
 
 namespace AZ
@@ -58,6 +58,6 @@ namespace AzPhysics
         // This is used instead of adding alignas(16) to the struct because that generates
         // warnings everywhere the struct is used indicating that padding is added, which 
         // causes compilation errors.
-        AZ::Vector4 m_unusedPadding;
+        AZ::Data::Asset<AZ::Data::AssetData> m_unusedPadding;
     };
 }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SystemConfiguration.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <AzCore/RTTI/RTTI.h>
-#include <AzCore/Asset/AssetCommon.h>
 #include <AzFramework/Physics/Configuration/CollisionConfiguration.h>
 
 namespace AZ
@@ -20,7 +19,7 @@ namespace AzPhysics
 {
     //! Contains global physics settings.
     //! Used to initialize the Physics System.
-    struct SystemConfiguration
+    struct alignas(16) SystemConfiguration
     {
         AZ_CLASS_ALLOCATOR_DECL;
         AZ_RTTI(AzPhysics::SystemConfiguration, "{24697CAF-AC00-443D-9C27-28D58734A84C}");
@@ -54,10 +53,15 @@ namespace AzPhysics
         AZ::u32 OnMaxTimeStepChanged();
         float GetFixedTimeStepMax() const;
 
-        // Padding with a 16 byte aligned type to make the class aligned to 16 bytes too.
-        // This is used instead of adding alignas(16) to the struct because that generates
-        // warnings everywhere the struct is used indicating that padding is added, which 
-        // causes compilation errors.
-        AZ::Data::Asset<AZ::Data::AssetData> m_unusedPadding;
+        // Padding with a 16 byte aligned structure to make SystemConfiguration aligned to 16 bytes too.
+        // Without this, SystemConfiguration generates warnings everywhere it is used indicating that
+        // padding was added. But having this structure limits the warnings to this member usage because
+        // SystemConfiguration won't need extra padding to achieve 16 byte alignment.
+        AZ_PUSH_DISABLE_WARNING(4324, "-Wunknown-warning-option") // structure was padded due to alignment
+        struct alignas(16)
+        {
+            unsigned char m_unused[16];
+        } m_unusedPadding;
+        AZ_POP_DISABLE_WARNING
     };
 }

--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/Legacy/LegacyPhysicsMaterialSelection.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/Legacy/LegacyPhysicsMaterialSelection.h
@@ -10,7 +10,7 @@
 
 namespace PhysicsLegacy
 {
-    // O3DE_DEPRECATION #9840
+    // O3DE_DEPRECATION_NOTICE(GHI-9840)
     // Legacy Physics material Id class used to identify the material in the collection of materials.
     // Used when converting old material asset to new one.
     class MaterialId
@@ -24,7 +24,7 @@ namespace PhysicsLegacy
         AZ::Uuid m_id = AZ::Uuid::CreateNull();
     };
 
-    // O3DE_DEPRECATION #9840
+    // O3DE_DEPRECATION_NOTICE(GHI-9840)
     // Legacy class to store a vector of MaterialIds selected from the library.
     // Used when converting old material asset to new one.
     class MaterialSelection

--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/Legacy/LegacyPhysicsMaterialSelection.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/Legacy/LegacyPhysicsMaterialSelection.h
@@ -10,7 +10,7 @@
 
 namespace PhysicsLegacy
 {
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9840
     // Legacy Physics material Id class used to identify the material in the collection of materials.
     // Used when converting old material asset to new one.
     class MaterialId
@@ -24,7 +24,7 @@ namespace PhysicsLegacy
         AZ::Uuid m_id = AZ::Uuid::CreateNull();
     };
 
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9840
     // Legacy class to store a vector of MaterialIds selected from the library.
     // Used when converting old material asset to new one.
     class MaterialSelection

--- a/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialAsset.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Material/PhysicsMaterialAsset.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
 #include <AzCore/RTTI/BehaviorContext.h>
+#include <AzCore/Asset/AssetSerializer.h>
 
 #include <AzFramework/Physics/Material/PhysicsMaterialAsset.h>
 
@@ -25,6 +26,8 @@ namespace Physics
                 ->Field("MaterialProperties", &MaterialAsset::m_materialProperties)
                 ->Field("LegacyPhysicsMaterialId", &MaterialAsset::m_legacyPhysicsMaterialId)
                 ;
+
+            serializeContext->RegisterGenericType<AZ::Data::Asset<MaterialAsset>>();
 
             if (auto* editContext = serializeContext->GetEditContext())
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsMaterialConversionUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsMaterialConversionUtils.cpp
@@ -94,7 +94,7 @@ namespace Physics::Utils
             for (size_t i = 0; i < legacyMaterialSelection.m_materialIdsAssignedToSlots.size(); ++i)
             {
                 // Using Material 1, Material 2, etc. for slot names when there is more than one entry.
-                slotNames.push_back(AZStd::string::format("Material %d", i + 1));
+                slotNames.push_back(AZStd::string::format("Material %zu", i + 1));
             }
 
             newMaterialSlots.SetSlots(slotNames);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsMaterialConversionUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsMaterialConversionUtils.h
@@ -16,7 +16,7 @@
 #include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialAsset.h>
 
-// O3DE_DEPRECATION
+// O3DE_DEPRECATION #9840
 // Utilities used for legacy material conversion.
 
 namespace Physics::Utils

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsMaterialConversionUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsMaterialConversionUtils.h
@@ -16,7 +16,7 @@
 #include <AzFramework/Physics/Material/PhysicsMaterialSlots.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialAsset.h>
 
-// O3DE_DEPRECATION #9840
+// O3DE_DEPRECATION_NOTICE(GHI-9840)
 // Utilities used for legacy material conversion.
 
 namespace Physics::Utils

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsPrefabConversionUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsPrefabConversionUtils.h
@@ -11,7 +11,7 @@
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 
- // O3DE_DEPRECATION #9840
+ // O3DE_DEPRECATION_NOTICE(GHI-9840)
  // Utilities used for legacy material conversion.
 
 namespace Physics::Utils

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsPrefabConversionUtils.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Physics/Material/Legacy/LegacyPhysicsPrefabConversionUtils.h
@@ -11,7 +11,7 @@
 #include <AzToolsFramework/Prefab/PrefabLoaderInterface.h>
 #include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
 
- // O3DE_DEPRECATION
+ // O3DE_DEPRECATION #9840
  // Utilities used for legacy material conversion.
 
 namespace Physics::Utils

--- a/Gems/Blast/Code/Source/Editor/Material/LegacyBlastMaterialAssetConversion.cpp
+++ b/Gems/Blast/Code/Source/Editor/Material/LegacyBlastMaterialAssetConversion.cpp
@@ -29,7 +29,7 @@ namespace Blast
     AZ_CONSOLEFREEFUNC("ed_blastConvertMaterialLibrariesIntoIndividualMaterials", ConvertMaterialLibrariesIntoIndividualMaterials, AZ::ConsoleFunctorFlags::Null,
         "Finds legacy blast material library assets in the project and generates new individual blast material assets. Original library assets will be deleted.");
 
-    // O3DE_DEPRECATION #9839
+    // O3DE_DEPRECATION_NOTICE(GHI-9839)
     // Default values used for initializing materials.
     // Use BlastMaterialConfiguration to define properties for materials at the time of creation.
     class BlastMaterialConfiguration
@@ -63,7 +63,7 @@ namespace Blast
         AZStd::string m_materialName{ "Default" };
     };
 
-    // O3DE_DEPRECATION #9839
+    // O3DE_DEPRECATION_NOTICE(GHI-9839)
     // A single BlastMaterial entry in the material library
     // BlastMaterialLibraryAsset holds a collection of BlastMaterialFromAssetConfiguration instances.
     class BlastMaterialFromAssetConfiguration
@@ -97,7 +97,7 @@ namespace Blast
         }
     };
 
-    // O3DE_DEPRECATION #9839
+    // O3DE_DEPRECATION_NOTICE(GHI-9839)
     // An asset that holds a list of materials.
     class BlastMaterialLibraryAsset : public AZ::Data::AssetData
     {

--- a/Gems/Blast/Code/Source/Editor/Material/LegacyBlastMaterialAssetConversion.cpp
+++ b/Gems/Blast/Code/Source/Editor/Material/LegacyBlastMaterialAssetConversion.cpp
@@ -29,7 +29,7 @@ namespace Blast
     AZ_CONSOLEFREEFUNC("ed_blastConvertMaterialLibrariesIntoIndividualMaterials", ConvertMaterialLibrariesIntoIndividualMaterials, AZ::ConsoleFunctorFlags::Null,
         "Finds legacy blast material library assets in the project and generates new individual blast material assets. Original library assets will be deleted.");
 
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9839
     // Default values used for initializing materials.
     // Use BlastMaterialConfiguration to define properties for materials at the time of creation.
     class BlastMaterialConfiguration
@@ -63,7 +63,7 @@ namespace Blast
         AZStd::string m_materialName{ "Default" };
     };
 
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9839
     // A single BlastMaterial entry in the material library
     // BlastMaterialLibraryAsset holds a collection of BlastMaterialFromAssetConfiguration instances.
     class BlastMaterialFromAssetConfiguration
@@ -97,7 +97,7 @@ namespace Blast
         }
     };
 
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9839
     // An asset that holds a list of materials.
     class BlastMaterialLibraryAsset : public AZ::Data::AssetData
     {

--- a/Gems/Blast/Code/Source/Material/BlastMaterialAsset.h
+++ b/Gems/Blast/Code/Source/Material/BlastMaterialAsset.h
@@ -15,7 +15,7 @@
 
 namespace Blast
 {
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9839
     // Legacy blast material Id class used to identify the material in the collection of materials.
     // Used when converting old material asset to new one.
     class BlastMaterialId

--- a/Gems/Blast/Code/Source/Material/BlastMaterialAsset.h
+++ b/Gems/Blast/Code/Source/Material/BlastMaterialAsset.h
@@ -15,7 +15,7 @@
 
 namespace Blast
 {
-    // O3DE_DEPRECATION #9839
+    // O3DE_DEPRECATION_NOTICE(GHI-9839)
     // Legacy blast material Id class used to identify the material in the collection of materials.
     // Used when converting old material asset to new one.
     class BlastMaterialId

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Utilities/LegacyPhysicsMaterialFbxManifestConversion.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Utilities/LegacyPhysicsMaterialFbxManifestConversion.cpp
@@ -126,7 +126,7 @@ namespace EMotionFX::Pipeline::Utilities
         return physicsSetupModified;
     }
 
-    // Converts all legacy material selections found inside FBX
+    // Converts all legacy material selections found inside an FBX
     // manifest (Actor Group) into new material slots.
     void FixFbxManifestPhysicsMaterials(
         const AZStd::string& fbxManifestFullPath,

--- a/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Utilities/LegacyPhysicsMaterialFbxManifestConversion.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Pipeline/SceneAPIExt/Utilities/LegacyPhysicsMaterialFbxManifestConversion.cpp
@@ -22,6 +22,8 @@
 
 namespace EMotionFX::Pipeline::Utilities
 {
+    // Converts legacy material selection inside character collider configuration
+    // into new material slots.
     bool FixCharacterColliderConfiguration(
         Physics::CharacterColliderConfiguration& characterColliderConfiguration,
         const Physics::Utils::LegacyMaterialIdToNewAssetIdMap& legacyMaterialIdToNewAssetIdMap)
@@ -51,7 +53,7 @@ namespace EMotionFX::Pipeline::Utilities
                 {
                     AZ_Assert(
                         colliderConfiguration->m_legacyMaterialSelection.m_materialIdsAssignedToSlots.size() == materialSlots.GetSlotsCount(),
-                        "Number of elements in legacy material selection (%zu) and match slots (%zu) do not match.",
+                        "Number of elements in legacy material selection (%zu) and material slots (%zu) do not match.",
                         colliderConfiguration->m_legacyMaterialSelection.m_materialIdsAssignedToSlots.size(), materialSlots.GetSlotsCount());
 
                     for (size_t i = 0; i < materialSlots.GetSlotsCount(); ++i)
@@ -74,6 +76,8 @@ namespace EMotionFX::Pipeline::Utilities
         return characterColliderConfigurationModified;
     }
 
+    // Converts all legacy material selections found inside physics setup rule
+    // into new material slots.
     bool FixActorPhysicsSetupRule(
         EMotionFX::Pipeline::Rule::ActorPhysicsSetupRule& actorPhysicsSetupRule,
         const Physics::Utils::LegacyMaterialIdToNewAssetIdMap& legacyMaterialIdToNewAssetIdMap)
@@ -122,6 +126,8 @@ namespace EMotionFX::Pipeline::Utilities
         return physicsSetupModified;
     }
 
+    // Converts all legacy material selections found inside FBX
+    // manifest (Actor Group) into new material slots.
     void FixFbxManifestPhysicsMaterials(
         const AZStd::string& fbxManifestFullPath,
         const Physics::Utils::LegacyMaterialIdToNewAssetIdMap& legacyMaterialIdToNewAssetIdMap)

--- a/Gems/EMotionFX/Code/Tests/SystemComponentFixture.h
+++ b/Gems/EMotionFX/Code/Tests/SystemComponentFixture.h
@@ -26,6 +26,7 @@
 #include <AzFramework/Application/Application.h>
 #include <AzFramework/Asset/AssetCatalogComponent.h>
 #include <AzFramework/IO/LocalFileIO.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialSystemComponent.h>
 
 #include <Integration/System/SystemComponent.h>
 #include <Integration/AnimationBus.h>
@@ -215,6 +216,7 @@ namespace EMotionFX
         AZ::AssetManagerComponent,
         AZ::JobManagerComponent,
         AZ::StreamerComponent,
+        Physics::MaterialSystemComponent,
         EMotionFX::Integration::SystemComponent
     >;
 
@@ -226,6 +228,7 @@ namespace EMotionFX
         AZ::JobManagerComponent,
         AZ::StreamerComponent,
         AzFramework::AssetCatalogComponent,
+        Physics::MaterialSystemComponent,
         EMotionFX::Integration::SystemComponent
     >;
 } // end namespace EMotionFX

--- a/Gems/EMotionFX/Code/Tests/UI/UIFixture.h
+++ b/Gems/EMotionFX/Code/Tests/UI/UIFixture.h
@@ -12,6 +12,7 @@
 
 #include <AzCore/Memory/MemoryComponent.h>
 #include <AzCore/UserSettings/UserSettingsComponent.h>
+#include <AzFramework/Physics/Material/PhysicsMaterialSystemComponent.h>
 #include <AzToolsFramework/UI/PropertyEditor/PropertyManagerComponent.h>
 #include <AzToolsFramework/UI/PropertyEditor/ReflectedPropertyEditor.hxx>
 
@@ -61,6 +62,7 @@ namespace EMotionFX
         AZ::JobManagerComponent,
         AZ::StreamerComponent,
         AZ::UserSettingsComponent,
+        Physics::MaterialSystemComponent,
         AzToolsFramework::Components::PropertyManagerComponent,
         EMotionFX::Integration::SystemComponent
     >;

--- a/Gems/PhysX/Code/Editor/Source/Configuration/PhysXEditorSettingsRegistryManager.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Configuration/PhysXEditorSettingsRegistryManager.cpp
@@ -10,6 +10,7 @@
 
 #include <AzCore/IO/SystemFile.h>
 #include <AzCore/IO/TextStreamWriters.h>
+#include <AzCore/IO/ByteContainerStream.h>
 #include <AzCore/JSON/document.h>
 #include <AzCore/JSON/pointer.h>
 #include <AzCore/JSON/prettywriter.h>

--- a/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialFbxManifestConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialFbxManifestConversion.cpp
@@ -89,6 +89,8 @@ namespace PhysX
         return newMaterialSlots;
     }
 
+    // Converts legacy material selection inside PhysX Mesh Group
+    // into new material slots.
     struct FixPhysXMeshGroup
     {
         static bool Fix(
@@ -109,7 +111,7 @@ namespace PhysX
             {
                 AZ_Assert(
                     physxMeshGroup.m_legacyPhysicsMaterials.size() == materialSlots.GetSlotsCount(),
-                    "Number of elements in legacy material selection (%zu) and match slots (%zu) do not match.",
+                    "Number of elements in legacy material selection (%zu) and material slots (%zu) do not match.",
                     physxMeshGroup.m_legacyPhysicsMaterials.size(), materialSlots.GetSlotsCount());
 
                 for (size_t i = 0; i < materialSlots.GetSlotsCount(); ++i)
@@ -130,6 +132,8 @@ namespace PhysX
         }
     };
 
+    // Converts all legacy material selections found inside FBX
+    // manifest (PhysX Mesh Group) into new material slots.
     void FixFbxManifestPhysicsMaterials(
         const AZStd::string& fbxManifestFullPath,
         const LegacyMaterialNameToNewAssetIdsMap& legacyMaterialNameToNewAssetIdsMap)

--- a/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialFbxManifestConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialFbxManifestConversion.cpp
@@ -132,7 +132,7 @@ namespace PhysX
         }
     };
 
-    // Converts all legacy material selections found inside FBX
+    // Converts all legacy material selections found inside an FBX
     // manifest (PhysX Mesh Group) into new material slots.
     void FixFbxManifestPhysicsMaterials(
         const AZStd::string& fbxManifestFullPath,

--- a/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialLibraryConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialLibraryConversion.cpp
@@ -23,7 +23,7 @@
 
 namespace PhysicsLegacy
 {
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9840
     // Default values used for initializing materials.
     // Use MaterialConfiguration to define properties for materials at the time of creation.
     class MaterialConfiguration
@@ -63,7 +63,7 @@ namespace PhysicsLegacy
         AZ::Color m_debugColor = AZ::Colors::White;
     };
 
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9840
     // A single Material entry in the material library
     // MaterialLibraryAsset holds a collection of MaterialFromAssetConfiguration instances.
     class MaterialFromAssetConfiguration
@@ -98,7 +98,7 @@ namespace PhysicsLegacy
         }
     };
 
-    // O3DE_DEPRECATION
+    // O3DE_DEPRECATION #9840
     // An asset that holds a list of materials.
     class MaterialLibraryAsset
         : public AZ::Data::AssetData

--- a/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialLibraryConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialLibraryConversion.cpp
@@ -23,7 +23,7 @@
 
 namespace PhysicsLegacy
 {
-    // O3DE_DEPRECATION #9840
+    // O3DE_DEPRECATION_NOTICE(GHI-9840)
     // Default values used for initializing materials.
     // Use MaterialConfiguration to define properties for materials at the time of creation.
     class MaterialConfiguration
@@ -63,7 +63,7 @@ namespace PhysicsLegacy
         AZ::Color m_debugColor = AZ::Colors::White;
     };
 
-    // O3DE_DEPRECATION #9840
+    // O3DE_DEPRECATION_NOTICE(GHI-9840)
     // A single Material entry in the material library
     // MaterialLibraryAsset holds a collection of MaterialFromAssetConfiguration instances.
     class MaterialFromAssetConfiguration
@@ -98,7 +98,7 @@ namespace PhysicsLegacy
         }
     };
 
-    // O3DE_DEPRECATION #9840
+    // O3DE_DEPRECATION_NOTICE(GHI-9840)
     // An asset that holds a list of materials.
     class MaterialLibraryAsset
         : public AZ::Data::AssetData

--- a/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialPrefabConversion.cpp
+++ b/Gems/PhysX/Code/Editor/Source/Material/Conversion/LegacyPhysicsMaterialPrefabConversion.cpp
@@ -61,7 +61,7 @@ namespace PhysX
             {
                 AZ_Assert(
                     legacyMaterialSelection.m_materialIdsAssignedToSlots.size() == materialSlots.GetSlotsCount(),
-                    "Number of elements in legacy material selection (%zu) and match slots (%zu) do not match.",
+                    "Number of elements in legacy material selection (%zu) and material slots (%zu) do not match.",
                     legacyMaterialSelection.m_materialIdsAssignedToSlots.size(), materialSlots.GetSlotsCount());
 
                 for (size_t i = 0; i < materialSlots.GetSlotsCount(); ++i)

--- a/Gems/PhysX/Code/Source/Material/PhysXMaterialConfiguration.cpp
+++ b/Gems/PhysX/Code/Source/Material/PhysXMaterialConfiguration.cpp
@@ -90,7 +90,7 @@ namespace PhysX
     void MaterialConfiguration::ValidateMaterialAsset(
         [[maybe_unused]] AZ::Data::Asset<Physics::MaterialAsset> materialAsset)
     {
-#if !defined(_RELEASE)
+#if !defined(AZ_RELEASE_BUILD)
         if (!materialAsset)
         {
             AZ_Error("MaterialConfiguration", false, "Invalid material asset");

--- a/Gems/PhysX/Code/Source/Module.cpp
+++ b/Gems/PhysX/Code/Source/Module.cpp
@@ -43,6 +43,9 @@ namespace PhysX
             , m_physXSystem(AZStd::make_unique<PhysXSettingsRegistryManager>(), PxCooking::GetRealTimeCookingParams())
 #endif
         {
+            // PhysXSystemConfiguration needs to be 16-byte aligned since it contains a SIMD vector4.
+            // The vector4 itself is aligned relative to the module class, but if the module class is
+            // not also aligned, it will crash. This checks makes sure they will be aligned to 16 bytes.
             static_assert(alignof(PhysX::PhysXSystemConfiguration) == 16);
             static_assert(alignof(PhysX::PhysXSystem) == 16);
             static_assert(alignof(PhysX::Module) == 16);

--- a/Gems/PhysX/Code/Source/Pipeline/MeshAssetHandler.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshAssetHandler.cpp
@@ -159,10 +159,10 @@ namespace PhysX
                     else
                     {
                         AZ_Warning("PhysX Mesh Asset", false,
-                            "Loading PhysX Mesh '%s' it didn't find physics material '%s', assigned to slot '%s'. Default physics material will be used.",
+                            "Loading PhysX Mesh '%s' it didn't find physics material '%s', assigned to slot '%.*s'. Default physics material will be used.",
                             asset.GetHint().c_str(),
                             materialAsset.GetHint().c_str(),
-                            meshAsset->m_assetData.m_materialSlots.GetSlotName(slotId).c_str());
+                            AZ_STRING_ARG(meshAsset->m_assetData.m_materialSlots.GetSlotName(slotId)));
                     }
                 }
             }

--- a/Gems/PhysX/Code/Source/Pipeline/MeshGroup.h
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshGroup.h
@@ -232,7 +232,7 @@ namespace PhysX
             ConvexDecompositionParams m_convexDecompositionParams{};
             AZ::SceneAPI::Containers::RuleContainer m_rules{};
             Physics::MaterialSlots m_physicsMaterialSlots;
-            // O3DE_DEPRECATION
+            // O3DE_DEPRECATION #9840
             AZStd::vector<AZStd::string> m_legacyMaterialSlots; // Kept to convert old physics material assets.
             AZStd::vector<AZStd::string> m_legacyPhysicsMaterials; // Kept to convert old physics material assets.
             friend FixPhysXMeshGroup;

--- a/Gems/PhysX/Code/Source/Pipeline/MeshGroup.h
+++ b/Gems/PhysX/Code/Source/Pipeline/MeshGroup.h
@@ -232,7 +232,7 @@ namespace PhysX
             ConvexDecompositionParams m_convexDecompositionParams{};
             AZ::SceneAPI::Containers::RuleContainer m_rules{};
             Physics::MaterialSlots m_physicsMaterialSlots;
-            // O3DE_DEPRECATION #9840
+            // O3DE_DEPRECATION_NOTICE(GHI-9840)
             AZStd::vector<AZStd::string> m_legacyMaterialSlots; // Kept to convert old physics material assets.
             AZStd::vector<AZStd::string> m_legacyPhysicsMaterials; // Kept to convert old physics material assets.
             friend FixPhysXMeshGroup;

--- a/Gems/PhysX/Code/Source/RigidBody.cpp
+++ b/Gems/PhysX/Code/Source/RigidBody.cpp
@@ -22,6 +22,7 @@
 #include <extensions/PxRigidBodyExt.h>
 #include <PxPhysicsAPI.h>
 #include <PhysX/PhysXLocks.h>
+#include <PhysX/Material/PhysXMaterial.h>
 #include <Common/PhysXSceneQueryHelpers.h>
 
 namespace PhysX

--- a/Gems/PhysX/Code/Source/Utils.h
+++ b/Gems/PhysX/Code/Source/Utils.h
@@ -10,6 +10,7 @@
 
 #include <PhysX/ForceRegionComponentBus.h>
 
+#include <AzCore/Component/Entity.h>
 #include <AzCore/Math/Quaternion.h>
 #include <AzCore/Math/Transform.h>
 #include <AzCore/Math/Vector3.h>

--- a/Gems/PhysX/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
@@ -44,46 +44,53 @@ namespace PhysXEditorTests
         return samples;
     }
 
+    AZ::Data::Asset<Physics::MaterialAsset> FindOrCreateMaterialAsset(AZ::Data::AssetId assetId)
+    {
+        AZ::Data::Asset<Physics::MaterialAsset> materialAsset =
+            AZ::Data::AssetManager::Instance().FindAsset<Physics::MaterialAsset>(assetId , AZ::Data::AssetLoadBehavior::Default);
+
+        if (!materialAsset)
+        {
+            const PhysX::MaterialConfiguration defaultMaterialConfiguration;
+            const Physics::MaterialAsset::MaterialProperties materialProperties =
+            {
+                {PhysX::MaterialConstants::DynamicFrictionName, defaultMaterialConfiguration.m_dynamicFriction},
+                {PhysX::MaterialConstants::StaticFrictionName, defaultMaterialConfiguration.m_staticFriction},
+                {PhysX::MaterialConstants::RestitutionName, defaultMaterialConfiguration.m_restitution},
+                {PhysX::MaterialConstants::DensityName, defaultMaterialConfiguration.m_density},
+                {PhysX::MaterialConstants::RestitutionCombineModeName, static_cast<AZ::u32>(defaultMaterialConfiguration.m_restitutionCombine)},
+                {PhysX::MaterialConstants::FrictionCombineModeName, static_cast<AZ::u32>(defaultMaterialConfiguration.m_frictionCombine)},
+                {PhysX::MaterialConstants::DebugColorName, defaultMaterialConfiguration.m_debugColor}
+            };
+
+            materialAsset =
+                AZ::Data::AssetManager::Instance().CreateAsset<Physics::MaterialAsset>(assetId, AZ::Data::AssetLoadBehavior::Default);
+
+            if (!materialAsset)
+            {
+                AZ_Error("PhysXEditorTests", false, "Failed to create material asset with id '%s'", assetId.ToString<AZStd::string>().c_str());
+                return {};
+            }
+
+            materialAsset->SetData(
+                PhysX::MaterialConstants::MaterialAssetType,
+                PhysX::MaterialConstants::MaterialAssetVersion,
+                materialProperties);
+        }
+
+        return materialAsset;
+    }
+
     AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> GetMaterialList()
     {
-        const PhysX::MaterialConfiguration defaultMaterialConfiguration;
-        const Physics::MaterialAsset::MaterialProperties materialProperties =
-        {
-            {PhysX::MaterialConstants::DynamicFrictionName, defaultMaterialConfiguration.m_dynamicFriction},
-            {PhysX::MaterialConstants::StaticFrictionName, defaultMaterialConfiguration.m_staticFriction},
-            {PhysX::MaterialConstants::RestitutionName, defaultMaterialConfiguration.m_restitution},
-            {PhysX::MaterialConstants::DensityName, defaultMaterialConfiguration.m_density},
-            {PhysX::MaterialConstants::RestitutionCombineModeName, static_cast<AZ::u32>(defaultMaterialConfiguration.m_restitutionCombine)},
-            {PhysX::MaterialConstants::FrictionCombineModeName, static_cast<AZ::u32>(defaultMaterialConfiguration.m_frictionCombine)},
-            {PhysX::MaterialConstants::DebugColorName, defaultMaterialConfiguration.m_debugColor}
-        };
-
         AZ::Data::Asset<Physics::MaterialAsset> materialAsset1 =
-            AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
-                AZ::Data::AssetId(AZ::Uuid::CreateString("{EC976D51-2C26-4C1E-BBF2-75BAAAFA162C}")),
-                AZ::Data::AssetLoadBehavior::Default);
-        materialAsset1->SetData(
-            PhysX::MaterialConstants::MaterialAssetType,
-            PhysX::MaterialConstants::MaterialAssetVersion,
-            materialProperties);
+            FindOrCreateMaterialAsset(AZ::Uuid::CreateString("{EC976D51-2C26-4C1E-BBF2-75BAAAFA162C}"));
 
         AZ::Data::Asset<Physics::MaterialAsset> materialAsset2 =
-            AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
-                AZ::Data::AssetId(AZ::Uuid::CreateString("{B9836F51-A235-4781-95E3-A6302BEE9EFF}")),
-                AZ::Data::AssetLoadBehavior::Default);
-        materialAsset2->SetData(
-            PhysX::MaterialConstants::MaterialAssetType,
-            PhysX::MaterialConstants::MaterialAssetVersion,
-            materialProperties);
+            FindOrCreateMaterialAsset(AZ::Uuid::CreateString("{B9836F51-A235-4781-95E3-A6302BEE9EFF}"));
 
         AZ::Data::Asset<Physics::MaterialAsset> materialAsset3 =
-            AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
-                AZ::Data::AssetId(AZ::Uuid::CreateString("{7E060707-BB03-47EB-B046-4503C7145B6E}")),
-                AZ::Data::AssetLoadBehavior::Default);
-        materialAsset3->SetData(
-            PhysX::MaterialConstants::MaterialAssetType,
-            PhysX::MaterialConstants::MaterialAssetVersion,
-            materialProperties);
+            FindOrCreateMaterialAsset(AZ::Uuid::CreateString("{7E060707-BB03-47EB-B046-4503C7145B6E}"));
 
         return {
             materialAsset1,

--- a/Gems/PhysX/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
+++ b/Gems/PhysX/Code/Tests/EditorHeightfieldColliderComponentTests.cpp
@@ -20,6 +20,8 @@
 #include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
 #include <AzFramework/Physics/Material/PhysicsMaterialManager.h>
 #include <PhysX/MockPhysXHeightfieldProviderComponent.h>
+#include <PhysX/Material/PhysXMaterial.h>
+#include <PhysX/Material/PhysXMaterialConfiguration.h>
 #include <AzCore/Casting/lossy_cast.h>
 #include <Utils.h>
 
@@ -44,23 +46,44 @@ namespace PhysXEditorTests
 
     AZStd::vector<AZ::Data::Asset<Physics::MaterialAsset>> GetMaterialList()
     {
+        const PhysX::MaterialConfiguration defaultMaterialConfiguration;
+        const Physics::MaterialAsset::MaterialProperties materialProperties =
+        {
+            {PhysX::MaterialConstants::DynamicFrictionName, defaultMaterialConfiguration.m_dynamicFriction},
+            {PhysX::MaterialConstants::StaticFrictionName, defaultMaterialConfiguration.m_staticFriction},
+            {PhysX::MaterialConstants::RestitutionName, defaultMaterialConfiguration.m_restitution},
+            {PhysX::MaterialConstants::DensityName, defaultMaterialConfiguration.m_density},
+            {PhysX::MaterialConstants::RestitutionCombineModeName, static_cast<AZ::u32>(defaultMaterialConfiguration.m_restitutionCombine)},
+            {PhysX::MaterialConstants::FrictionCombineModeName, static_cast<AZ::u32>(defaultMaterialConfiguration.m_frictionCombine)},
+            {PhysX::MaterialConstants::DebugColorName, defaultMaterialConfiguration.m_debugColor}
+        };
+
         AZ::Data::Asset<Physics::MaterialAsset> materialAsset1 =
             AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
                 AZ::Data::AssetId(AZ::Uuid::CreateString("{EC976D51-2C26-4C1E-BBF2-75BAAAFA162C}")),
                 AZ::Data::AssetLoadBehavior::Default);
-        materialAsset1->SetData("", 0, {});
+        materialAsset1->SetData(
+            PhysX::MaterialConstants::MaterialAssetType,
+            PhysX::MaterialConstants::MaterialAssetVersion,
+            materialProperties);
 
         AZ::Data::Asset<Physics::MaterialAsset> materialAsset2 =
             AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
                 AZ::Data::AssetId(AZ::Uuid::CreateString("{B9836F51-A235-4781-95E3-A6302BEE9EFF}")),
                 AZ::Data::AssetLoadBehavior::Default);
-        materialAsset2->SetData("", 0, {});
+        materialAsset2->SetData(
+            PhysX::MaterialConstants::MaterialAssetType,
+            PhysX::MaterialConstants::MaterialAssetVersion,
+            materialProperties);
 
         AZ::Data::Asset<Physics::MaterialAsset> materialAsset3 =
             AZ::Data::AssetManager::Instance().FindOrCreateAsset<Physics::MaterialAsset>(
                 AZ::Data::AssetId(AZ::Uuid::CreateString("{7E060707-BB03-47EB-B046-4503C7145B6E}")),
                 AZ::Data::AssetLoadBehavior::Default);
-        materialAsset3->SetData("", 0, {});
+        materialAsset3->SetData(
+            PhysX::MaterialConstants::MaterialAssetType,
+            PhysX::MaterialConstants::MaterialAssetVersion,
+            materialProperties);
 
         return {
             materialAsset1,

--- a/Gems/PhysX/Registry/AssetProcessorGemConfig.setreg
+++ b/Gems/PhysX/Registry/AssetProcessorGemConfig.setreg
@@ -26,7 +26,7 @@
                     "critical": true,
                     "productAssetType": "{BC7B88B9-EE31-4FBF-A01E-2A93624C49D3}"
                 },
-                // O3DE_DEPRECATION
+                // O3DE_DEPRECATION #9840
                 // Legacy physics material library asset.
                 // Used to collect old material assets to convert them to the new one.
                 "RC physmaterial": {

--- a/Gems/PhysX/Registry/AssetProcessorGemConfig.setreg
+++ b/Gems/PhysX/Registry/AssetProcessorGemConfig.setreg
@@ -26,7 +26,7 @@
                     "critical": true,
                     "productAssetType": "{BC7B88B9-EE31-4FBF-A01E-2A93624C49D3}"
                 },
-                // O3DE_DEPRECATION #9840
+                // O3DE_DEPRECATION_NOTICE(GHI-9840)
                 // Legacy physics material library asset.
                 // Used to collect old material assets to convert them to the new one.
                 "RC physmaterial": {

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
@@ -28,33 +28,27 @@ namespace UnitTest
     {
         // AZ::Test::GemTestEnvironment ...
         void AddGemsAndComponents() override;
-        void PostSystemEntityActivate() override;
+        AZ::ComponentApplication* CreateApplicationInstance() override;
 
     public:
         EditorWhiteBoxPhysicsTestEnvironment() = default;
         ~EditorWhiteBoxPhysicsTestEnvironment() override = default;
     };
 
-    void EditorWhiteBoxPhysicsTestEnvironment::PostSystemEntityActivate()
-    {
-        AZ::SerializeContext* serializeContext = nullptr;
-        AZ::ComponentApplicationBus::BroadcastResult(
-            serializeContext, &AZ::ComponentApplicationBus::Events::GetSerializeContext);
-
-        AZ::Data::AssetManager::Instance().RegisterHandler(
-            aznew AZ::SliceAssetHandler(serializeContext), AZ::AzTypeInfo<AZ::SliceAsset>::Uuid());
-    }
-
     void EditorWhiteBoxPhysicsTestEnvironment::AddGemsAndComponents()
     {
         AddDynamicModulePaths({"PhysX.Editor.Gem"});
         AddComponentDescriptors(
-            {AzToolsFramework::EditorEntityContextComponent::CreateDescriptor(),
-             WhiteBox::EditorWhiteBoxComponent::CreateDescriptor(), WhiteBox::WhiteBoxComponent::CreateDescriptor(),
+            {WhiteBox::EditorWhiteBoxComponent::CreateDescriptor(),
+             WhiteBox::WhiteBoxComponent::CreateDescriptor(),
              WhiteBox::WhiteBoxColliderComponent::CreateDescriptor(),
-             WhiteBox::EditorWhiteBoxColliderComponent::CreateDescriptor(),
-             AzToolsFramework::Components::TransformComponent::CreateDescriptor()});
-        AddRequiredComponents({AzToolsFramework::EditorEntityContextComponent::TYPEINFO_Uuid()});
+             WhiteBox::EditorWhiteBoxColliderComponent::CreateDescriptor()});
+    }
+
+    AZ::ComponentApplication* EditorWhiteBoxPhysicsTestEnvironment::CreateApplicationInstance()
+    {
+        // Using ToolsTestApplication to have AzFramework and AzToolsFramework components.
+        return aznew UnitTest::ToolsTestApplication("EditorWhiteBoxPhysics");
     }
 
     class WhiteBoxPhysicsFixture : public ::testing::Test

--- a/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
+++ b/Gems/WhiteBox/Code/Tests/WhiteBoxPhysicsTest.cpp
@@ -26,7 +26,7 @@ namespace UnitTest
 {
     class EditorWhiteBoxPhysicsTestEnvironment : public AZ::Test::GemTestEnvironment
     {
-        // AZ::Test::GemTestEnvironment ...
+        // AZ::Test::GemTestEnvironment overrides ...
         void AddGemsAndComponents() override;
         AZ::ComponentApplication* CreateApplicationInstance() override;
 


### PR DESCRIPTION
**This PR is part of the work to refactoring physics materials. It's NOT merging to development branch.**

- Fixed PhysX, Whitebox.Physics and EMotionFX unit tests. Since they use AzFramework material classes they need to add the `Physics::MaterialSystemComponent` so the material classes get reflected and the material asset handler gets registered.
- Adding GHI numbers on deprecation comments
- Using new macro `AZ_RELEASE_BUILD`
- Fix compilation issues on non-unity build
- Improve some comments and fix typo
- Fix printing of a string_view
- Fix alignment of AzPhysics SystemConfiguration using an Asset as padding. Vector4 didn't force 16 byte alignment on Android and the static assert checks in PhysX Module failed.

Signed-off-by: moraaar <moraaar@amazon.com>