### PR TITLE
Draft prototype idea for unit tests - using Enter-Synchronization-Barrier to test a specific thread condition

### DIFF
--- a/Gems/RecastNavigation/Code/Source/Components/RecastNavigationMeshComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/Components/RecastNavigationMeshComponent.cpp
@@ -170,7 +170,7 @@ namespace RecastNavigation
 
     void RecastNavigationMeshComponent::OnReceivedAllNewTiles()
     {
-        ReceivedAllNewTilesImpl(m_meshConfig, m_sendNotificationEvent);        
+        CreateTaskGraphToProcessTiles(m_meshConfig, m_sendNotificationEvent);
     }
 
     void RecastNavigationMeshComponent::OnTileProcessedEvent(AZStd::shared_ptr<TileGeometry> tile)
@@ -185,6 +185,8 @@ namespace RecastNavigation
         {
             // The async operation to receive all tiled has finished. Kick off processing of received tiles on the main thread.
             m_receivedAllNewTilesEvent.Enqueue(AZ::TimeMs{ 0 });
+
+            ENTER_BARRIER_IF_ENABLED(BarrierAfterReceivedAllTiles);
         }
     }
 } // namespace RecastNavigation

--- a/Gems/RecastNavigation/Code/Source/Components/RecastNavigationMeshComponent.cpp
+++ b/Gems/RecastNavigation/Code/Source/Components/RecastNavigationMeshComponent.cpp
@@ -170,7 +170,7 @@ namespace RecastNavigation
 
     void RecastNavigationMeshComponent::OnReceivedAllNewTiles()
     {
-        CreateTaskGraphToProcessTiles(m_meshConfig, m_sendNotificationEvent);
+        ReceivedAllNewTilesImpl(m_meshConfig, m_sendNotificationEvent);
     }
 
     void RecastNavigationMeshComponent::OnTileProcessedEvent(AZStd::shared_ptr<TileGeometry> tile)

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshCommon.cpp
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshCommon.cpp
@@ -409,7 +409,7 @@ namespace RecastNavigation
         return true;
     }
 
-    void RecastNavigationMeshCommon::CreateTaskGraphToProcessTiles(const RecastNavigationMeshConfig& config, AZ::ScheduledEvent& sendNotificationEvent)
+    void RecastNavigationMeshCommon::ReceivedAllNewTilesImpl(const RecastNavigationMeshConfig& config, AZ::ScheduledEvent& sendNotificationEvent)
     {
         if (!m_taskGraphEvent || m_taskGraphEvent->IsSignaled())
         {

--- a/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshCommon.h
+++ b/Gems/RecastNavigation/Code/Source/Misc/RecastNavigationMeshCommon.h
@@ -90,7 +90,7 @@ namespace RecastNavigation
         //! Creates a task graph with tasks to process received tile data.
         //! @param config navigation mesh configuration to apply to the tile data
         //! @param sendNotificationEvent once all the tiles are processed and added to the navigation update notify on the main thread
-        void CreateTaskGraphToProcessTiles(const RecastNavigationMeshConfig& config, AZ::ScheduledEvent& sendNotificationEvent);
+        void ReceivedAllNewTilesImpl(const RecastNavigationMeshConfig& config, AZ::ScheduledEvent& sendNotificationEvent);
 
         static Barrier BarrierAfterReceivedAllTiles;
         static Barrier BarrierOnDeactivateAndBeforeProcessingFirstTile;

--- a/Gems/RecastNavigation/Code/Tests/NavigationMeshTest.cpp
+++ b/Gems/RecastNavigation/Code/Tests/NavigationMeshTest.cpp
@@ -820,9 +820,12 @@ namespace RecastNavigationTests
 
         AZ::TickBus::Broadcast(&AZ::TickBus::Events::OnTick, 0.1f, AZ::ScriptTimePoint{});
 
-        //ENTER_BARRIER_IF_ENABLED(RecastNavigationMeshComponent::BarrierOnDeactivateAndBeforeProcessingFirstTile);
+        /*
+         * Now we have a setup where all the tiles were received and about to be queued up.
+         * Deactivate will block in @BarrierOnDeactivateAndBeforeProcessingFirstTile barrier until the first tile
+         * is about to be processed in a task.
+         */
 
-        // Deactivate the entity now.
         e.Deactivate();
     }
 }


### PR DESCRIPTION
This is a prototype of an idea of using https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-entersynchronizationbarrier to set up a unit test that creates a specific state between two threads to test a specific condition.

Uses Windows API:
- InitializeSynchronizationBarrier
- EnterSynchronizationBarrier

Requires instrumenting the product code but could be isolated to debug builds, for example:
```
#ifdef _DEBUG
    #define INIT_BARRIER(BARRIER, EXPECTED_THREAD_COUNT) BARRIER.Initialize(EXPECTED_THREAD_COUNT)
    #define ENTER_BARRIER_IF_ENABLED(BARRIER) BARRIER.Enter()
#else
    #define INIT_BARRIER()
    #define ENTER_BARRIER_IF_ENABLED()
#endif
```

This is all just to exercise this one line:
![image](https://user-images.githubusercontent.com/5432499/171966384-f917663c-d72b-40cb-b8f6-e109ad49f5a6.png)
This draft prototype enables coverage to hit that line 439.