### PR TITLE
Fixed typing issue with node being able to connect to 2 different types

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -431,6 +431,7 @@ namespace ScriptCanvas
                 ->Field("Slots", &Node::m_slots)
                 ->Field("Datums", &Node::m_slotDatums)
                 ->Field("NodeDisabledFlag", &Node::m_disabledFlag)
+                ->Field("Name", &Node::m_name)
                 ;
 
             if (AZ::EditContext* editContext = serializeContext->GetEditContext())

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -27,6 +27,7 @@
 #include <ScriptCanvas/Serialization/RuntimeVariableSerializer.h>
 #include <ScriptCanvas/SystemComponent.h>
 #include <ScriptCanvas/Variable/GraphVariableManagerComponent.h>
+#include <ScriptCanvas/Core/Contracts/MathOperatorContract.h>
 
 #if defined(SC_EXECUTION_TRACE_ENABLED)
 #include <ScriptCanvas/Asset/ExecutionLogAsset.h>
@@ -258,13 +259,27 @@ namespace ScriptCanvas
             ScriptCanvas::Node* node = aznew Node;
             node->SetNodeName("++");
 
+            // This contract ensures the user can only increment incrementable types
+            ContractDescriptor operatorMethodContract;
+            operatorMethodContract.m_createFunc = []() -> MathOperatorContract*
+            {
+                auto mathContract = aznew MathOperatorContract();
+                AZStd::unordered_set<Data::Type> supportedTypes = {
+                    Data::Type::Number()
+                };
+                mathContract->SetSupportedNativeTypes(supportedTypes);
+                return mathContract;
+            };
+
             DynamicDataSlotConfiguration inputPin;
 
             inputPin.m_name = " ";
             inputPin.m_toolTip = "Input";
+            inputPin.m_contractDescs.push_back(AZStd::move(operatorMethodContract));
             inputPin.SetConnectionType(ConnectionType::Input);
+            inputPin.m_dynamicGroup = AZ_CRC("DisplayType", 0x4271e42f);
             inputPin.m_dynamicDataType = DynamicDataType::Any;
-            inputPin.m_displayType = Data::Type::Number();
+            inputPin.m_displayGroup = "DisplayType";
 
             node->AddSlot(inputPin, true);
 
@@ -272,9 +287,11 @@ namespace ScriptCanvas
 
             outputPin.m_name = " ";
             outputPin.m_toolTip = "Output";
+            outputPin.m_contractDescs.push_back(AZStd::move(operatorMethodContract));
             outputPin.SetConnectionType(ConnectionType::Output);
+            outputPin.m_dynamicGroup = AZ_CRC("DisplayType", 0x4271e42f);
             outputPin.m_dynamicDataType = DynamicDataType::Any;
-            outputPin.m_displayType = Data::Type::Number();
+            outputPin.m_displayGroup = "DisplayType";
 
             node->AddSlot(outputPin, true);
 

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -259,27 +259,12 @@ namespace ScriptCanvas
             ScriptCanvas::Node* node = aznew Node;
             node->SetNodeName("++");
 
-            // This contract ensures the user can only increment incrementable types
-            ContractDescriptor operatorMethodContract;
-            operatorMethodContract.m_createFunc = []() -> MathOperatorContract*
-            {
-                auto mathContract = aznew MathOperatorContract();
-                AZStd::unordered_set<Data::Type> supportedTypes = {
-                    Data::Type::Number()
-                };
-                mathContract->SetSupportedNativeTypes(supportedTypes);
-                return mathContract;
-            };
-
             DynamicDataSlotConfiguration inputPin;
 
             inputPin.m_name = " ";
             inputPin.m_toolTip = "Input";
-            inputPin.m_contractDescs.push_back(AZStd::move(operatorMethodContract));
             inputPin.SetConnectionType(ConnectionType::Input);
-            inputPin.m_dynamicGroup = AZ_CRC("DisplayType", 0x4271e42f);
-            inputPin.m_dynamicDataType = DynamicDataType::Any;
-            inputPin.m_displayGroup = "DisplayType";
+            inputPin.m_displayType = Data::Type::Number();
 
             node->AddSlot(inputPin, true);
 
@@ -287,11 +272,8 @@ namespace ScriptCanvas
 
             outputPin.m_name = " ";
             outputPin.m_toolTip = "Output";
-            outputPin.m_contractDescs.push_back(AZStd::move(operatorMethodContract));
             outputPin.SetConnectionType(ConnectionType::Output);
-            outputPin.m_dynamicGroup = AZ_CRC("DisplayType", 0x4271e42f);
-            outputPin.m_dynamicDataType = DynamicDataType::Any;
-            outputPin.m_displayGroup = "DisplayType";
+            outputPin.m_displayType = Data::Type::Number();
 
             node->AddSlot(outputPin, true);
 


### PR DESCRIPTION
Fixed the issue with increment node being able to connect to data types that don't make sense, and also allowing the node to connect to 2 different types for the input and output. Currently, the node just accepts numbers as valid connections. Also, .scriptcanvas files now store an extra value for the node name so my increment node is able to load properly.

<img width="767" alt="TypingIssue" src="https://user-images.githubusercontent.com/105814224/171946679-11293ce4-c10c-4d5d-9c21-55f9d327f570.png">

