### PR TITLE
Asset Processor - Intermediate Assets - Fix Job Deletion Issue

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -2424,7 +2424,7 @@ namespace AssetProcessor
 
         m_knownFolders.remove(normalizedPath);
 
-        SourceFolderDeleted(sourceName);
+        SourceFolderDeleted(normalizedPath);
     }
 
     namespace

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/JobsModel.cpp
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/JobsModel.cpp
@@ -463,26 +463,6 @@ namespace AssetProcessor
         }
     }
 
-    void JobsModel::OnFolderRemoved(QString folderPath)
-    {
-        QList<AssetProcessor::QueueElementID> elementsToRemove;
-        for (int index = 0; index < m_cachedJobs.size(); ++index)
-        {
-            if (m_cachedJobs[index]->m_elementId.GetInputAssetName().startsWith(folderPath, Qt::CaseSensitive))
-            {
-                elementsToRemove.push_back(m_cachedJobs[index]->m_elementId);
-            }
-        }
-
-        // now that we've collected all the elements to remove, we can remove them.  
-        // Doing it this way avoids problems with mutating these cache structures while iterating them.
-        for (const AssetProcessor::QueueElementID& removal : elementsToRemove)
-        {
-            RemoveJob(removal);
-        }
-
-    }
-
     void JobsModel::OnJobRemoved(AzToolsFramework::AssetSystem::JobInfo jobInfo)
     {
         RemoveJob(QueueElementID(jobInfo.m_sourceFile.c_str(), jobInfo.m_platform.c_str(), jobInfo.m_jobKey.c_str()));

--- a/Code/Tools/AssetProcessor/native/resourcecompiler/JobsModel.h
+++ b/Code/Tools/AssetProcessor/native/resourcecompiler/JobsModel.h
@@ -92,7 +92,6 @@ public Q_SLOTS:
         void OnJobStatusChanged(JobEntry entry, AzToolsFramework::AssetSystem::JobStatus status);
         void OnJobRemoved(AzToolsFramework::AssetSystem::JobInfo jobInfo);
         void OnSourceRemoved(QString sourceDatabasePath);
-        void OnFolderRemoved(QString folderPath);
 
     protected:
         QIcon m_pendingIcon;

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/AssetProcessorManagerTest.cpp
@@ -3585,7 +3585,7 @@ TEST_F(AssetProcessorManagerTest, SourceFile_With_NonASCII_Characters_Fail_Job_O
     folderPathDir.removeRecursively();
     m_assetProcessorManager.get()->AssessDeletedFile(folderPath);
     ASSERT_TRUE(BlockUntilIdle(5000));
-    EXPECT_EQ(deletedFolderPath, "Test\xD0");
+    EXPECT_EQ(deletedFolderPath, folderPath);
 }
 
 TEST_F(AssetProcessorManagerTest, SourceFileProcessFailure_ClearsFingerprint)

--- a/Code/Tools/AssetProcessor/native/tests/assetmanager/ModtimeScanningTests.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/assetmanager/ModtimeScanningTests.cpp
@@ -685,7 +685,7 @@ namespace UnitTests
         ASSERT_TRUE(BlockUntilIdle(5000));
 
         ASSERT_THAT(m_data->m_deletedSources, testing::UnorderedElementsAre("textures/a.txt"));
-        ASSERT_THAT(deletedFolders, testing::UnorderedElementsAre("textures"));
+        ASSERT_THAT(deletedFolders, testing::UnorderedElementsAre(absPath.toUtf8().constData()));
     }
 
     TEST_F(LockedFileTest, DeleteFile_LockedProduct_DeleteFails)

--- a/Code/Tools/AssetProcessor/native/tests/utilities/JobModelTest.cpp
+++ b/Code/Tools/AssetProcessor/native/tests/utilities/JobModelTest.cpp
@@ -130,39 +130,6 @@ TEST_F(JobModelUnitTests, Test_RemoveAllJobsBySource)
     }
 }
 
-TEST_F(JobModelUnitTests, Test_RemoveAllJobsBySourceFolder)
-{
-    VerifyModel(); // verify up front for sanity.
-
-    AssetProcessor::CachedJobInfo* testJobInfo = new AssetProcessor::CachedJobInfo();
-    testJobInfo->m_elementId.SetInputAssetName("sourceFolder1/source.txt");
-    testJobInfo->m_elementId.SetPlatform("platform");
-    testJobInfo->m_elementId.SetJobDescriptor("jobKey");
-
-    testJobInfo->m_jobState = AzToolsFramework::AssetSystem::JobStatus::Completed;
-    m_unitTestJobModel->m_cachedJobs.push_back(testJobInfo);
-    m_unitTestJobModel->m_cachedJobsLookup.insert(testJobInfo->m_elementId, aznumeric_caster(m_unitTestJobModel->m_cachedJobs.size() - 1));
-
-    AssetProcessor::QueueElementID elementId("sourceFolder1/source.txt", "platform", "jobKey");
-    auto iter = m_unitTestJobModel->m_cachedJobsLookup.find(elementId);
-    ASSERT_NE(iter, m_unitTestJobModel->m_cachedJobsLookup.end());
-    unsigned int jobIndex = iter.value();
-    ASSERT_EQ(jobIndex, 6); //last job
-
-    ASSERT_EQ(m_unitTestJobModel->m_cachedJobs.size(), 7);
-    m_unitTestJobModel->OnFolderRemoved("sourceFolder1");
-
-    ASSERT_EQ(m_unitTestJobModel->m_cachedJobs.size(), 6);
-    VerifyModel();
-
-    // make sure sourceFolder1/source.txt is completely gone.
-    for (int idx = 0; idx < m_unitTestJobModel->m_cachedJobs.size(); idx++)
-    {
-        AssetProcessor::CachedJobInfo* jobInfo = m_unitTestJobModel->m_cachedJobs[idx];
-        ASSERT_NE(jobInfo->m_elementId.GetInputAssetName(), QString::fromUtf8("sourceFolder1/source.txt"));
-    }
-}
-
 void JobModelUnitTests::SetUp()
 {
     AssetProcessorTest::SetUp();

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -446,7 +446,6 @@ void MainWindow::Activate()
     connect(m_guiApplicationManager->GetRCController(), &AssetProcessor::RCController::JobStatusChanged, m_jobsModel, &AssetProcessor::JobsModel::OnJobStatusChanged);
     connect(m_guiApplicationManager->GetAssetProcessorManager(), &AssetProcessor::AssetProcessorManager::JobRemoved, m_jobsModel, &AssetProcessor::JobsModel::OnJobRemoved);
     connect(m_guiApplicationManager->GetAssetProcessorManager(), &AssetProcessor::AssetProcessorManager::SourceDeleted, m_jobsModel, &AssetProcessor::JobsModel::OnSourceRemoved);
-    connect(m_guiApplicationManager->GetAssetProcessorManager(), &AssetProcessor::AssetProcessorManager::SourceFolderDeleted, m_jobsModel, &AssetProcessor::JobsModel::OnFolderRemoved);
 
     connect(ui->jobTreeView, &AzQtComponents::TableView::customContextMenuRequested, this, &MainWindow::ShowJobViewContextMenu);
     connect(ui->jobContextLogTableView, &AzQtComponents::TableView::customContextMenuRequested, this, &MainWindow::ShowLogLineContextMenu);


### PR DESCRIPTION
Fixes an issue with all jobs in the UI being removed when scan folders are deleted.

AP was sending out a SourceFolderDeleted message with a relative path of "", which the JobsModel was listening to and deleting every job that began with "" (aka everything).

Since there is already an event for each file deleted, this event wasn't needed and can just be removed.