### PR TITLE
Draw small operator node

### DIFF
--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.cpp
@@ -42,8 +42,16 @@ namespace GraphCanvas
     GeneralNodeFrameComponent::GeneralNodeFrameComponent()
         : m_frameWidget(nullptr)
         , m_shouldDeleteFrame(true)
+        , m_nodeType("")
     {
 
+    }
+
+    GeneralNodeFrameComponent::GeneralNodeFrameComponent(const AZStd::string& nodeType)
+        : m_frameWidget(nullptr)
+        , m_shouldDeleteFrame(true)
+        , m_nodeType(nodeType)
+    {
     }
 
     GeneralNodeFrameComponent::~GeneralNodeFrameComponent()
@@ -56,7 +64,7 @@ namespace GraphCanvas
 
     void GeneralNodeFrameComponent::Init()
     {
-        m_frameWidget = aznew GeneralNodeFrameGraphicsWidget(GetEntityId());
+        m_frameWidget = aznew GeneralNodeFrameGraphicsWidget(GetEntityId(), m_nodeType);
     }
 
     void GeneralNodeFrameComponent::Activate()
@@ -98,6 +106,13 @@ namespace GraphCanvas
 
     GeneralNodeFrameGraphicsWidget::GeneralNodeFrameGraphicsWidget(const AZ::EntityId& entityKey)
         : NodeFrameGraphicsWidget(entityKey)
+        , m_nodeType("")
+    {
+    }
+
+    GeneralNodeFrameGraphicsWidget::GeneralNodeFrameGraphicsWidget(const AZ::EntityId& entityKey, const AZStd::string& nodeType)
+        : NodeFrameGraphicsWidget(entityKey)
+        , m_nodeType(nodeType)
     {
     }
 
@@ -132,7 +147,7 @@ namespace GraphCanvas
 
         if (border.style() != Qt::NoPen || background.color().alpha() > 0)
         {
-            qreal cornerRadius = GetCornerRadius();
+            qreal cornerRadius = m_nodeType == ".small" ? 20 : GetCornerRadius();
 
             border.setJoinStyle(Qt::PenJoinStyle::MiterJoin); // sharp corners
             painter->setPen(border);

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.cpp
@@ -106,14 +106,13 @@ namespace GraphCanvas
 
     GeneralNodeFrameGraphicsWidget::GeneralNodeFrameGraphicsWidget(const AZ::EntityId& entityKey)
         : NodeFrameGraphicsWidget(entityKey)
-        , m_nodeType("")
     {
     }
 
     GeneralNodeFrameGraphicsWidget::GeneralNodeFrameGraphicsWidget(const AZ::EntityId& entityKey, const AZStd::string& nodeType)
         : NodeFrameGraphicsWidget(entityKey)
-        , m_nodeType(nodeType)
     {
+        m_nodeType = nodeType;
     }
 
     QPainterPath GeneralNodeFrameGraphicsWidget::GetOutline() const
@@ -147,7 +146,7 @@ namespace GraphCanvas
 
         if (border.style() != Qt::NoPen || background.color().alpha() > 0)
         {
-            qreal cornerRadius = m_nodeType == ".small" ? 20 : GetCornerRadius();
+            qreal cornerRadius = GetCornerRadius();
 
             border.setJoinStyle(Qt::PenJoinStyle::MiterJoin); // sharp corners
             painter->setPen(border);

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.cpp
@@ -104,12 +104,7 @@ namespace GraphCanvas
     // GeneralNodeFrameGraphicsWidget
     ///////////////////////////////////
 
-    GeneralNodeFrameGraphicsWidget::GeneralNodeFrameGraphicsWidget(const AZ::EntityId& entityKey)
-        : NodeFrameGraphicsWidget(entityKey)
-    {
-    }
-
-    GeneralNodeFrameGraphicsWidget::GeneralNodeFrameGraphicsWidget(const AZ::EntityId& entityKey, const AZStd::string& nodeType)
+    GeneralNodeFrameGraphicsWidget::GeneralNodeFrameGraphicsWidget(const AZ::EntityId& entityKey, AZStd::string nodeType)
         : NodeFrameGraphicsWidget(entityKey)
     {
         m_nodeType = nodeType;

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.cpp
@@ -106,8 +106,13 @@ namespace GraphCanvas
 
     GeneralNodeFrameGraphicsWidget::GeneralNodeFrameGraphicsWidget(const AZ::EntityId& entityKey, AZStd::string nodeType)
         : NodeFrameGraphicsWidget(entityKey)
+        , m_nodeType(AZStd::move(nodeType))
     {
-        m_nodeType = nodeType;
+    }
+
+    qreal GeneralNodeFrameGraphicsWidget::GetCornerRadius() const
+    {
+        return m_nodeType == Styling::Elements::Small ? 25.0 : m_style.GetAttribute(Styling::Attribute::BorderRadius, 5.0);
     }
 
     QPainterPath GeneralNodeFrameGraphicsWidget::GetOutline() const

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.h
@@ -34,6 +34,7 @@ namespace GraphCanvas
         static void Reflect(AZ::ReflectContext*);
 
         GeneralNodeFrameComponent();
+        GeneralNodeFrameComponent(const AZStd::string& nodeType);
         ~GeneralNodeFrameComponent() override;
 
         // AZ::Component
@@ -80,6 +81,7 @@ namespace GraphCanvas
         const GeneralNodeFrameComponent& operator=(const GeneralNodeFrameComponent&) = delete;
         bool                            m_shouldDeleteFrame;
         GeneralNodeFrameGraphicsWidget* m_frameWidget;
+        const AZStd::string m_nodeType;
     };
 
     //! The QGraphicsItem for the generic frame.
@@ -94,6 +96,7 @@ namespace GraphCanvas
         static void Reflect(AZ::ReflectContext*) = delete;
 
         GeneralNodeFrameGraphicsWidget(const AZ::EntityId& nodeVisual);
+        GeneralNodeFrameGraphicsWidget(const AZ::EntityId& nodeVisual, const AZStd::string& nodeType);
         ~GeneralNodeFrameGraphicsWidget() override = default;
 
         // SceneMemberUIRequestBus
@@ -103,5 +106,7 @@ namespace GraphCanvas
         // QGraphicsWidget
         void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
         ////
+    private:
+        const AZStd::string m_nodeType;
     };
 }

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.h
@@ -98,6 +98,10 @@ namespace GraphCanvas
         explicit GeneralNodeFrameGraphicsWidget(const AZ::EntityId& nodeVisual, AZStd::string nodeType = "");
         ~GeneralNodeFrameGraphicsWidget() override = default;
 
+        // NodeFrameGraphicsWidget
+        qreal GetCornerRadius() const override;
+        ////
+
         // SceneMemberUIRequestBus
         QPainterPath GetOutline() const override;
         ////
@@ -105,5 +109,9 @@ namespace GraphCanvas
         // QGraphicsWidget
         void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
         ////
+
+    private:
+
+        AZStd::string m_nodeType;
     };
 }

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.h
@@ -95,8 +95,7 @@ namespace GraphCanvas
         // Do not allow Serialization of Graphics Ui classes
         static void Reflect(AZ::ReflectContext*) = delete;
 
-        GeneralNodeFrameGraphicsWidget(const AZ::EntityId& nodeVisual);
-        GeneralNodeFrameGraphicsWidget(const AZ::EntityId& nodeVisual, const AZStd::string& nodeType);
+        explicit GeneralNodeFrameGraphicsWidget(const AZ::EntityId& nodeVisual, AZStd::string nodeType = "");
         ~GeneralNodeFrameGraphicsWidget() override = default;
 
         // SceneMemberUIRequestBus

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeFrameComponent.h
@@ -106,7 +106,5 @@ namespace GraphCanvas
         // QGraphicsWidget
         void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget = nullptr) override;
         ////
-    private:
-        const AZStd::string m_nodeType;
     };
 }

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.cpp
@@ -79,7 +79,7 @@ namespace GraphCanvas
     {
         NodeLayoutComponent::Init();
 
-        m_layoutOrientation = m_nodeType == ".small" ? Qt::Horizontal : Qt::Vertical;
+        m_layoutOrientation = m_nodeType == Styling::Elements::Small ? Qt::Horizontal : Qt::Vertical;
 
         m_layout = new QGraphicsLinearLayout(m_layoutOrientation);
         m_layout->setInstantInvalidatePropagation(true);

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.cpp
@@ -57,15 +57,8 @@ namespace GraphCanvas
         return entity;
     }
 
-    GeneralNodeLayoutComponent::GeneralNodeLayoutComponent()
-        : m_nodeType("")
-        , m_title(nullptr)
-        , m_slots(nullptr)
-    {
-    }
-
-    GeneralNodeLayoutComponent::GeneralNodeLayoutComponent(const AZStd::string& nodeType)
-        : m_nodeType(nodeType)
+    GeneralNodeLayoutComponent::GeneralNodeLayoutComponent(AZStd::string nodeType)
+        : m_nodeType(AZStd::move(nodeType))
         , m_title(nullptr)
         , m_slots(nullptr)
     {
@@ -84,19 +77,16 @@ namespace GraphCanvas
         m_layout = new QGraphicsLinearLayout(m_layoutOrientation);
         m_layout->setInstantInvalidatePropagation(true);
 
+        m_title = new QGraphicsLinearLayout(m_layoutOrientation);
+        m_title->setInstantInvalidatePropagation(true);
+
         if (m_layoutOrientation == Qt::Vertical)
         {
-            m_title = new QGraphicsLinearLayout(Qt::Vertical);
-            m_title->setInstantInvalidatePropagation(true);
-
             m_slots = new QGraphicsLinearLayout(Qt::Vertical);
             m_slots->setInstantInvalidatePropagation(true);
         }
         else
         {
-            m_title = new QGraphicsLinearLayout(Qt::Horizontal);
-            m_title->setInstantInvalidatePropagation(true);
-
             m_inputSlots = new QGraphicsLinearLayout(Qt::Horizontal);
             m_inputSlots->setInstantInvalidatePropagation(true);
 

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.cpp
@@ -47,10 +47,10 @@ namespace GraphCanvas
         // Create this Node's entity.
         AZ::Entity* entity = NodeComponent::CreateCoreNodeEntity(configuration);
 
-        entity->CreateComponent<GeneralNodeFrameComponent>();
+        entity->CreateComponent<GeneralNodeFrameComponent>(nodeType);
         entity->CreateComponent<StylingComponent>(Styling::Elements::Node, AZ::EntityId(), nodeType);        
-        entity->CreateComponent<GeneralNodeLayoutComponent>();
-        entity->CreateComponent<GeneralNodeTitleComponent>();
+        entity->CreateComponent<GeneralNodeLayoutComponent>(nodeType);
+        entity->CreateComponent<GeneralNodeTitleComponent>(nodeType);
         entity->CreateComponent<GeneralSlotLayoutComponent>();
         entity->CreateComponent<NodeLayerControllerComponent>();
 
@@ -58,7 +58,15 @@ namespace GraphCanvas
     }
 
     GeneralNodeLayoutComponent::GeneralNodeLayoutComponent()
-        : m_title(nullptr)
+        : m_nodeType("")
+        , m_title(nullptr)
+        , m_slots(nullptr)
+    {
+    }
+
+    GeneralNodeLayoutComponent::GeneralNodeLayoutComponent(const AZStd::string& nodeType)
+        : m_nodeType(nodeType)
+        , m_title(nullptr)
         , m_slots(nullptr)
     {
     }
@@ -71,14 +79,30 @@ namespace GraphCanvas
     {
         NodeLayoutComponent::Init();
 
-        m_layout = new QGraphicsLinearLayout(Qt::Vertical);
+        m_layoutOrientation = m_nodeType == ".small" ? Qt::Horizontal : Qt::Vertical;
+
+        m_layout = new QGraphicsLinearLayout(m_layoutOrientation);
         m_layout->setInstantInvalidatePropagation(true);
 
-        m_title = new QGraphicsLinearLayout(Qt::Horizontal);
-        m_title->setInstantInvalidatePropagation(true);
+        if (m_layoutOrientation == Qt::Vertical)
+        {
+            m_title = new QGraphicsLinearLayout(Qt::Vertical);
+            m_title->setInstantInvalidatePropagation(true);
 
-        m_slots = new QGraphicsLinearLayout(Qt::Horizontal);
-        m_slots->setInstantInvalidatePropagation(true);
+            m_slots = new QGraphicsLinearLayout(Qt::Vertical);
+            m_slots->setInstantInvalidatePropagation(true);
+        }
+        else
+        {
+            m_title = new QGraphicsLinearLayout(Qt::Horizontal);
+            m_title->setInstantInvalidatePropagation(true);
+
+            m_inputSlots = new QGraphicsLinearLayout(Qt::Horizontal);
+            m_inputSlots->setInstantInvalidatePropagation(true);
+
+            m_outputSlots = new QGraphicsLinearLayout(Qt::Horizontal);
+            m_outputSlots->setInstantInvalidatePropagation(true);
+        }
     }
 
     void GeneralNodeLayoutComponent::Activate()
@@ -102,23 +126,55 @@ namespace GraphCanvas
 
     void GeneralNodeLayoutComponent::OnNodeActivated()
     {
-        QGraphicsWidget* titleGraphicsItem = nullptr;
-        NodeTitleRequestBus::EventResult(titleGraphicsItem, GetEntityId(), &NodeTitleRequests::GetGraphicsWidget);
-        if (titleGraphicsItem)
+        if (m_layoutOrientation == Qt::Vertical)
         {
-            m_title->addItem(titleGraphicsItem);
-            m_title->setContentsMargins(0, 0, 0, 0);
-        }
-        GetLayoutAs<QGraphicsLinearLayout>()->addItem(m_title);
+            QGraphicsWidget* titleGraphicsItem = nullptr;
+            NodeTitleRequestBus::EventResult(titleGraphicsItem, GetEntityId(), &NodeTitleRequests::GetGraphicsWidget);
+            if (titleGraphicsItem)
+            {
+                m_title->addItem(titleGraphicsItem);
+                m_title->setContentsMargins(0, 0, 0, 0);
+            }
+            GetLayoutAs<QGraphicsLinearLayout>()->addItem(m_title);
 
-        QGraphicsLayoutItem* slotsGraphicsItem = nullptr;
-        NodeSlotsRequestBus::EventResult(slotsGraphicsItem, GetEntityId(), &NodeSlotsRequestBus::Events::GetGraphicsLayoutItem);
-        if (slotsGraphicsItem)
-        {
-            m_slots->addItem(slotsGraphicsItem);
-            m_slots->setContentsMargins(0, 0, 0, 0);
+            QGraphicsLayoutItem* slotsGraphicsItem = nullptr;
+            NodeSlotsRequestBus::EventResult(slotsGraphicsItem, GetEntityId(), &NodeSlotsRequestBus::Events::GetGraphicsLayoutItem);
+            if (slotsGraphicsItem)
+            {
+                m_slots->addItem(slotsGraphicsItem);
+                m_slots->setContentsMargins(0, 0, 0, 0);
+            }
+            GetLayoutAs<QGraphicsLinearLayout>()->addItem(m_slots);
         }
-        GetLayoutAs<QGraphicsLinearLayout>()->addItem(m_slots);
+        else
+        {
+            QGraphicsLayoutItem* inputGraphicsItem = nullptr;
+            NodeSlotsRequestBus::EventResult(inputGraphicsItem, GetEntityId(), &NodeSlotsRequestBus::Events::GetInputGraphicsLayoutItem);
+            if (inputGraphicsItem)
+            {
+                m_inputSlots->addItem(inputGraphicsItem);
+                m_inputSlots->setContentsMargins(0, 0, 0, 0);
+            }
+            GetLayoutAs<QGraphicsLinearLayout>()->addItem(m_inputSlots);
+
+            QGraphicsWidget* titleGraphicsItem = nullptr;
+            NodeTitleRequestBus::EventResult(titleGraphicsItem, GetEntityId(), &NodeTitleRequests::GetGraphicsWidget);
+            if (titleGraphicsItem)
+            {
+                m_title->addItem(titleGraphicsItem);
+                m_title->setContentsMargins(0, 0, 0, 0);
+            }
+            GetLayoutAs<QGraphicsLinearLayout>()->addItem(m_title);
+
+            QGraphicsLayoutItem* outputGraphicsItem = nullptr;
+            NodeSlotsRequestBus::EventResult(outputGraphicsItem, GetEntityId(), &NodeSlotsRequestBus::Events::GetOutputGraphicsLayoutItem);
+            if (outputGraphicsItem)
+            {
+                m_outputSlots->addItem(outputGraphicsItem);
+                m_outputSlots->setContentsMargins(0, 0, 0, 0);
+            }
+            GetLayoutAs<QGraphicsLinearLayout>()->addItem(m_outputSlots);
+        }
 
         StyleNotificationBus::Handler::BusConnect(GetEntityId());
 

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.h
@@ -34,6 +34,7 @@ namespace GraphCanvas
         static AZ::Entity* CreateGeneralNodeEntity(const char* nodeType, const NodeConfiguration& nodeConfiguration = NodeConfiguration());
 
         GeneralNodeLayoutComponent();
+        GeneralNodeLayoutComponent(const AZStd::string& nodeType);
         ~GeneralNodeLayoutComponent();
 
         // AZ::Component
@@ -69,5 +70,12 @@ namespace GraphCanvas
 
         QGraphicsLinearLayout* m_title;
         QGraphicsLinearLayout* m_slots;
+
+        QGraphicsLinearLayout* m_inputSlots;
+        QGraphicsLinearLayout* m_outputSlots;
+
+        Qt::Orientation m_layoutOrientation;
+
+        const AZStd::string m_nodeType;
     };
 }

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeLayoutComponent.h
@@ -33,8 +33,7 @@ namespace GraphCanvas
         
         static AZ::Entity* CreateGeneralNodeEntity(const char* nodeType, const NodeConfiguration& nodeConfiguration = NodeConfiguration());
 
-        GeneralNodeLayoutComponent();
-        GeneralNodeLayoutComponent(const AZStd::string& nodeType);
+        explicit GeneralNodeLayoutComponent(AZStd::string nodeType = "");
         ~GeneralNodeLayoutComponent();
 
         // AZ::Component

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeTitleComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeTitleComponent.cpp
@@ -465,7 +465,7 @@ namespace GraphCanvas
     void GeneralNodeTitleGraphicsWidget::OnAddedToScene(const AZ::EntityId& scene)
     {
         SceneNotificationBus::Handler::BusConnect(scene);
-        if (m_nodeType == ".small")
+        if (m_nodeType == Styling::Elements::Small)
             m_titleWidget->SetAlignment(Qt::AlignCenter);
         UpdateStyles();
         RefreshDisplay();
@@ -491,7 +491,7 @@ namespace GraphCanvas
     {
         GRAPH_CANVAS_DETAILED_PROFILE_FUNCTION();
 
-        if (m_nodeType == ".small")
+        if (m_nodeType == Styling::Elements::Small)
             return;
 
         // Background

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeTitleComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeTitleComponent.cpp
@@ -51,12 +51,18 @@ namespace GraphCanvas
     }
 
     GeneralNodeTitleComponent::GeneralNodeTitleComponent()
+        : m_nodeType("")
+    {
+    }
+
+    GeneralNodeTitleComponent::GeneralNodeTitleComponent(const AZStd::string& nodeType)
+        : m_nodeType(nodeType)
     {
     }
 
     void GeneralNodeTitleComponent::Init()
     {
-        m_generalNodeTitleWidget = aznew GeneralNodeTitleGraphicsWidget(GetEntityId());
+        m_generalNodeTitleWidget = aznew GeneralNodeTitleGraphicsWidget(GetEntityId(), m_nodeType);
     }
 
     void GeneralNodeTitleComponent::Activate()
@@ -216,8 +222,28 @@ namespace GraphCanvas
     ///////////////////////////////////
     GeneralNodeTitleGraphicsWidget::GeneralNodeTitleGraphicsWidget(const AZ::EntityId& entityId)
         : m_entityId(entityId)
+        , m_nodeType("")
         , m_paletteOverride(nullptr)
         , m_colorOverride(nullptr)
+    {
+        Initialize();
+    }
+
+    GeneralNodeTitleGraphicsWidget::GeneralNodeTitleGraphicsWidget(const AZ::EntityId& entityId, const AZStd::string& nodeType)
+        : m_entityId(entityId)
+        , m_nodeType(nodeType)
+        , m_paletteOverride(nullptr)
+        , m_colorOverride(nullptr)
+    {
+        Initialize();
+    }
+
+    GeneralNodeTitleGraphicsWidget::~GeneralNodeTitleGraphicsWidget()
+    {
+        delete m_colorOverride;
+    }
+
+    void GeneralNodeTitleGraphicsWidget::Initialize()
     {
         setCacheMode(QGraphicsItem::CacheMode::DeviceCoordinateCache);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -230,12 +256,7 @@ namespace GraphCanvas
         m_linearLayout = new QGraphicsLinearLayout(Qt::Vertical);
         m_linearLayout->setSpacing(0);
         setLayout(m_linearLayout);
-        setData(GraphicsItemName, QStringLiteral("Title/%1").arg(static_cast<AZ::u64>(entityId), 16, 16, QChar('0')));
-    }
-
-    GeneralNodeTitleGraphicsWidget::~GeneralNodeTitleGraphicsWidget()
-    {
-        delete m_colorOverride;
+        setData(GraphicsItemName, QStringLiteral("Title/%1").arg(static_cast<AZ::u64>(m_entityId), 16, 16, QChar('0')));
     }
 
     void GeneralNodeTitleGraphicsWidget::Activate()
@@ -444,6 +465,8 @@ namespace GraphCanvas
     void GeneralNodeTitleGraphicsWidget::OnAddedToScene(const AZ::EntityId& scene)
     {
         SceneNotificationBus::Handler::BusConnect(scene);
+        if (m_nodeType == ".small")
+            m_titleWidget->SetAlignment(Qt::AlignCenter);
         UpdateStyles();
         RefreshDisplay();
     }
@@ -467,6 +490,9 @@ namespace GraphCanvas
     void GeneralNodeTitleGraphicsWidget::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
     {
         GRAPH_CANVAS_DETAILED_PROFILE_FUNCTION();
+
+        if (m_nodeType == ".small")
+            return;
 
         // Background
         QRectF bounds = boundingRect();

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeTitleComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeTitleComponent.cpp
@@ -465,8 +465,12 @@ namespace GraphCanvas
     void GeneralNodeTitleGraphicsWidget::OnAddedToScene(const AZ::EntityId& scene)
     {
         SceneNotificationBus::Handler::BusConnect(scene);
+
         if (m_nodeType == Styling::Elements::Small)
+        {
             m_titleWidget->SetAlignment(Qt::AlignCenter);
+        }
+            
         UpdateStyles();
         RefreshDisplay();
     }
@@ -492,7 +496,9 @@ namespace GraphCanvas
         GRAPH_CANVAS_DETAILED_PROFILE_FUNCTION();
 
         if (m_nodeType == Styling::Elements::Small)
+        {
             return;
+        }
 
         // Background
         QRectF bounds = boundingRect();

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeTitleComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralNodeTitleComponent.h
@@ -37,6 +37,7 @@ namespace GraphCanvas
         static void Reflect(AZ::ReflectContext*);
 
         GeneralNodeTitleComponent();
+        GeneralNodeTitleComponent(const AZStd::string& nodeType);
         ~GeneralNodeTitleComponent() = default;
 
         // AZ::Component
@@ -102,6 +103,8 @@ namespace GraphCanvas
         GeneralNodeTitleComponentSaveData m_saveData;
         
         GeneralNodeTitleGraphicsWidget* m_generalNodeTitleWidget = nullptr;
+
+        const AZStd::string m_nodeType;
     };    
 
     //! The Title QGraphicsWidget for displaying a title
@@ -117,7 +120,10 @@ namespace GraphCanvas
         AZ_CLASS_ALLOCATOR(GeneralNodeTitleGraphicsWidget, AZ::SystemAllocator, 0);        
 
         GeneralNodeTitleGraphicsWidget(const AZ::EntityId& entityId);
+        GeneralNodeTitleGraphicsWidget(const AZ::EntityId& entityId, const AZStd::string& nodeType);
         ~GeneralNodeTitleGraphicsWidget() override;
+
+        void Initialize();
 
         void Activate();
         void Deactivate();
@@ -176,6 +182,8 @@ namespace GraphCanvas
         const Styling::StyleHelper* m_paletteOverride;
         Styling::StyleHelper* m_colorOverride;        
 
-        Styling::StyleHelper m_styleHelper;        
+        Styling::StyleHelper m_styleHelper;
+
+        const AZStd::string m_nodeType;
     };
 }

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralSlotLayoutComponent.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralSlotLayoutComponent.cpp
@@ -259,9 +259,19 @@ namespace GraphCanvas
         }
     }
 
+    QGraphicsLayoutItem* GeneralSlotLayoutGraphicsWidget::LinearSlotGroupWidget::GetInputSlotLayout()
+    {
+        return m_inputs;
+    }
+
     const AZStd::vector< SlotLayoutInfo >& GeneralSlotLayoutGraphicsWidget::LinearSlotGroupWidget::GetInputSlots() const
     {
         return m_inputSlots;
+    }
+
+    QGraphicsLayoutItem* GeneralSlotLayoutGraphicsWidget::LinearSlotGroupWidget::GetOutputSlotLayout()
+    {
+        return m_outputs;
     }
 
     const AZStd::vector< SlotLayoutInfo >& GeneralSlotLayoutGraphicsWidget::LinearSlotGroupWidget::GetOutputSlots() const
@@ -478,6 +488,16 @@ namespace GraphCanvas
     QGraphicsLayoutItem* GeneralSlotLayoutGraphicsWidget::GetGraphicsLayoutItem()
     {
         return this;
+    }
+
+    QGraphicsLayoutItem* GeneralSlotLayoutGraphicsWidget::GetInputGraphicsLayoutItem()
+    {
+        return FindCreateSlotGroupWidget(SlotGroups::DataGroup)->GetInputSlotLayout();
+    }
+
+    QGraphicsLayoutItem* GeneralSlotLayoutGraphicsWidget::GetOutputGraphicsLayoutItem()
+    {
+        return FindCreateSlotGroupWidget(SlotGroups::DataGroup)->GetOutputSlotLayout();
     }
 
     void GeneralSlotLayoutGraphicsWidget::OnSceneSet(const AZ::EntityId& /*sceneId*/)

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralSlotLayoutComponent.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/General/GeneralSlotLayoutComponent.h
@@ -108,7 +108,10 @@ namespace GraphCanvas
             void DisplaySlot(const AZ::EntityId& slotId);
             void RemoveSlot(const AZ::EntityId& slotId);
 
+            QGraphicsLayoutItem* GetInputSlotLayout();
             const AZStd::vector< SlotLayoutInfo >& GetInputSlots() const;
+
+            QGraphicsLayoutItem* GetOutputSlotLayout();
             const AZStd::vector< SlotLayoutInfo >& GetOutputSlots() const;
 
             bool IsEmpty() const;
@@ -155,6 +158,9 @@ namespace GraphCanvas
 
         // NodeSlotsRequestBus
         QGraphicsLayoutItem* GetGraphicsLayoutItem() override;
+
+        QGraphicsLayoutItem* GetInputGraphicsLayoutItem() override;
+        QGraphicsLayoutItem* GetOutputGraphicsLayoutItem() override;
         ////
 
         // SceneMemberNotificationBus

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.cpp
@@ -240,7 +240,7 @@ namespace GraphCanvas
 
     qreal NodeFrameGraphicsWidget::GetCornerRadius() const
     {
-        return m_nodeType == Styling::Elements::Small ? 25 : m_style.GetAttribute(Styling::Attribute::BorderRadius, 5.0);
+        return m_nodeType == Styling::Elements::Small ? 25.0 : m_style.GetAttribute(Styling::Attribute::BorderRadius, 5.0);
     }
 
     qreal NodeFrameGraphicsWidget::GetBorderWidth() const

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.cpp
@@ -240,7 +240,7 @@ namespace GraphCanvas
 
     qreal NodeFrameGraphicsWidget::GetCornerRadius() const
     {
-        return m_style.GetAttribute(Styling::Attribute::BorderRadius, 5.0);
+        return m_nodeType == Styling::Elements::Small ? 25 : m_style.GetAttribute(Styling::Attribute::BorderRadius, 5.0);
     }
 
     qreal NodeFrameGraphicsWidget::GetBorderWidth() const

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.cpp
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.cpp
@@ -240,7 +240,7 @@ namespace GraphCanvas
 
     qreal NodeFrameGraphicsWidget::GetCornerRadius() const
     {
-        return m_nodeType == Styling::Elements::Small ? 25.0 : m_style.GetAttribute(Styling::Attribute::BorderRadius, 5.0);
+        return m_style.GetAttribute(Styling::Attribute::BorderRadius, 5.0);
     }
 
     qreal NodeFrameGraphicsWidget::GetBorderWidth() const

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.h
@@ -141,6 +141,8 @@ namespace GraphCanvas
         Styling::StyleHelper m_style;
         NodeFrameDisplayState m_displayState;
 
+        AZStd::string m_nodeType;
+
         bool m_enabledSteppedSizing = true;
         EditorId m_editorId;
 

--- a/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.h
+++ b/Gems/GraphCanvas/Code/Source/Components/Nodes/NodeFrameGraphicsWidget.h
@@ -141,8 +141,6 @@ namespace GraphCanvas
         Styling::StyleHelper m_style;
         NodeFrameDisplayState m_displayState;
 
-        AZStd::string m_nodeType;
-
         bool m_enabledSteppedSizing = true;
         EditorId m_editorId;
 

--- a/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasLabel.cpp
+++ b/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasLabel.cpp
@@ -165,6 +165,12 @@ namespace GraphCanvas
         }
     }
 
+    void GraphCanvasLabel::SetAlignment(Qt::Alignment alignment)
+    {
+        m_alignment = alignment;
+        update();
+    }
+
     void GraphCanvasLabel::SetDefaultAlignment(Qt::Alignment defaultAlignment)
     {
         m_defaultAlignment = defaultAlignment;
@@ -390,7 +396,7 @@ namespace GraphCanvas
             painter->setBrush(QBrush());
             painter->setFont(m_styleHelper.GetFont());
 
-            Qt::Alignment textAlignment = m_styleHelper.GetTextAlignment(m_defaultAlignment);
+            Qt::Alignment textAlignment = m_alignment ? m_alignment : m_styleHelper.GetTextAlignment(m_defaultAlignment);
 
             QTextOption opt(textAlignment);
             opt.setFlags(QTextOption::IncludeTrailingSpaces);

--- a/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasLabel.h
+++ b/Gems/GraphCanvas/Code/Source/Widgets/GraphCanvasLabel.h
@@ -75,6 +75,8 @@ namespace GraphCanvas
         //! Sets whether or not the text label will allow newlines in the text
         void SetAllowNewlines(bool allow);
 
+        void SetAlignment(Qt::Alignment alignment);
+
         void SetDefaultAlignment(Qt::Alignment defaultAlignment);
 
         Styling::StyleHelper& GetStyleHelper();
@@ -95,7 +97,9 @@ namespace GraphCanvas
         QSizeF sizeHint(Qt::SizeHint which, const QSizeF& constraint = QSizeF()) const override;
         ////
 
-    private:        
+    private:
+        // If this has a value other than null, this will be used as the text alignment
+        Qt::Alignment   m_alignment;
 
         Qt::Alignment   m_defaultAlignment;
         bool m_elide;

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Nodes/NodeLayoutBus.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Components/Nodes/NodeLayoutBus.h
@@ -44,6 +44,10 @@ namespace GraphCanvas
         using BusIdType = AZ::EntityId;
 
         virtual QGraphicsLayoutItem* GetGraphicsLayoutItem() = 0;
+
+        virtual QGraphicsLayoutItem* GetInputGraphicsLayoutItem() = 0;
+        virtual QGraphicsLayoutItem* GetOutputGraphicsLayoutItem() = 0;
+
     };
 
     using NodeSlotsRequestBus = AZ::EBus<NodeSlotsRequests>;

--- a/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/definitions.h
+++ b/Gems/GraphCanvas/Code/StaticLib/GraphCanvas/Styling/definitions.h
@@ -65,6 +65,8 @@ namespace GraphCanvas
             // Custom Widgets
             const char* const CheckBox = "checkBox";
 
+            const char* const Small = ".small";
+
         } // namespace Elements
 
         enum class Element : AZ::u32

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1553,9 +1553,10 @@ namespace ScriptCanvasEditor
 
         // ScriptCanvas has access to better typing information regarding the slots than is exposed to GraphCanvas.
         // So let ScriptCanvas check the types based on it's own information rather than relying on the information passed back from GraphCanvas.
-        ScriptCanvas::Data::Type slotType = slot->GetDataType();
-
+        
+        if (slot->CanHaveInputField())
         {
+            ScriptCanvas::Data::Type slotType = slot->GetDataType();
             GraphCanvas::DataInterface* dataInterface = nullptr;
             GraphCanvas::NodePropertyDisplay* dataDisplay = nullptr;
 

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1530,7 +1530,7 @@ namespace ScriptCanvasEditor
         ScriptCanvas::Slot* slot = nullptr;
         ScriptCanvas::NodeRequestBus::EventResult(slot, scriptCanvasNodeId, &ScriptCanvas::NodeRequests::GetSlot, scriptCanvasSlotId);
 
-        if (slot == nullptr || slot->IsUserAdded())
+        if (slot == nullptr || slot->IsUserAdded() || !slot->CanHaveInputField())
         {
             return nullptr;
         }
@@ -1553,11 +1553,11 @@ namespace ScriptCanvasEditor
 
         // ScriptCanvas has access to better typing information regarding the slots than is exposed to GraphCanvas.
         // So let ScriptCanvas check the types based on it's own information rather than relying on the information passed back from GraphCanvas.
-        
-        if (slot->CanHaveInputField())
+
+        ScriptCanvas::Data::Type slotType = slot->GetDataType();
+        GraphCanvas::DataInterface* dataInterface = nullptr;
+
         {
-            ScriptCanvas::Data::Type slotType = slot->GetDataType();
-            GraphCanvas::DataInterface* dataInterface = nullptr;
             GraphCanvas::NodePropertyDisplay* dataDisplay = nullptr;
 
             if (slotType.IS_A(ScriptCanvas::Data::Type::Boolean()))

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
@@ -13,6 +13,7 @@
 
 #include <GraphCanvas/Components/Nodes/NodeBus.h>
 #include <GraphCanvas/Components/Nodes/NodeTitleBus.h>
+#include <GraphCanvas/GraphCanvasBus.h>
 
 #include <ScriptCanvas/Bus/EditorScriptCanvasBus.h>
 #include <ScriptCanvas/Core/NodelingBus.h>
@@ -237,6 +238,60 @@ namespace ScriptCanvasEditor::Nodes
 
         return nodeIdPair;
     }
+
+    NodeIdPair CreateSmallOperatorNode(const SmallOperatorNodeData& nodeData)
+    {
+        NodeIdPair nodeIdPair;
+
+        ScriptCanvas::Node* node{};
+        AZ::Entity* scriptCanvasEntity{ aznew AZ::Entity };
+        scriptCanvasEntity->Init();
+        nodeIdPair.m_scriptCanvasId = scriptCanvasEntity->GetId();
+
+        AZ::Entity* nodeEntity = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(nodeEntity, &AZ::ComponentApplicationRequests::FindEntity, scriptCanvasEntity->GetId());
+
+        node = aznew ScriptCanvas::Node();
+        node->SetNodeName(nodeData.m_name);
+
+        ScriptCanvas::DynamicDataSlotConfiguration inputPin;
+
+        inputPin.m_name = " ";
+        inputPin.m_toolTip = "Input";
+        inputPin.m_canHaveInputField = false;
+        inputPin.SetConnectionType(ScriptCanvas::ConnectionType::Input);
+        inputPin.m_displayType = nodeData.m_dataType;
+
+        node->AddSlot(inputPin, true);
+
+        ScriptCanvas::DynamicDataSlotConfiguration outputPin;
+
+        outputPin.m_name = " ";
+        outputPin.m_toolTip = "Output";
+        outputPin.SetConnectionType(ScriptCanvas::ConnectionType::Output);
+        outputPin.m_displayType = nodeData.m_dataType;
+
+        node->AddSlot(outputPin, true);
+
+        if (node && nodeEntity)
+        {
+            nodeEntity->SetName(node->GetNodeName());
+            nodeEntity->AddComponent(node);
+        }
+
+        ScriptCanvas::GraphRequestBus::Event(nodeData.m_scriptCanvasId, &ScriptCanvas::GraphRequests::AddNode, nodeEntity->GetId());
+
+        AZ::EntityId graphCanvasGraphId;
+        EditorGraphRequestBus::EventResult(graphCanvasGraphId, nodeData.m_scriptCanvasId, &EditorGraphRequests::GetGraphCanvasGraphId);
+
+        NodeReplacementConfiguration nodeConfiguration;
+        nodeConfiguration.m_nodeSubStyle = ".small";
+
+        nodeIdPair.m_graphCanvasId = DisplayGeneralScriptCanvasNode(graphCanvasGraphId, node, nodeConfiguration);
+
+        return nodeIdPair;
+    }
+
 
     NodeIdPair CreateScriptEventReceiverNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const AZ::Data::AssetId& assetId)
     {

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
@@ -285,7 +285,7 @@ namespace ScriptCanvasEditor::Nodes
         EditorGraphRequestBus::EventResult(graphCanvasGraphId, nodeData.m_scriptCanvasId, &EditorGraphRequests::GetGraphCanvasGraphId);
 
         NodeReplacementConfiguration nodeConfiguration;
-        nodeConfiguration.m_nodeSubStyle = ".small";
+        nodeConfiguration.m_nodeSubStyle = GraphCanvas::Styling::Elements::Small;
 
         nodeIdPair.m_graphCanvasId = DisplayGeneralScriptCanvasNode(graphCanvasGraphId, node, nodeConfiguration);
 

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
@@ -13,6 +13,8 @@
 #include <ScriptCanvas/Bus/NodeIdPair.h>
 #include <ScriptCanvas/Core/SubgraphInterfaceUtility.h>
 #include <ScriptCanvas/Variable/VariableCore.h>
+#include <ScriptCanvas/Data/Data.h>
+
 
 namespace ScriptCanvas
 {
@@ -26,6 +28,14 @@ namespace ScriptEvents
 
 namespace ScriptCanvasEditor::Nodes
 {
+    struct SmallOperatorNodeData
+    {
+        ScriptCanvas::ScriptCanvasId m_scriptCanvasId;
+        AZStd::string m_name;
+        AZStd::string m_tooltip;
+        ScriptCanvas::Data::Type m_dataType;
+    };
+
     // Specific create methods which will also handle displaying the node.
     AZStd::pair<ScriptCanvas::Node*, NodeIdPair> CreateAndGetNode(const AZ::Uuid& classData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const StyleConfiguration& styleConfiguration, AZStd::function<void(ScriptCanvas::Node*)> = nullptr);
     NodeIdPair CreateNode(const AZ::Uuid& classData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const StyleConfiguration& styleConfiguration);
@@ -33,6 +43,9 @@ namespace ScriptCanvasEditor::Nodes
     NodeIdPair CreateObjectMethodOverloadNode(AZStd::string_view className, AZStd::string_view methodName, const ScriptCanvas::ScriptCanvasId& scriptCanvasGraphId);
     NodeIdPair CreateGlobalMethodNode(AZStd::string_view methodName, bool isProperty, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
     NodeIdPair CreateEbusWrapperNode(AZStd::string_view busName, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
+
+    // Create method for a small operator node
+    NodeIdPair CreateSmallOperatorNode(const SmallOperatorNodeData& smallOperatorNodeData);
 
     // Script Events
     NodeIdPair CreateScriptEventReceiverNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const AZ::Data::AssetId& assetId);

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -67,11 +67,13 @@ namespace ScriptCanvasEditor::Nodes
 
         if (nodeConfiguration.m_nodeType == NodeType::GeneralNode)
         {
-            GraphCanvas::GraphCanvasRequestBus::BroadcastResult(graphCanvasEntity, &GraphCanvas::GraphCanvasRequests::CreateGeneralNode, nodeConfiguration.m_nodeSubStyle.c_str());
+            GraphCanvas::GraphCanvasRequestBus::BroadcastResult(
+                graphCanvasEntity, &GraphCanvas::GraphCanvasRequests::CreateGeneralNode, nodeConfiguration.m_nodeSubStyle.c_str());
         }
         else if (nodeConfiguration.m_nodeType == NodeType::WrapperNode)
         {
-            GraphCanvas::GraphCanvasRequestBus::BroadcastResult(graphCanvasEntity, &GraphCanvas::GraphCanvasRequests::CreateWrapperNode, nodeConfiguration.m_nodeSubStyle.c_str());
+            GraphCanvas::GraphCanvasRequestBus::BroadcastResult(
+                graphCanvasEntity, &GraphCanvas::GraphCanvasRequests::CreateWrapperNode, nodeConfiguration.m_nodeSubStyle.c_str());
         }
 
         AZ_Assert(graphCanvasEntity, "Unable to create GraphCanvas Bus Node");
@@ -106,7 +108,8 @@ namespace ScriptCanvasEditor::Nodes
         }
 
         GraphCanvas::TranslationKey key;
-        key << ScriptCanvasEditor::TranslationHelper::AssetContext::CustomNodeContext << azrtti_typeid(node).ToString<AZStd::string>() << "details";
+        key << ScriptCanvasEditor::TranslationHelper::AssetContext::CustomNodeContext << azrtti_typeid(node).ToString<AZStd::string>()
+            << "details";
 
         GraphCanvas::TranslationRequests::Details details;
         GraphCanvas::TranslationRequestBus::BroadcastResult(details, &GraphCanvas::TranslationRequests::GetDetails, key, details);
@@ -118,7 +121,8 @@ namespace ScriptCanvasEditor::Nodes
         for (const auto& slot : node->GetSlots())
         {
             GraphCanvas::TranslationKey slotKey;
-            slotKey << ScriptCanvasEditor::TranslationHelper::AssetContext::CustomNodeContext << azrtti_typeid(node).ToString<AZStd::string>() << "slots";
+            slotKey << ScriptCanvasEditor::TranslationHelper::AssetContext::CustomNodeContext
+                    << azrtti_typeid(node).ToString<AZStd::string>() << "slots";
 
             int& index = (slot.IsData() && slot.IsInput()) ? paramIndex : outputIndex;
 
@@ -144,7 +148,8 @@ namespace ScriptCanvasEditor::Nodes
                 slotKey << slotKeyStr << "details";
 
                 GraphCanvas::TranslationRequests::Details slotDetails;
-                GraphCanvas::TranslationRequestBus::BroadcastResult(slotDetails, &GraphCanvas::TranslationRequests::GetDetails, slotKey, slotDetails);
+                GraphCanvas::TranslationRequestBus::BroadcastResult(
+                    slotDetails, &GraphCanvas::TranslationRequests::GetDetails, slotKey, slotDetails);
 
                 if (slotDetails.m_name.empty())
                 {
@@ -179,9 +184,9 @@ namespace ScriptCanvasEditor::Nodes
 
         graphCanvasEntity->SetName(AZStd::string::format("GC-Node(%s)", details.m_name.c_str()));
 
+        GraphCanvas::NodeTitleRequestBus::Event(graphCanvasEntity->GetId(), &GraphCanvas::NodeTitleRequests::SetTitle, details.m_name);
         GraphCanvas::NodeTitleRequestBus::Event(
-            graphCanvasEntity->GetId(), &GraphCanvas::NodeTitleRequests::SetTitle, details.m_name);
-        GraphCanvas::NodeTitleRequestBus::Event(graphCanvasEntity->GetId(), &GraphCanvas::NodeTitleRequests::SetSubTitle, details.m_category);
+            graphCanvasEntity->GetId(), &GraphCanvas::NodeTitleRequests::SetSubTitle, details.m_category);
 
         // Add to the tooltip the C++ class for reference
         if (!details.m_tooltip.empty())
@@ -194,10 +199,12 @@ namespace ScriptCanvasEditor::Nodes
 
         if (!nodeConfiguration.m_titlePalette.empty())
         {
-            GraphCanvas::NodeTitleRequestBus::Event(graphCanvasEntity->GetId(), &GraphCanvas::NodeTitleRequests::SetPaletteOverride, nodeConfiguration.m_titlePalette);
+            GraphCanvas::NodeTitleRequestBus::Event(
+                graphCanvasEntity->GetId(), &GraphCanvas::NodeTitleRequests::SetPaletteOverride, nodeConfiguration.m_titlePalette);
         }
 
-        EditorNodeNotificationBus::Event(node->GetEntityId(), &EditorNodeNotifications::OnGraphCanvasNodeDisplayed, graphCanvasEntity->GetId());
+        EditorNodeNotificationBus::Event(
+            node->GetEntityId(), &EditorNodeNotifications::OnGraphCanvasNodeDisplayed, graphCanvasEntity->GetId());
 
         return graphCanvasEntity->GetId();
     }
@@ -1100,6 +1107,7 @@ namespace ScriptCanvasEditor::Nodes
 ///////////////////
 // Header Methods
 ///////////////////
+
     AZ::EntityId DisplayScriptCanvasNode(AZ::EntityId graphCanvasGraphId, const ScriptCanvas::Node* node)
     {
         AZ_PROFILE_FUNCTION(ScriptCanvas);

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.h
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.h
@@ -41,6 +41,8 @@ namespace ScriptCanvasEditor::Nodes
     // Generic method of displaying a node.
     AZ::EntityId DisplayScriptCanvasNode(AZ::EntityId graphCanvasGraphId, const ScriptCanvas::Node* node);
 
+    AZ::EntityId DisplayGeneralScriptCanvasNode(AZ::EntityId, const ScriptCanvas::Node* node, const NodeReplacementConfiguration& nodeConfiguration);
+
     // Core Node
     AZ::EntityId DisplayEbusEventNode(AZ::EntityId graphCanvasGraphId, const AZStd::string& busName, const AZStd::string& eventName, const ScriptCanvas::EBusEventId& eventId);
     AZ::EntityId DisplayEbusWrapperNode(AZ::EntityId graphCanvasGraphId, const ScriptCanvas::Nodes::Core::EBusEventHandler* busNode);

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -280,6 +280,17 @@ namespace ScriptCanvasEditor
         styleConfiguration.m_nodeSubStyle = m_styleOverride;
         styleConfiguration.m_titlePalette = m_titlePalette;
 
+        // TODO: Make created node dependant on data given rather than type id
+        if (m_typeId.IsNull())
+        {
+            Nodes::SmallOperatorNodeData nodeData;
+            nodeData.m_scriptCanvasId = scriptCanvasId;
+            nodeData.m_name = "++";
+            nodeData.m_tooltip = "Increments a node";
+            nodeData.m_dataType = ScriptCanvas::Data::Type::Number();
+
+            return Nodes::CreateSmallOperatorNode(nodeData);
+        }
         return Nodes::CreateNode(m_typeId, scriptCanvasId, styleConfiguration);
     }
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.cpp
@@ -223,6 +223,7 @@ namespace ScriptCanvas
         , m_dynamicDataType(DynamicDataType::None)
         , m_id(slotConfiguration.m_slotId)
         , m_isVisible(slotConfiguration.m_isVisible)
+        , m_canHaveInputField(slotConfiguration.m_canHaveInputField)
     {
         if (!slotConfiguration.m_displayGroup.empty())
         {
@@ -429,6 +430,11 @@ namespace ScriptCanvas
     bool Slot::IsVariableReference() const
     {
         return m_isVariableReference || m_dataType == DataType::VariableReference;
+    }
+
+    bool Slot::CanHaveInputField() const
+    {
+        return m_canHaveInputField;
     }
 
     bool Slot::CanConvertToValue() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -183,8 +183,6 @@ namespace ScriptCanvas
 
         bool IsLatent() const;
 
-        bool NeedsNodeProperyDisplay() const;
-
         // Here to allow conversion of the previously untyped any slots into the dynamic type any.
         void SetDynamicDataType(DynamicDataType dynamicDataType);
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Slot.h
@@ -150,6 +150,8 @@ namespace ScriptCanvas
         // Or a value data pin.
         bool IsVariableReference() const;
 
+        bool CanHaveInputField() const;
+
         bool CanConvertTypes() const;
 
         bool CanConvertToValue() const;
@@ -180,6 +182,8 @@ namespace ScriptCanvas
         ScriptCanvas::ConnectionType GetConnectionType() const;
 
         bool IsLatent() const;
+
+        bool NeedsNodeProperyDisplay() const;
 
         // Here to allow conversion of the previously untyped any slots into the dynamic type any.
         void SetDynamicDataType(DynamicDataType dynamicDataType);
@@ -235,6 +239,8 @@ namespace ScriptCanvas
         AZ::Crc32 m_displayGroup;
         AZ::Crc32 m_dynamicGroup;
 
+        bool m_canHaveInputField = false;
+
         bool               m_isLatentSlot  = false;
         SlotDescriptor     m_descriptor;
 
@@ -251,5 +257,7 @@ namespace ScriptCanvas
         Node*  m_node;
 
         AZStd::vector<AZStd::unique_ptr<Contract>> m_contracts;
+
+        bool m_needsNodePropertyDisplay = true;
     };
 } 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/SlotConfigurations.h
@@ -228,6 +228,7 @@ namespace ScriptCanvas
         bool m_isVisible = true;
         bool m_isLatent = false;
         bool m_isUserAdded = false;
+        bool m_canHaveInputField = true;
 
         AZStd::vector<ContractDescriptor> m_contractDescs;
         bool m_addUniqueSlotByNameAndType = true; // Only adds a new slot if a slot with the supplied name and CombinedSlotType does not exist on the node

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/SystemComponent.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/SystemComponent.h
@@ -74,6 +74,7 @@ namespace ScriptCanvas
         ScriptCanvasId FindScriptCanvasId(AZ::Entity* graphEntity) override;
         ScriptCanvas::Node* GetNode(const AZ::EntityId&, const AZ::Uuid&) override;
         ScriptCanvas::Node* CreateNodeOnEntity(const AZ::EntityId& entityId, ScriptCanvasId scriptCanvasId, const AZ::Uuid& nodeType) override;
+
         SystemComponentConfiguration GetSystemComponentConfiguration() override
         {
             SystemComponentConfiguration configuration;

--- a/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Source/SystemComponent.cpp
@@ -225,70 +225,24 @@ namespace ScriptCanvas
         return nullptr;
     }
 
-    ScriptCanvas::Node* CreateIncrementNode()
-    {
-        ScriptCanvas::Node* node = aznew Node;
-        node->SetNodeName("++");
-
-        DynamicDataSlotConfiguration inputPin;
-
-        inputPin.m_name = " ";
-        inputPin.m_toolTip = "Input";
-        inputPin.SetConnectionType(ConnectionType::Input);
-        inputPin.m_displayType = Data::Type::Number();
-
-        node->AddSlot(inputPin, true);
-
-        DynamicDataSlotConfiguration outputPin;
-
-        outputPin.m_name = " ";
-        outputPin.m_toolTip = "Output";
-        outputPin.SetConnectionType(ConnectionType::Output);
-        outputPin.m_displayType = Data::Type::Number();
-
-        node->AddSlot(outputPin, true);
-
-        return node;
-    }
-
     ScriptCanvas::Node* SystemComponent::CreateNodeOnEntity(const AZ::EntityId& entityId, ScriptCanvasId scriptCanvasId, const AZ::Uuid& nodeType)
     {
-        if (!nodeType.IsNull())
-        {
-            AZ::SerializeContext* serializeContext = nullptr;
-            AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
-            AZ_Assert(serializeContext, "Failed to retrieve application serialize context");
+        AZ::SerializeContext* serializeContext = nullptr;
+        AZ::ComponentApplicationBus::BroadcastResult(serializeContext, &AZ::ComponentApplicationRequests::GetSerializeContext);
+        AZ_Assert(serializeContext, "Failed to retrieve application serialize context");
 
-            const AZ::SerializeContext::ClassData* classData = serializeContext->FindClassData(nodeType);
-            AZ_Assert(classData, "Type %s is not registered in the serialization context", nodeType.ToString<AZStd::string>().data());
+        const AZ::SerializeContext::ClassData* classData = serializeContext->FindClassData(nodeType);
+        AZ_Assert(classData, "Type %s is not registered in the serialization context", nodeType.ToString<AZStd::string>().data());
 
-            if (classData)
-            {
-                AZ::Entity* nodeEntity = nullptr;
-                AZ::ComponentApplicationBus::BroadcastResult(nodeEntity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
-                ScriptCanvas::Node* node = reinterpret_cast<ScriptCanvas::Node*>(classData->m_factory->Create(classData->m_name));
-                AZ_Assert(node, "ClassData (%s) does not correspond to a supported ScriptCanvas Node", classData->m_name);
-                if (node && nodeEntity)
-                {
-                    nodeEntity->SetName(classData->m_name);
-                    nodeEntity->AddComponent(node);
-                }
-
-                GraphRequestBus::Event(scriptCanvasId, &GraphRequests::AddNode, nodeEntity->GetId());
-                return node;
-            }
-        }
-        else
+        if (classData)
         {
             AZ::Entity* nodeEntity = nullptr;
             AZ::ComponentApplicationBus::BroadcastResult(nodeEntity, &AZ::ComponentApplicationRequests::FindEntity, entityId);
-
-            // For now, just create an increment node if the Uuid is null
-            ScriptCanvas::Node* node = CreateIncrementNode();
-
+            ScriptCanvas::Node* node = reinterpret_cast<ScriptCanvas::Node*>(classData->m_factory->Create(classData->m_name));
+            AZ_Assert(node, "ClassData (%s) does not correspond to a supported ScriptCanvas Node", classData->m_name);
             if (node && nodeEntity)
             {
-                nodeEntity->SetName(node->GetNodeName());
+                nodeEntity->SetName(classData->m_name);
                 nodeEntity->AddComponent(node);
             }
 


### PR DESCRIPTION
Now draws the small operator node as a differently styled node. For the ease of creation of new types of nodes like this one, I also moved some of the code around for sending GraphCanvas the draw request. There is now a function in NodeCreateUtils that creates the node based on some data provided in its parameters. The small operator nodes do not generate an input field when their input data pin is not connected.

<img width="390" alt="Untitled" src="https://user-images.githubusercontent.com/105814224/173417620-fc54f9cc-525b-4214-a6de-104060847578.png">

