### PR TITLE
Clean up template and xml by removing useless lines

### DIFF
--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Header.jinja
@@ -43,8 +43,13 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 namespace {{attribute_Namespace}}
 {
 {% endif %}
-{% set className = Class.attrib['Name'] %}
-{% set baseClasses = ", ".join(Class.attrib['Base'].split(';')) if Class.attrib['Base'] is string else "ScriptCanvas::Node" %}
+
+{%- set className = Class.attrib['Name'] %}
+
+{%- set baseClass = "ScriptCanvas::Node" %}
+{% if Class.attrib['Base'] is defined and Class.attrib['Base'] %}
+{%    set baseClass = Class.attrib['Base'] %}
+{% endif %}
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////
@@ -64,7 +69,7 @@ namespace {{attribute_Namespace}}
 // You must #include the generated header into the source header
 #define SCRIPTCANVAS_NODE_{{ className }} \
 public: \
-    AZ_COMPONENT({{ className }}, "{{ classUuid }}", {{ baseClasses }} ); \
+    AZ_COMPONENT({{ className }}, "{{ classUuid }}", {{ baseClass }} ); \
     static void Reflect(AZ::ReflectContext* reflection); \
     void ConfigureSlots() override; \
     bool RequiresDynamicSlotOrdering() const override; \

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasGrammar_Source.jinja
@@ -29,9 +29,14 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 #include "{{ xml.attrib['Include'] }}"
 
 {%     for Class in xml.iter('Class') %}
-{% set baseClass = Class.attrib['Base'].split(';')[0] if Class.attrib['Base'] is string else "ScriptCanvas::Node" %}
-{% set attribute_Namespace = undefined %}
-{%- if Class.attrib['Namespace'] is defined %}
+
+{%- set baseClass = "ScriptCanvas::Node" %}
+{% if Class.attrib['Base'] is defined and Class.attrib['Base'] %}
+{%    set baseClass = Class.attrib['Base'] %}
+{% endif %}
+
+{%- set attribute_Namespace = undefined %}
+{% if Class.attrib['Namespace'] is defined %}
 {%      if Class.attrib['Namespace'] != "None" %}
 {%          set attribute_Namespace = Class.attrib['Namespace'] %}
 {%      endif %}
@@ -221,6 +226,8 @@ void {{ Class.attrib['QualifiedName'] }}::Reflect(AZ::ReflectContext* context)
 {% endif %}
 {% if Class.attrib['Version'] is defined %}
             ->Version({{ Class.attrib['Version'] }}{% if Class.attrib['VersionConverter'] is defined %}, &{{ Class.attrib['VersionConverter'] }}{% endif %})
+{% else %}
+            ->Version(0)
 {% endif %}
 {% for Property in Class.iter('SerializedProperty') %}
             ->Field("{{ Property.attrib['Name'] }}", &{{ Class.attrib['Name'] }}::{{ Property.attrib['Name'] | replace(' ','') }})

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Header.jinja
@@ -44,9 +44,9 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {%      endif %}
 {% endif %}
 
-{%- set attribute_Base = Class.attrib['Base']  %}
-{% if not Class.attrib['Base'] is defined %}
-{%    set attribute_Base = "ScriptCanvas::Nodeable" %}
+{% set attribute_Base = "ScriptCanvas::Nodeable" %}
+{% if Class.attrib['Base'] is defined and Class.attrib['Base'] %}
+{%    set attribute_Base = Class.attrib['Base'] %}
 {% endif %}
 
 {% if attribute_Namespace is defined %}
@@ -70,7 +70,7 @@ namespace {{attribute_Namespace}}
 // You must #include the generated header into the source header
 #define SCRIPTCANVAS_NODE_{{className}} \
 public: \
-    AZ_RTTI({{className}}, "{{nodeableClassName|createHashGuid}}"{% if Class.attrib['Base'] is defined %}, {{ Class.attrib['Base'] }}{% endif %}); \
+    AZ_RTTI({{className}}, "{{nodeableClassName|createHashGuid}}", {{attribute_Base}}); \
     static void Reflect(AZ::ReflectContext* reflection); \
     static void ExtendReflectionSerialize([[maybe_unused]] AZ::SerializeContext::ClassBuilder* builder){% if Class.attrib['ExtendReflectionSerialize'] is defined %};{% else %}{}{% endif %} \
     static void ExtendReflectionEdit([[maybe_unused]] AZ::EditContext::ClassBuilder* builder){% if Class.attrib['ExtendReflectionEdit'] is defined %};{% else %}{}{% endif %} \
@@ -112,10 +112,10 @@ public: \
 
               size_t GenerateFingerprint() const override;
 
-{% if Class.attrib['EntryPoint'] is defined and Class.attrib['EntryPoint'] == "true" %}
+{% if Class.attrib['GraphEntryPoint'] is defined and Class.attrib['GraphEntryPoint'] == "True" %}
               bool IsEntryPoint() const override { return true; }
-
 {% endif %}
+
               {{nodeableNodeName}}();
 
               {{Class.attrib['NodeDeclarations']}}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasNodeable_Source.jinja
@@ -45,14 +45,13 @@ SPDX-License-Identifier: Apache-2.0 OR MIT
 {%- set attribute_EventHandler = Class.attrib['EventHandler'] %}
 {%- set attribute_Deprecated = Class.attrib['Deprecated'] %}
 
-
-{%- set attribute_Base = Class.attrib['Base']  %}
-{% if not Class.attrib['Base'] is defined %}
-{%    set attribute_Base = "ScriptCanvas::Nodeable" %}
+{%- set attribute_Base = "ScriptCanvas::Nodeable" %}
+{% if Class.attrib['Base'] is defined and Class.attrib['Base'] %}
+{%    set attribute_Base = Class.attrib['Base'] %}
 {% endif %}
 
-{% set attribute_Namespace = undefined %}
-{%- if Class.attrib['Namespace'] is defined %}
+{%- set attribute_Namespace = undefined %}
+{% if Class.attrib['Namespace'] is defined %}
 {%      if Class.attrib['Namespace'] != "None" %}
 {%          set attribute_Namespace = Class.attrib['Namespace'] %}
 {%      endif %}
@@ -159,7 +158,7 @@ void {{attribute_QualifiedName}}::Reflect(AZ::ReflectContext* context)
 
     if (AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
     {
-{% if ExtendReflectionSerialize is defined %}   auto {{preSerialize}} = {% else %}   {% endif %}serializeContext->Class<{{ attribute_Name }}{% if attribute_Base is defined %}, {{ attribute_Base }}{% endif %}>(){{postSerialize}}
+{% if ExtendReflectionSerialize is defined %}   auto {{preSerialize}} = {% else %}   {% endif %}serializeContext->Class<{{ attribute_Name }}, {{ attribute_Base }}>(){{postSerialize}}
 {% if attribute_EventHandler is defined %}
 #if defined(OBJECT_STREAM_EDITOR_ASSET_LOADING_SUPPORT_ENABLED)////
             {{preSerialize}}->EventHandler<{{ attribute_EventHandler }}>(){{postSerialize}}

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Internal/Nodeables/BaseTimer.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Internal/Nodeables/BaseTimer.ScriptCanvasNodeable.xml
@@ -2,33 +2,25 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Internal/Nodeables/BaseTimer.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="BaseTimer"
-         QualifiedName="ScriptCanvas::Nodeables::Time::BaseTimer"
-         PreferredClassName="BaseTimer"
-           Uuid="{64814C82-DAE5-9B04-B375-5E47D51ECD26}"
-           BaseClass="True"
-           Base="ScriptCanvas::Nodeable"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Utilities"
-           Version="0"
-           EntryPoint="true"
-           GeneratePropertyFriend="False"
-           Description="Provides a basic interaciton layer for all time based nodes for users(handles swapping between ticks and seconds).">
+        QualifiedName="ScriptCanvas::Nodeables::Time::BaseTimer"
+        PreferredClassName="BaseTimer"
+        Uuid="{64814C82-DAE5-9B04-B375-5E47D51ECD26}"
+        BaseClass="True"
+        Category="Timing"
+        Description="Provides a basic interaciton layer for all time based nodes for users(handles swapping between ticks and seconds).">
 
-      <Property Name="m_timeUnits" Type="int" DefaultValue="0" Serialize="true">
-        <PropertyData Name="Units"
-                      Description="Units to represent the time in."
-                      Serialize="true"
-                      UIHandler="AZ::Edit::UIHandlers::ComboBox">
-          <EditAttribute Key="AZ::Edit::Attributes::GenericValueList" Value="&amp;BaseTimer::GetTimeUnitList"/>
-          <EditAttribute Key="AZ::Edit::Attributes::PostChangeNotify" Value="&amp;BaseTimer::OnTimeUnitsChanged"/>
-        </PropertyData>
-      </Property>
+        <Property Name="m_timeUnits" Type="int" DefaultValue="0" Serialize="true">
+            <PropertyData Name="Units"
+                Description="Units to represent the time in."
+                Serialize="true"
+                UIHandler="AZ::Edit::UIHandlers::ComboBox">
+                <EditAttribute Key="AZ::Edit::Attributes::GenericValueList" Value="&amp;BaseTimer::GetTimeUnitList"/>
+                <EditAttribute Key="AZ::Edit::Attributes::PostChangeNotify" Value="&amp;BaseTimer::OnTimeUnitsChanged"/>
+            </PropertyData>
+        </Property>
 
-      <Property Name="m_tickOrder" Type="int" DefaultValue="static_cast&lt;int&gt;(AZ::TICK_DEFAULT)" Serialize="true">
-        <PropertyData Name="TickOrder"
-                      Description="When the tick for this time update should be handled."
-                      />
-      </Property>
-
+        <Property Name="m_tickOrder" Type="int" DefaultValue="static_cast&lt;int&gt;(AZ::TICK_DEFAULT)" Serialize="true">
+            <PropertyData Name="TickOrder" Description="When the tick for this time update should be handled."/>
+        </Property>
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Internal/Nodes/BaseTimerNode.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Internal/Nodes/BaseTimerNode.ScriptCanvasGrammar.xml
@@ -2,23 +2,18 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Internal/Nodes/BaseTimerNode.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="BaseTimerNode"
-	       QualifiedName="ScriptCanvas::Nodes::Internal::BaseTimerNode"
-	       PreferredClassName="BaseTimerNode"
-           Uuid="{BAD6C904-6078-49E8-B461-CA4410B785A4}"
-           Base="ScriptCanvas::Node"
-           BaseClass="True"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Utilities"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="Provides a basic interaction layer for all time based nodes for users(handles swapping between ticks and seconds).">
+        QualifiedName="ScriptCanvas::Nodes::Internal::BaseTimerNode"
+        PreferredClassName="BaseTimerNode"
+        Uuid="{BAD6C904-6078-49E8-B461-CA4410B785A4}"
+        BaseClass="True"
+        Category="Utilities"
+        Description="Provides a basic interaction layer for all time based nodes for users(handles swapping between ticks and seconds).">
         <SerializedProperty Name="m_timeUnits" />
         <SerializedProperty Name="m_tickOrder" />
         <EditProperty UiHandler="AZ::Edit::UIHandlers::ComboBox" FieldName="m_timeUnits" Name="m_timeUnits" >
             <EditAttribute Key="AZ::Edit::Attributes::GenericValueList" Value="&amp;BaseTimerNode::GetTimeUnitList"/>
             <EditAttribute Key="AZ::Edit::Attributes::PostChangeNotify" Value="&amp;BaseTimerNode::OnTimeUnitsChanged"/>
         </EditProperty>
-        <EditProperty UiHandler="AZ::Edit::UIHandlers::Default" FieldName="m_tickOrder" Name="m_tickOrder" >
-        </EditProperty>
+        <EditProperty UiHandler="AZ::Edit::UIHandlers::Default" FieldName="m_tickOrder" Name="m_tickOrder"/>
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Internal/Nodes/ExpressionNodeBase.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Internal/Nodes/ExpressionNodeBase.ScriptCanvasGrammar.xml
@@ -2,16 +2,13 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Internal/Nodes/ExpressionNodeBase.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="ExpressionNodeBase"
-	       QualifiedName="ScriptCanvas::Nodes::Internal::ExpressionNodeBase"
-	       PreferredClassName="ExpressionNodeBase"
-           Uuid="{797C800D-8C96-4675-B5B5-2A321AC09433}"
-           BaseClass="True"
-           Base="ScriptCanvas::Node"
-           Category="Internal"
-           Version="0"
-           DynamicSlotOrdering="True"
-           GeneratePropertyFriend="True"
-           Description="Base class for any node that wants to evaluate user given expressions.">
+        QualifiedName="ScriptCanvas::Nodes::Internal::ExpressionNodeBase"
+        PreferredClassName="ExpressionNodeBase"
+        Uuid="{797C800D-8C96-4675-B5B5-2A321AC09433}"
+        BaseClass="True"
+        Category="Internal"
+        DynamicSlotOrdering="True"
+        Description="Base class for any node that wants to evaluate user given expressions.">
         <In Name="In" Description="Input signal"/>
         <SerializedProperty Name="m_format" />
         <SerializedProperty Name="m_expressionTree" />

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Internal/Nodes/StringFormatted.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Internal/Nodes/StringFormatted.ScriptCanvasGrammar.xml
@@ -2,16 +2,14 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Internal/Nodes/StringFormatted.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="StringFormatted"
-           QualifiedName="ScriptCanvas::Nodes::Internal::StringFormatted"
-           PreferredClassName="StringFormatted"
-           Uuid="{0B1577E0-339D-4573-93D1-6C311AD12A13}"
-           BaseClass="True"
-           Base="ScriptCanvas::Node"
-           Category="Internal"
-           Version="1"
-           DynamicSlotOrdering="True"
-           GeneratePropertyFriend="True"
-           Description="Base class for any nodes that use string formatting capabilities.">
+        QualifiedName="ScriptCanvas::Nodes::Internal::StringFormatted"
+        PreferredClassName="StringFormatted"
+        Uuid="{0B1577E0-339D-4573-93D1-6C311AD12A13}"
+        BaseClass="True"
+        Category="Internal"
+        Version="1"
+        DynamicSlotOrdering="True"
+        Description="Base class for any nodes that use string formatting capabilities.">
         <In Name="In" Description="Input signal"/>
         <Out Name="Out" Description=""/>
         <SerializedProperty Name="m_format" />

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/EqualTo.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/EqualTo.h
@@ -34,6 +34,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<EqualTo>("Equal To (==)", "Checks if Value A and Value B are equal to each other")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Math/Comparisons")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/Greater.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/Greater.h
@@ -34,6 +34,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<Greater>("Greater Than (>)", "Checks if Value A is greater than Value B")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Math/Comparisons")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/GreaterEqual.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/GreaterEqual.h
@@ -34,6 +34,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<GreaterEqual>("Greater Than or Equal To (>=)", "Checks if Value A is greater than or equal to Value B")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Math/Comparisons")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/Less.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/Less.h
@@ -34,6 +34,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<Less>("Less Than (<)", "Checks if Value A is less than Value B")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Math/Comparisons")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/LessEqual.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/LessEqual.h
@@ -34,6 +34,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<LessEqual>("Less Than or Equal To (<=)", "Checks if Value A is less than or equal to Value B")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Math/Comparisons")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/NotEqualTo.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Comparison/NotEqualTo.h
@@ -34,6 +34,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<NotEqualTo>("Not Equal To (!=)", "Checks if Value A is not equal to Value B")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Math/Comparisons")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/AzEventHandler.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/AzEventHandler.ScriptCanvasGrammar.xml
@@ -4,9 +4,6 @@
         QualifiedName="ScriptCanvas::Nodes::Core::AzEventHandler"
         PreferredClassName="AZ Event Handler"
         Uuid="{38B808C5-152C-4643-A08C-463EBED55E19}"
-        Base="ScriptCanvas::Node"
-        Icon="Icons/ScriptCanvas/AzEvent.png"
-        Version="0"
         EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
         GraphEntryPoint="True"
         Description="Handler for an AZ::Event returned from a BehaviorContent method.">

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/EBusEventHandler.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="EBusEventHandler"
-	    QualifiedName="ScriptCanvas::Nodes::Core::EBusEventHandler"
-	    PreferredClassName="Event Handler"
+        QualifiedName="ScriptCanvas::Nodes::Core::EBusEventHandler"
+        PreferredClassName="Event Handler"
         Uuid="{33E12915-EFCA-4AA7-A188-D694DAD58980}"
         Version="5"
         VersionConverter="ScriptCanvas::VersionConverters::EBusEventHandlerVersionConverter"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/EBusEventHandler.ScriptCanvasGrammar.xml
@@ -2,18 +2,15 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/EBusEventHandler.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="EBusEventHandler"
-	       QualifiedName="ScriptCanvas::Nodes::Core::EBusEventHandler"
-	       PreferredClassName="Event Handler"
-           Uuid="{33E12915-EFCA-4AA7-A188-D694DAD58980}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/Bus.png"
-           Version="5"
-           VersionConverter="ScriptCanvas::VersionConverters::EBusEventHandlerVersionConverter"
-           EventHandler="SerializeContextOnWriteEndHandler&lt;EBusEventHandler&gt;"
-           EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-           GraphEntryPoint="True"
-           GeneratePropertyFriend="True"
-           Description="Allows you to handle a event.">
+	    QualifiedName="ScriptCanvas::Nodes::Core::EBusEventHandler"
+	    PreferredClassName="Event Handler"
+        Uuid="{33E12915-EFCA-4AA7-A188-D694DAD58980}"
+        Version="5"
+        VersionConverter="ScriptCanvas::VersionConverters::EBusEventHandlerVersionConverter"
+        EventHandler="SerializeContextOnWriteEndHandler&lt;EBusEventHandler&gt;"
+        EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
+        GraphEntryPoint="True"
+        Description="Allows you to handle a event.">
         <In Name="Connect" Description="Connect this event handler to the specified entity."/>
         <In Name="Disconnect" Description="Disconnect this event handler."/>
         <Out Name="OnConnected" Description="Signaled when a connection has taken place."/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ExtractProperty.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ExtractProperty.ScriptCanvasGrammar.xml
@@ -2,22 +2,19 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/ExtractProperty.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="ExtractProperty"
-	       QualifiedName="ScriptCanvas::Nodes::Core::ExtractProperty"
-	       PreferredClassName="Extract Properties"
-           Uuid="{D4C9DA8E-838B-41C6-B870-C75294C323DC}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Utilities"
-           Version="1"
-           VersionConverter="VersionConverter"
-           GeneratePropertyFriend="True"
-           Description="Extracts property values from connected input">
+	    QualifiedName="ScriptCanvas::Nodes::Core::ExtractProperty"
+	    PreferredClassName="Extract Properties"
+        Uuid="{D4C9DA8E-838B-41C6-B870-C75294C323DC}"
+        Category="Utilities"
+        Version="1"
+        VersionConverter="VersionConverter"
+        Description="Extracts property values from connected input">
         <In Name="In" Description="When signaled assigns property values using the supplied source input"/>
         <Out Name="Out" Description="Signaled after all property haves have been pushed to the output slots"/>
         <DynamicDataSlot Name="Source"
-                         Description="The value on which to extract properties from."
-                         ConnectionType="ScriptCanvas::ConnectionType::Input"
-                         DynamicType="ScriptCanvas::DynamicDataType::Value" />
+            Description="The value on which to extract properties from."
+            ConnectionType="ScriptCanvas::ConnectionType::Input"
+            DynamicType="ScriptCanvas::DynamicDataType::Value" />
         <SerializedProperty Name="m_dataType" />
         <SerializedProperty Name="m_propertyAccounts" />
     </Class>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ExtractProperty.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ExtractProperty.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/ExtractProperty.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="ExtractProperty"
-	    QualifiedName="ScriptCanvas::Nodes::Core::ExtractProperty"
-	    PreferredClassName="Extract Properties"
+        QualifiedName="ScriptCanvas::Nodes::Core::ExtractProperty"
+        PreferredClassName="Extract Properties"
         Uuid="{D4C9DA8E-838B-41C6-B870-C75294C323DC}"
         Category="Utilities"
         Version="1"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ForEach.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ForEach.ScriptCanvasGrammar.xml
@@ -2,16 +2,13 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/ForEach.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="ForEach"
-	       QualifiedName="ScriptCanvas::Nodes::Core::ForEach"
-	       PreferredClassName="For Each"
-           Uuid="{31823035-A3FF-4B8D-A3A6-819519478B7C}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Containers"
-           Version="2"
-           VersionConverter="ScriptCanvas::VersionConverters::ForEachVersionConverter"
-           GeneratePropertyFriend="True"
-           Description="Node for iterating through a container">
+	    QualifiedName="ScriptCanvas::Nodes::Core::ForEach"
+	    PreferredClassName="For Each"
+        Uuid="{31823035-A3FF-4B8D-A3A6-819519478B7C}"
+        Category="Containers"
+        Version="2"
+        VersionConverter="ScriptCanvas::VersionConverters::ForEachVersionConverter"
+        Description="Node for iterating through a container">
         <In Name="In" Description="Signaled upon node entry"/>
         <In Name="Break" Description="Stops the iteration when signaled"/>
         <Out Name="Each" Description="Signalled after each element of the container"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ForEach.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ForEach.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/ForEach.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="ForEach"
-	    QualifiedName="ScriptCanvas::Nodes::Core::ForEach"
-	    PreferredClassName="For Each"
+        QualifiedName="ScriptCanvas::Nodes::Core::ForEach"
+        PreferredClassName="For Each"
         Uuid="{31823035-A3FF-4B8D-A3A6-819519478B7C}"
         Category="Containers"
         Version="2"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionCallNode.ScriptCanvasGrammar.xml
@@ -2,20 +2,17 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/FunctionCallNode.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="FunctionCallNode"
-           QualifiedName="ScriptCanvas::Nodes::Core::FunctionCallNode"
-           PreferredClassName="Function Call Node"
-           Uuid="{ECFDD30E-A16D-4435-97B7-B2A4DF3C543A}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/Bus.png"
-           Version="Version::Current"
-           VersionConverter="ScriptCanvas::VersionConverters::FunctionNodeVersionConverter"
-           DynamicSlotOrdering="True"
-           EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-           GeneratePropertyFriend="True"
-           Description="Displays a node that represents a call to a function in a user graph">
-      <SerializedProperty Name="m_sourceId" />
-      <SerializedProperty Name="m_asset" />
-      <SerializedProperty Name="m_slotExecutionMap" />
-      <SerializedProperty Name="m_slotExecutionMapSourceInterface" />
+        QualifiedName="ScriptCanvas::Nodes::Core::FunctionCallNode"
+        PreferredClassName="Function Call Node"
+        Uuid="{ECFDD30E-A16D-4435-97B7-B2A4DF3C543A}"
+        Version="Version::Current"
+        VersionConverter="ScriptCanvas::VersionConverters::FunctionNodeVersionConverter"
+        DynamicSlotOrdering="True"
+        EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
+        Description="Displays a node that represents a call to a function in a user graph">
+        <SerializedProperty Name="m_sourceId" />
+        <SerializedProperty Name="m_asset" />
+        <SerializedProperty Name="m_slotExecutionMap" />
+        <SerializedProperty Name="m_slotExecutionMapSourceInterface" />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionDefinitionNode.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/FunctionDefinitionNode.ScriptCanvasGrammar.xml
@@ -2,17 +2,15 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/FunctionDefinitionNode.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="FunctionDefinitionNode"
-           QualifiedName="ScriptCanvas::Nodes::Core::FunctionDefinitionNode"
-           PreferredClassName="Function Definition"
-           Uuid="{4EE28D9F-67FB-4E61-B777-5DC5B059710F}"
-           Base="ScriptCanvas::Nodes::Core::Internal::Nodeling"
-           Icon="Icons/ScriptCanvas/Start.png"
-           Category="Core"
-           Version="1"
-           EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-           GeneratePropertyFriend="True"
-           GraphEntryPoint="True"
-           Description="Represents either an execution entry or exit node.">
+        QualifiedName="ScriptCanvas::Nodes::Core::FunctionDefinitionNode"
+        PreferredClassName="Function Definition"
+        Uuid="{4EE28D9F-67FB-4E61-B777-5DC5B059710F}"
+        Base="ScriptCanvas::Nodes::Core::Internal::Nodeling"
+        Category="Core"
+        Version="1"
+        EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
+        GraphEntryPoint="True"
+        Description="Represents either an execution entry or exit node.">
         <SerializedProperty Name="m_isExecutionEntry" />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/GetVariable.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/GetVariable.ScriptCanvasGrammar.xml
@@ -2,14 +2,10 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/GetVariable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="GetVariableNode"
-	       QualifiedName="ScriptCanvas::Nodes::Core::GetVariableNode"
-	       PreferredClassName="Get Variable"
-           Uuid="{8225BE35-4C45-4A32-94D9-3DE114F6F5AF}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="Node for referencing a property within the graph">
+	    QualifiedName="ScriptCanvas::Nodes::Core::GetVariableNode"
+	    PreferredClassName="Get Variable"
+        Uuid="{8225BE35-4C45-4A32-94D9-3DE114F6F5AF}"
+        Description="Node for referencing a property within the graph">
         <In Name="In" Description="When signaled sends the property referenced by this node to a Data Output slot"/>
         <Out Name="Out" Description="Signaled after the referenced property has been pushed to the Data Output slot"/>
         <SerializedProperty Name="m_variableId" />

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/GetVariable.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/GetVariable.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/GetVariable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="GetVariableNode"
-	    QualifiedName="ScriptCanvas::Nodes::Core::GetVariableNode"
-	    PreferredClassName="Get Variable"
+        QualifiedName="ScriptCanvas::Nodes::Core::GetVariableNode"
+        PreferredClassName="Get Variable"
         Uuid="{8225BE35-4C45-4A32-94D9-3DE114F6F5AF}"
         Description="Node for referencing a property within the graph">
         <In Name="In" Description="When signaled sends the property referenced by this node to a Data Output slot"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Nodeling.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Nodeling.ScriptCanvasGrammar.xml
@@ -1,18 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/Nodeling.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Class Name="Nodeling"
-         QualifiedName="ScriptCanvas::Nodes::Core::Internal::Nodeling"
-         PreferredClassName="Nodeling"
-         Uuid="{4413EEA0-8D81-4D61-A1E1-3C1A437F3643}"
-         BaseClass="True"
-         Base="ScriptCanvas::Node"
-         Icon="Icons/ScriptCanvas/Start.png"
-         Category="Core"
-         Version="1"
-         GeneratePropertyFriend="True"
-         Description="Represents either an execution entry or exit node">
-    <SerializedProperty Name="m_displayName" />
-    <SerializedProperty Name="m_identifier" />
-  </Class>
+    <Class Name="Nodeling"
+        QualifiedName="ScriptCanvas::Nodes::Core::Internal::Nodeling"
+        PreferredClassName="Nodeling"
+        Uuid="{4413EEA0-8D81-4D61-A1E1-3C1A437F3643}"
+        BaseClass="True"
+        Category="Core"
+        Version="1"
+        Description="Represents either an execution entry or exit node">
+        <SerializedProperty Name="m_displayName" />
+        <SerializedProperty Name="m_identifier" />
+    </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ReceiveScriptEvent.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ReceiveScriptEvent.ScriptCanvasGrammar.xml
@@ -2,23 +2,21 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/ReceiveScriptEvent.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="ReceiveScriptEvent"
-	       QualifiedName="ScriptCanvas::Nodes::Core::ReceiveScriptEvent"
-	       PreferredClassName="Receive Script Event"
-           Uuid="{76CF9938-4A7E-4CDA-8DF3-77C10239D99C}"
-           Base="ScriptCanvas::Nodes::Core::Internal::ScriptEventBase"
-           Icon="Icons/ScriptCanvas/Bus.png"
-           Version="4"
-           VersionConverter="ScriptCanvas::VersionConverters::ReceiveScriptEventVersionConverter"
-           EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-           GraphEntryPoint="True"
-           GeneratePropertyFriend="True"
-           Description="Allows you to handle a event.">
+        QualifiedName="ScriptCanvas::Nodes::Core::ReceiveScriptEvent"
+        PreferredClassName="Receive Script Event"
+        Uuid="{76CF9938-4A7E-4CDA-8DF3-77C10239D99C}"
+        Base="ScriptCanvas::Nodes::Core::Internal::ScriptEventBase"
+        Version="4"
+        VersionConverter="ScriptCanvas::VersionConverters::ReceiveScriptEventVersionConverter"
+        EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
+        GraphEntryPoint="True"
+        Description="Allows you to handle a event.">
         <SerializedProperty Name="m_busId" />
+        <SerializedProperty Name="m_autoConnectToGraphOwner" />
         <In Name="Connect" Description="Connect this event handler to the specified entity."/>
         <In Name="Disconnect" Description="Disconnect this event handler."/>
         <Out Name="OnConnected" Description="Signaled when a connection has taken place."/>
         <Out Name="OnDisconnected" Description="Signaled when this event handler is disconnected."/>
         <Out Name="OnFailure" Description="Signaled when it is not possible to connect this handler."/>
-        <SerializedProperty Name="m_autoConnectToGraphOwner" />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ScriptEventBase.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/ScriptEventBase.ScriptCanvasGrammar.xml
@@ -2,17 +2,15 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/ScriptEventBase.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="ScriptEventBase"
-	       QualifiedName="ScriptCanvas::Nodes::Core::Internal::ScriptEventBase"
-	       PreferredClassName="Script Event"
-           Uuid="{B6614CEC-4788-476C-A19A-BA0A8B490C73}"
-           BaseClass="True"
-           Base="ScriptCanvas::Node"
-           Category="Internal"
-           Version="6"
-           VersionConverter="VersionConverters::ScriptEventBaseVersionConverter"
-           EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-           GeneratePropertyFriend="True"
-           Description="Base class for Script Events.">
+        QualifiedName="ScriptCanvas::Nodes::Core::Internal::ScriptEventBase"
+        PreferredClassName="Script Event"
+        Uuid="{B6614CEC-4788-476C-A19A-BA0A8B490C73}"
+        BaseClass="True"
+        Category="Internal"
+        Version="6"
+        VersionConverter="VersionConverters::ScriptEventBaseVersionConverter"
+        EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
+        Description="Base class for Script Events.">
         <SerializedProperty Name="m_version" />
         <SerializedProperty Name="m_eventMap" />
         <SerializedProperty Name="m_eventSlotMapping" />

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SendScriptEvent.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SendScriptEvent.ScriptCanvasGrammar.xml
@@ -2,16 +2,14 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/SendScriptEvent.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="SendScriptEvent"
-	       QualifiedName="ScriptCanvas::Nodes::Core::SendScriptEvent"
-	       PreferredClassName="Send Script Event"
-           Uuid="{64A97CC3-2BEA-4B47-809B-6C7DA34FD00F}"
-           Base="ScriptCanvas::Nodes::Core::Internal::ScriptEventBase"
-           Icon="Icons/ScriptCanvas/Bus.png"
-           Version="4"
-           DynamicSlotOrdering="True"
-           EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-           GeneratePropertyFriend="True"
-           Description="Allows you to send an event.">
+        QualifiedName="ScriptCanvas::Nodes::Core::SendScriptEvent"
+        PreferredClassName="Send Script Event"
+        Uuid="{64A97CC3-2BEA-4B47-809B-6C7DA34FD00F}"
+        Base="ScriptCanvas::Nodes::Core::Internal::ScriptEventBase"
+        Version="4"
+        DynamicSlotOrdering="True"
+        EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
+        Description="Allows you to send an event.">
         <SerializedProperty Name="m_namespaces" />
         <SerializedProperty Name="m_busId" />
         <SerializedProperty Name="m_eventId" />

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SetVariable.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SetVariable.ScriptCanvasGrammar.xml
@@ -2,14 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/SetVariable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="SetVariableNode"
-	       QualifiedName="ScriptCanvas::Nodes::Core::SetVariableNode"
-	       PreferredClassName="Set Variable"
-           Uuid="{5EFD2942-AFF9-4137-939C-023AEAA72EB0}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Version="1"
-           GeneratePropertyFriend="True"
-           Description="Node for setting a property within the graph">
+	    QualifiedName="ScriptCanvas::Nodes::Core::SetVariableNode"
+	    PreferredClassName="Set Variable"
+        Uuid="{5EFD2942-AFF9-4137-939C-023AEAA72EB0}"
+        Version="1"
+        Description="Node for setting a property within the graph">
         <In Name="In" Description="When signaled sends the variable referenced by this node to a Data Output slot"/>
         <Out Name="Out" Description="Signaled after the referenced variable has been pushed to the Data Output slot"/>
         <SerializedProperty Name="m_variableId" />

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SetVariable.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/SetVariable.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/SetVariable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="SetVariableNode"
-	    QualifiedName="ScriptCanvas::Nodes::Core::SetVariableNode"
-	    PreferredClassName="Set Variable"
+        QualifiedName="ScriptCanvas::Nodes::Core::SetVariableNode"
+        PreferredClassName="Set Variable"
         Uuid="{5EFD2942-AFF9-4137-939C-023AEAA72EB0}"
         Version="1"
         Description="Node for setting a property within the graph">

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Start.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Start.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/Start.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Start"
-	    QualifiedName="ScriptCanvas::Nodes::Core::Start"
-	    PreferredClassName="On Graph Start"
+        QualifiedName="ScriptCanvas::Nodes::Core::Start"
+        PreferredClassName="On Graph Start"
         Uuid="{F200B22A-5903-483A-BF63-5241BC03632B}"
         Category="Timing"
         Version="2"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Start.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Core/Start.ScriptCanvasGrammar.xml
@@ -2,16 +2,13 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Core/Start.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Start"
-	       QualifiedName="ScriptCanvas::Nodes::Core::Start"
-	       PreferredClassName="On Graph Start"
-           Uuid="{F200B22A-5903-483A-BF63-5241BC03632B}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/Start.png"
-           Category="Timing"
-           Version="2"
-           GraphEntryPoint="True"
-           GeneratePropertyFriend="True"
-           Description="Starts executing the graph when the entity that owns the graph is fully activated.">
+	    QualifiedName="ScriptCanvas::Nodes::Core::Start"
+	    PreferredClassName="On Graph Start"
+        Uuid="{F200B22A-5903-483A-BF63-5241BC03632B}"
+        Category="Timing"
+        Version="2"
+        GraphEntryPoint="True"
+        Description="Starts executing the graph when the entity that owns the graph is fully activated.">
         <Out Name="Out" Description="Signaled when the entity that owns this graph is fully activated."/>
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/And.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/And.h
@@ -36,6 +36,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<And>("And", "An execution flow gate that signals True if both Boolean A and Boolean B are True, otherwise signals False")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Logic")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Any.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Any.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/Any.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Any"
-	    QualifiedName="ScriptCanvas::Nodes::Logic::Any"
-	    PreferredClassName="Any"
+        QualifiedName="ScriptCanvas::Nodes::Logic::Any"
+        PreferredClassName="Any"
         Uuid="{6359C34F-3C34-4784-9FFD-18F1C8E3482D}"
         Version="1"
         VersionConverter="AnyNodeVersionConverter"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Any.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Any.ScriptCanvasGrammar.xml
@@ -5,6 +5,7 @@
         QualifiedName="ScriptCanvas::Nodes::Logic::Any"
         PreferredClassName="Any"
         Uuid="{6359C34F-3C34-4784-9FFD-18F1C8E3482D}"
+        Category="Logic"
         Version="1"
         VersionConverter="AnyNodeVersionConverter"
         Description="Will trigger the Out pin whenever any of the In pins get triggered">

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Any.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Any.ScriptCanvasGrammar.xml
@@ -2,14 +2,12 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/Any.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Any"
-	       QualifiedName="ScriptCanvas::Nodes::Logic::Any"
-	       PreferredClassName="Any"
-           Uuid="{6359C34F-3C34-4784-9FFD-18F1C8E3482D}"
-           Base="ScriptCanvas::Node"
-           Version="1"
-           VersionConverter="AnyNodeVersionConverter"
-           GeneratePropertyFriend="True"
-           Description="Will trigger the Out pin whenever any of the In pins get triggered">
+	    QualifiedName="ScriptCanvas::Nodes::Logic::Any"
+	    PreferredClassName="Any"
+        Uuid="{6359C34F-3C34-4784-9FFD-18F1C8E3482D}"
+        Version="1"
+        VersionConverter="AnyNodeVersionConverter"
+        Description="Will trigger the Out pin whenever any of the In pins get triggered">
         <Out Name="Out" Description="Signaled when the node receives a signal from the selected index"/>
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Break.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Break.ScriptCanvasGrammar.xml
@@ -2,14 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/Break.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Break"
-           QualifiedName="ScriptCanvas::Nodes::Logic::Break"
-           PreferredClassName="Break"
-           Uuid="{931A68D0-E3AD-44A7-A7BB-126A8F39C02F}"
-           Base="ScriptCanvas::Node"
-           Category="Logic"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="Used to exit a looping structure">
+        QualifiedName="ScriptCanvas::Nodes::Logic::Break"
+        PreferredClassName="Break"
+        Uuid="{931A68D0-E3AD-44A7-A7BB-126A8F39C02F}"
+        Category="Logic"
+        Description="Used to exit a looping structure">
         <In Name="In" Description=""/>
         <Out Name="Out 0" Description="Output 0"/>
     </Class>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Cycle.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Cycle.ScriptCanvasGrammar.xml
@@ -2,14 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/Cycle.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Cycle"
-	       QualifiedName="ScriptCanvas::Nodes::Logic::Cycle"
-	       PreferredClassName="Cycle"
-           Uuid="{974258F5-EE1B-4AEE-B956-C7B303801847}"
-           Base="ScriptCanvas::Node"
-           Category="Logic"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="">
+	    QualifiedName="ScriptCanvas::Nodes::Logic::Cycle"
+	    PreferredClassName="Cycle"
+        Uuid="{974258F5-EE1B-4AEE-B956-C7B303801847}"
+        Category="Logic"
+        Description="">
         <In Name="In" Description=""/>
         <Out Name="Out 0" Description="Output 0"/>
     </Class>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Cycle.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Cycle.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/Cycle.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Cycle"
-	    QualifiedName="ScriptCanvas::Nodes::Logic::Cycle"
-	    PreferredClassName="Cycle"
+        QualifiedName="ScriptCanvas::Nodes::Logic::Cycle"
+        PreferredClassName="Cycle"
         Uuid="{974258F5-EE1B-4AEE-B956-C7B303801847}"
         Category="Logic"
         Description="">

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Gate.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Gate.ScriptCanvasGrammar.xml
@@ -2,20 +2,17 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/Gate.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Gate"
-	       QualifiedName="ScriptCanvas::Nodes::Logic::Gate"
-	       PreferredClassName="If"
-           Uuid="{F19CC10A-02FD-4E75-ADAA-9CFBD8A4E2F8}"
-           Icon="Icons/ScriptCanvas/Print.png"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="An execution flow gate that continues True if the Condition is True, otherwise continues False">
+	    QualifiedName="ScriptCanvas::Nodes::Logic::Gate"
+	    PreferredClassName="If"
+        Uuid="{F19CC10A-02FD-4E75-ADAA-9CFBD8A4E2F8}"
+        Description="An execution flow gate that continues True if the Condition is True, otherwise continues False">
         <In Name="In" Description="Input signal"/>
         <Out Name="True" Description="Signaled if the condition provided evaluates to true."/>
         <Out Name="False" Description="Signaled if the condition provided evaluates to false."/>
         <Property Name="Condition"
-                  Description="If true the node will signal the Output and proceed execution"
-                  Type="bool"
-                  IsInput="True"
-                  IsOutput="False" />
+            Description="If true the node will signal the Output and proceed execution"
+            Type="bool"
+            IsInput="True"
+            IsOutput="False" />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Gate.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Gate.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/Gate.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Gate"
-	    QualifiedName="ScriptCanvas::Nodes::Logic::Gate"
-	    PreferredClassName="If"
+        QualifiedName="ScriptCanvas::Nodes::Logic::Gate"
+        PreferredClassName="If"
         Uuid="{F19CC10A-02FD-4E75-ADAA-9CFBD8A4E2F8}"
         Description="An execution flow gate that continues True if the Condition is True, otherwise continues False">
         <In Name="In" Description="Input signal"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/IsNull.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/IsNull.ScriptCanvasGrammar.xml
@@ -2,14 +2,10 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/IsNull.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="IsNull"
-	       QualifiedName="ScriptCanvas::Nodes::Logic::IsNull"
-	       PreferredClassName="Is Null"
-           Uuid="{760CE936-7059-42A3-A177-530A662E4ECF}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/IsNull.png"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="Evaluates reference types for null.">
+	    QualifiedName="ScriptCanvas::Nodes::Logic::IsNull"
+	    PreferredClassName="Is Null"
+        Uuid="{760CE936-7059-42A3-A177-530A662E4ECF}"
+        Description="Evaluates reference types for null.">
         <In Name="In" Description="Input signal"/>
         <Out Name="True" Description="Signaled if the reference provided is null."/>
         <Out Name="False" Description="Signaled if the reference provided is not null."/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/IsNull.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/IsNull.ScriptCanvasGrammar.xml
@@ -5,6 +5,7 @@
         QualifiedName="ScriptCanvas::Nodes::Logic::IsNull"
         PreferredClassName="Is Null"
         Uuid="{760CE936-7059-42A3-A177-530A662E4ECF}"
+        Category="Logic"
         Description="Evaluates reference types for null.">
         <In Name="In" Description="Input signal"/>
         <Out Name="True" Description="Signaled if the reference provided is null."/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/IsNull.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/IsNull.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/IsNull.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="IsNull"
-	    QualifiedName="ScriptCanvas::Nodes::Logic::IsNull"
-	    PreferredClassName="Is Null"
+        QualifiedName="ScriptCanvas::Nodes::Logic::IsNull"
+        PreferredClassName="Is Null"
         Uuid="{760CE936-7059-42A3-A177-530A662E4ECF}"
         Description="Evaluates reference types for null.">
         <In Name="In" Description="Input signal"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Not.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Not.h
@@ -34,6 +34,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<Not>("Not", "An execution flow gate that continues True if the Boolean is False, otherwise continues False if the Boolean is True")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Logic")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Once.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Once.ScriptCanvasGrammar.xml
@@ -2,14 +2,10 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/Once.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Once"
-           QualifiedName="ScriptCanvas::Nodes::Logic::Once"
-           PreferredClassName="Once"
-           Uuid="{0E37D3CA-2862-4667-BFDB-7393DD48241B}"
-           Base="ScriptCanvas::Node"
-           Icon="Icons/ScriptCanvas/Print.png"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="An execution flow gate that will only activate once. The gate will reopen if it receives a Reset pulse.">
+        QualifiedName="ScriptCanvas::Nodes::Logic::Once"
+        PreferredClassName="Once"
+        Uuid="{0E37D3CA-2862-4667-BFDB-7393DD48241B}"
+        Description="An execution flow gate that will only activate once. The gate will reopen if it receives a Reset pulse.">
         <In Name="In" Description="Input signal"/>
         <In Name="Reset" Description="Reset signal"/>
         <Out Name="Out" Description="Output signal"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Once.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Once.ScriptCanvasGrammar.xml
@@ -5,6 +5,7 @@
         QualifiedName="ScriptCanvas::Nodes::Logic::Once"
         PreferredClassName="Once"
         Uuid="{0E37D3CA-2862-4667-BFDB-7393DD48241B}"
+        Category="Logic"
         Description="An execution flow gate that will only activate once. The gate will reopen if it receives a Reset pulse.">
         <In Name="In" Description="Input signal"/>
         <In Name="Reset" Description="Reset signal"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Or.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/Or.h
@@ -34,6 +34,7 @@ namespace ScriptCanvas
                         {
                             editContext->Class<Or>("Or", "An execution flow gate that continues True if either Boolean A or Boolean B are True, otherwise continues False")
                                 ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
+                                    ->Attribute(AZ::Edit::Attributes::Category, "Logic")
                                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/ScriptCanvas/Placeholder.png")
                                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                                 ;

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/OrderedSequencer.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/OrderedSequencer.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/OrderedSequencer.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OrderedSequencer"
-	    QualifiedName="ScriptCanvas::Nodes::Logic::OrderedSequencer"
-	    PreferredClassName="Ordered Sequencer"
+        QualifiedName="ScriptCanvas::Nodes::Logic::OrderedSequencer"
+        PreferredClassName="Ordered Sequencer"
         Uuid="{BAFDA139-49A8-453B-A556-D4F4BA213B5C}"
         Category="Logic"
         Description="Triggers the execution outputs in the specified ordered. The next line will trigger once the first line reaches a break in execution(either through latent node, or a terminal endpoint)">

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/OrderedSequencer.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/OrderedSequencer.ScriptCanvasGrammar.xml
@@ -2,14 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/OrderedSequencer.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OrderedSequencer"
-	       QualifiedName="ScriptCanvas::Nodes::Logic::OrderedSequencer"
-	       PreferredClassName="Ordered Sequencer"
-           Uuid="{BAFDA139-49A8-453B-A556-D4F4BA213B5C}"
-           Base="ScriptCanvas::Node"
-           Category="Logic"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="Triggers the execution outputs in the specified ordered. The next line will trigger once the first line reaches a break in execution(either through latent node, or a terminal endpoint)">
+	    QualifiedName="ScriptCanvas::Nodes::Logic::OrderedSequencer"
+	    PreferredClassName="Ordered Sequencer"
+        Uuid="{BAFDA139-49A8-453B-A556-D4F4BA213B5C}"
+        Category="Logic"
+        Description="Triggers the execution outputs in the specified ordered. The next line will trigger once the first line reaches a break in execution(either through latent node, or a terminal endpoint)">
         <In Name="In" Description=""/>
         <Out Name="Out 0" Description="Output 0"/>
     </Class>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.ScriptCanvasGrammar.xml
@@ -5,6 +5,7 @@
         QualifiedName="ScriptCanvas::Nodes::Logic::TargetedSequencer"
         PreferredClassName="Switch"
         Uuid="{E1B5F3F8-AFEE-42C9-A22C-CB93F8281CC4}"
+        Category="Logic"
         Description="Triggers the specified output when triggered.">
         <In Name="In" Description=""/>
         <Out Name="Out 0" Description="Output 0"/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="TargetedSequencer"
-	    QualifiedName="ScriptCanvas::Nodes::Logic::TargetedSequencer"
-	    PreferredClassName="Switch"
+        QualifiedName="ScriptCanvas::Nodes::Logic::TargetedSequencer"
+        PreferredClassName="Switch"
         Uuid="{E1B5F3F8-AFEE-42C9-A22C-CB93F8281CC4}"
         Description="Triggers the specified output when triggered.">
         <In Name="In" Description=""/>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.ScriptCanvasGrammar.xml
@@ -2,19 +2,17 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/TargetedSequencer.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="TargetedSequencer"
-	       QualifiedName="ScriptCanvas::Nodes::Logic::TargetedSequencer"
-	       PreferredClassName="Switch"
-           Uuid="{E1B5F3F8-AFEE-42C9-A22C-CB93F8281CC4}"
-           Base="ScriptCanvas::Node"
-           GeneratePropertyFriend="True"
-           Description="Triggers the specified output when triggered.">
+	    QualifiedName="ScriptCanvas::Nodes::Logic::TargetedSequencer"
+	    PreferredClassName="Switch"
+        Uuid="{E1B5F3F8-AFEE-42C9-A22C-CB93F8281CC4}"
+        Description="Triggers the specified output when triggered.">
         <In Name="In" Description=""/>
         <Out Name="Out 0" Description="Output 0"/>
         <Property Name="Index"
-                  Description="Select which [Out#] to trigger."
-                  Type="int"
-                  DisplayGroup="OutputGroup"
-                  IsInput="True"
-                  IsOutput="False" />
+            Description="Select which [Out#] to trigger."
+            Type="int"
+            DisplayGroup="OutputGroup"
+            IsInput="True"
+            IsOutput="False" />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/WeightedRandomSequencer.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/WeightedRandomSequencer.ScriptCanvasGrammar.xml
@@ -2,14 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/WeightedRandomSequencer.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="WeightedRandomSequencer"
-	       QualifiedName="ScriptCanvas::Nodes::Logic::WeightedRandomSequencer"
-	       PreferredClassName="Random Signal"
-           Uuid="{DFB13C5E-5FB3-4650-BD3A-E1AD79CD42AC}"
-           Base="ScriptCanvas::Node"
-           Category="Logic"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="Triggers one of the selected outputs at Random depending on the weights provided.">
+	    QualifiedName="ScriptCanvas::Nodes::Logic::WeightedRandomSequencer"
+	    PreferredClassName="Random Signal"
+        Uuid="{DFB13C5E-5FB3-4650-BD3A-E1AD79CD42AC}"
+        Category="Logic"
+        Description="Triggers one of the selected outputs at Random depending on the weights provided.">
         <In Name="In" Description="Input signal"/>
         <SerializedProperty Name="m_weightedPairings" />
     </Class>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/WeightedRandomSequencer.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/WeightedRandomSequencer.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/WeightedRandomSequencer.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="WeightedRandomSequencer"
-	    QualifiedName="ScriptCanvas::Nodes::Logic::WeightedRandomSequencer"
-	    PreferredClassName="Random Signal"
+        QualifiedName="ScriptCanvas::Nodes::Logic::WeightedRandomSequencer"
+        PreferredClassName="Random Signal"
         Uuid="{DFB13C5E-5FB3-4650-BD3A-E1AD79CD42AC}"
         Category="Logic"
         Description="Triggers one of the selected outputs at Random depending on the weights provided.">

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/While.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Logic/While.ScriptCanvasGrammar.xml
@@ -2,23 +2,20 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Logic/While.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="While"
-           QualifiedName="ScriptCanvas::Nodes::Logic::While"
-           PreferredClassName="While"
-           Uuid="{C5BDF392-9669-4928-A0F5-F55B8A5B3BAC}"
-           Base="ScriptCanvas::Node"
-           Category="Logic"
-           Version="0"
-           GeneratePropertyFriend="True"
-           Description="">
+        QualifiedName="ScriptCanvas::Nodes::Logic::While"
+        PreferredClassName="While"
+        Uuid="{C5BDF392-9669-4928-A0F5-F55B8A5B3BAC}"
+        Category="Logic"
+        Description="">
 
-          <In Name="In" Description=""/>
-          <Out Name="Out" Description="Signalled if the condition is false, or if the loop calls the break node"/>
-          <Out Name="Loop" Description="Signalled if the condition is true, and every time the last node of 'Loop' finishes"/>
+        <In Name="In" Description=""/>
+        <Out Name="Out" Description="Signalled if the condition is false, or if the loop calls the break node"/>
+        <Out Name="Loop" Description="Signalled if the condition is true, and every time the last node of 'Loop' finishes"/>
 
-          <Property Name="Condition"
-                 Description="While this condition is true, Loop will signal, otherwise, Out will."
-                 Type="bool"
-                 IsInput="True"
-                 IsOutput="False" />
+        <Property Name="Condition"
+            Description="While this condition is true, Loop will signal, otherwise, Out will."
+            Type="bool"
+            IsInput="True"
+            IsOutput="False" />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathExpression.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathExpression.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Math/MathExpression.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="MathExpression"
-	    QualifiedName="ScriptCanvas::Nodes::Math::MathExpression"
-	    PreferredClassName="Math Expression"
+        QualifiedName="ScriptCanvas::Nodes::Math::MathExpression"
+        PreferredClassName="Math Expression"
         Uuid="{A5841DE8-CA11-4364-9C34-5ECE8B9623D7}"
         Base="ScriptCanvas::Nodes::Internal::ExpressionNodeBase"
         Category="Math"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathExpression.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Math/MathExpression.ScriptCanvasGrammar.xml
@@ -2,22 +2,19 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Math/MathExpression.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="MathExpression"
-	       QualifiedName="ScriptCanvas::Nodes::Math::MathExpression"
-	       PreferredClassName="Math Expression"
-           Uuid="{A5841DE8-CA11-4364-9C34-5ECE8B9623D7}"
-           Base="ScriptCanvas::Nodes::Internal::ExpressionNodeBase"
-           Category="Math"
-           Version="0"
-           DynamicSlotOrdering="True"
-           EditAttributes="AZ::Edit::Attributes::CategoryStyle@.math;ScriptCanvas::Attributes::Node::TitlePaletteOverride@MathNodeTitlePalette"
-           GeneratePropertyFriend="True"
-           Description="Will evaluate a series of math operations, allowing users to specify inputs using {}.">
+	    QualifiedName="ScriptCanvas::Nodes::Math::MathExpression"
+	    PreferredClassName="Math Expression"
+        Uuid="{A5841DE8-CA11-4364-9C34-5ECE8B9623D7}"
+        Base="ScriptCanvas::Nodes::Internal::ExpressionNodeBase"
+        Category="Math"
+        DynamicSlotOrdering="True"
+        Description="Will evaluate a series of math operations, allowing users to specify inputs using {}.">
         <Out Name="Out" Description="Output signal"/>
         <Property Name="Result"
-                  Description="The resulting string."
-                  Type="double"
-                  DisplayGroup="ExpressionDisplayGroup"
-                  IsInput="False"
-                  IsOutput="True" />
+            Description="The resulting string."
+            Type="double"
+            DisplayGroup="ExpressionDisplayGroup"
+            IsInput="False"
+            IsOutput="True" />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorAdd.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorAdd.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorAdd.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorAdd"
-	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorAdd"
-	    PreferredClassName="Add (+)"
+        QualifiedName="ScriptCanvas::Nodes::Operators::OperatorAdd"
+        PreferredClassName="Add (+)"
         Uuid="{C1B42FEC-0545-4511-9FAC-11E0387FEDF0}"
         Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
         Category="Math"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorAdd.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorAdd.ScriptCanvasGrammar.xml
@@ -2,12 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorAdd.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorAdd"
-	       QualifiedName="ScriptCanvas::Nodes::Operators::OperatorAdd"
-	       PreferredClassName="Add (+)"
-           Uuid="{C1B42FEC-0545-4511-9FAC-11E0387FEDF0}"
-           Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
-           Category="Math"
-           Version="0"
-           Description="Adds two or more values">
+	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorAdd"
+	    PreferredClassName="Add (+)"
+        Uuid="{C1B42FEC-0545-4511-9FAC-11E0387FEDF0}"
+        Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
+        Category="Math"
+        Description="Adds two or more values">
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorArithmetic"
-	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
-	    PreferredClassName="OperatorArithmetic"
+        QualifiedName="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
+        PreferredClassName="OperatorArithmetic"
         Uuid="{FE0589B0-F835-4CD5-BBD3-86510CBB985B}"
         BaseClass="True"
         Base="ScriptCanvas::Node"
@@ -15,8 +15,8 @@
         <Out Name="Out" Description=""/>
     </Class>
     <Class Name="OperatorArithmeticUnary"
-	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorArithmeticUnary"
-	    PreferredClassName="OperatorArithmeticUnary"
+        QualifiedName="ScriptCanvas::Nodes::Operators::OperatorArithmeticUnary"
+        PreferredClassName="OperatorArithmeticUnary"
         Uuid="{4B68DF49-35DE-48CF-BCE3-F892CCF2639D}"
         BaseClass="True"
         Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.ScriptCanvasGrammar.xml
@@ -2,27 +2,25 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorArithmetic.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorArithmetic"
-	       QualifiedName="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
-	       PreferredClassName="OperatorArithmetic"
-           Uuid="{FE0589B0-F835-4CD5-BBD3-86510CBB985B}"
-           BaseClass="True"
-           Base="ScriptCanvas::Node"
-           Category="Operators"
-           Version="1"
-           VersionConverter="OperatorArithmeticVersionConverter"
-           GeneratePropertyFriend="True"
-           Description="">
+	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
+	    PreferredClassName="OperatorArithmetic"
+        Uuid="{FE0589B0-F835-4CD5-BBD3-86510CBB985B}"
+        BaseClass="True"
+        Base="ScriptCanvas::Node"
+        Category="Operators"
+        Version="1"
+        VersionConverter="OperatorArithmeticVersionConverter"
+        Description="">
         <In Name="In" Description=""/>
         <Out Name="Out" Description=""/>
     </Class>
     <Class Name="OperatorArithmeticUnary"
-	       QualifiedName="ScriptCanvas::Nodes::Operators::OperatorArithmeticUnary"
-	       PreferredClassName="OperatorArithmeticUnary"
-           Uuid="{4B68DF49-35DE-48CF-BCE3-F892CCF2639D}"
-           BaseClass="True"
-           Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
-           Category="Operators/Math"
-           Version="0"
-           Description="">
+	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorArithmeticUnary"
+	    PreferredClassName="OperatorArithmeticUnary"
+        Uuid="{4B68DF49-35DE-48CF-BCE3-F892CCF2639D}"
+        BaseClass="True"
+        Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
+        Category="Operators/Math"
+        Description="">
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorDiv"
-	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorDiv"
-	    PreferredClassName="Divide (/)"
+        QualifiedName="ScriptCanvas::Nodes::Operators::OperatorDiv"
+        PreferredClassName="Divide (/)"
         Uuid="{DC17E19F-3829-410D-9A0B-AD60C6066DAA}"
         Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
         Category="Math"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.ScriptCanvasGrammar.xml
@@ -2,12 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorDiv.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorDiv"
-	       QualifiedName="ScriptCanvas::Nodes::Operators::OperatorDiv"
-	       PreferredClassName="Divide (/)"
-           Uuid="{DC17E19F-3829-410D-9A0B-AD60C6066DAA}"
-           Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
-           Category="Math"
-           Version="0"
-           Description="Divides two or more values">
+	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorDiv"
+	    PreferredClassName="Divide (/)"
+        Uuid="{DC17E19F-3829-410D-9A0B-AD60C6066DAA}"
+        Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
+        Category="Math"
+        Description="Divides two or more values">
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorMul"
-	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorMul"
-	    PreferredClassName="Multiply (*)"
+        QualifiedName="ScriptCanvas::Nodes::Operators::OperatorMul"
+        PreferredClassName="Multiply (*)"
         Uuid="{E9BB45A1-AE96-47B0-B2BF-2927D420A28C}"
         Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
         Category="Math"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.ScriptCanvasGrammar.xml
@@ -2,12 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorMul.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorMul"
-	       QualifiedName="ScriptCanvas::Nodes::Operators::OperatorMul"
-	       PreferredClassName="Multiply (*)"
-           Uuid="{E9BB45A1-AE96-47B0-B2BF-2927D420A28C}"
-           Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
-           Category="Math"
-           Version="0"
-           Description="Multiplies two of more values">
+	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorMul"
+	    PreferredClassName="Multiply (*)"
+        Uuid="{E9BB45A1-AE96-47B0-B2BF-2927D420A28C}"
+        Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
+        Category="Math"
+        Description="Multiplies two of more values">
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorSub.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorSub.ScriptCanvasGrammar.xml
@@ -2,12 +2,11 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorSub.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorSub"
-	       QualifiedName="ScriptCanvas::Nodes::Operators::OperatorSub"
-	       PreferredClassName="Subtract (-)"
-           Uuid="{D0615D0A-027F-47F6-A02B-E35DAF22F431}"
-           Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
-           Category="Math"
-           Version="0"
-           Description="Subtracts two of more elements">
+	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorSub"
+	    PreferredClassName="Subtract (-)"
+        Uuid="{D0615D0A-027F-47F6-A02B-E35DAF22F431}"
+        Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
+        Category="Math"
+        Description="Subtracts two of more elements">
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorSub.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Operators/Math/OperatorSub.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Operators/Math/OperatorSub.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="OperatorSub"
-	    QualifiedName="ScriptCanvas::Nodes::Operators::OperatorSub"
-	    PreferredClassName="Subtract (-)"
+        QualifiedName="ScriptCanvas::Nodes::Operators::OperatorSub"
+        PreferredClassName="Subtract (-)"
         Uuid="{D0615D0A-027F-47F6-A02B-E35DAF22F431}"
         Base="ScriptCanvas::Nodes::Operators::OperatorArithmetic"
         Category="Math"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.ScriptCanvasNodeable.xml
@@ -1,21 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/CreateSpawnTicketNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Class Name="CreateSpawnTicketNodeable"
-         QualifiedName="Nodeables::Spawning::CreateSpawnTicketNodeable"
-         PreferredClassName="CreateSpawnTicket"
-         Base="ScriptCanvas::Nodeable"
-         Icon="Icons/ScriptCanvas/Placeholder.png"
-         Category="Prefab/Spawning"
-         Version="0"
-         GeneratePropertyFriend="True"
-         Namespace="ScriptCanvas"
-         Description="Creates a spawn ticket using provided prefab">
+    <Class Name="CreateSpawnTicketNodeable"
+        QualifiedName="Nodeables::Spawning::CreateSpawnTicketNodeable"
+        PreferredClassName="CreateSpawnTicket"
+        Category="Prefab/Spawning"
+        Namespace="ScriptCanvas"
+        Description="Creates a spawn ticket using provided prefab">
 
-    <Input Name="Create Ticket" OutputName="Ticket Created">
-        <Parameter Name="Prefab" Type="const AzFramework::Scripts::SpawnableScriptAssetRef&amp;" Description="Prefab source asset to spawn"/>
-        <Return Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Shared="true"/>
-    </Input>
-  </Class>
+        <Input Name="Create Ticket" OutputName="Ticket Created">
+            <Parameter Name="Prefab" Type="const AzFramework::Scripts::SpawnableScriptAssetRef&amp;" Description="Prefab source asset to spawn"/>
+            <Return Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Shared="true"/>
+        </Input>
+    </Class>
 </ScriptCanvas>
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.ScriptCanvasNodeable.xml
@@ -1,23 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/DespawnNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Class Name="DespawnNodeable"
-         QualifiedName="Nodeables::Spawning::DespawnNodeable"
-         PreferredClassName="Despawn"
-         Base="ScriptCanvas::Nodeable"
-         Icon="Icons/ScriptCanvas/Placeholder.png"
-         Category="Prefab/Spawning"
-         Version="0"
-         GeneratePropertyFriend="True"
-         Namespace="ScriptCanvas"
-         Description="Despawns a selected prefab">
+    <Class Name="DespawnNodeable"
+        QualifiedName="Nodeables::Spawning::DespawnNodeable"
+        PreferredClassName="Despawn"
+        Category="Prefab/Spawning"
+        Namespace="ScriptCanvas"
+        Description="Despawns a selected prefab">
 
-    <Input Name="Request Despawn" OutputName="Despawn Requested">
-        <Parameter Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance assosiated with spawnable asset."/>
-    </Input>
+        <Input Name="Request Despawn" OutputName="Despawn Requested">
+            <Parameter Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance assosiated with spawnable asset."/>
+        </Input>
 
-    <Output Name="On Despawn" Description="Called when despawning entities has completed.">
-        <Parameter Name="SpawnTicketOut" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the despawn result."/>
-    </Output>/>
-  </Class>
+        <Output Name="On Despawn" Description="Called when despawning entities has completed.">
+            <Parameter Name="SpawnTicketOut" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the despawn result."/>
+        </Output>/>
+    </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.ScriptCanvasNodeable.xml
@@ -1,28 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Spawning/SpawnNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Class Name="SpawnNodeable"
-         QualifiedName="Nodeables::Spawning::SpawnNodeable"
-         PreferredClassName="Spawn"
-         Base="ScriptCanvas::Nodeable"
-         Icon="Icons/ScriptCanvas/Placeholder.png"
-         Category="Prefab/Spawning"
-         Version="0"
-         GeneratePropertyFriend="True"
-         Namespace="ScriptCanvas"
-         Description="Spawns a selected prefab">
+    <Class Name="SpawnNodeable"
+        QualifiedName="Nodeables::Spawning::SpawnNodeable"
+        PreferredClassName="Spawn"
+        Category="Prefab/Spawning"
+        Namespace="ScriptCanvas"
+        Description="Spawns a selected prefab">
 
-    <Input Name="Request Spawn" OutputName="Spawn Requested">
-        <Parameter Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance assosiated with spawnable asset."/>
-        <Parameter Name="ParentId" Type="AZ::EntityId" Description="Optional parent to assign spawned container entity to."/>
-        <Parameter Name="Local Translation" Type="Data::Vector3Type" Description="Position to spawn."/>
-        <Parameter Name="Local Rotation" Type="Data::Vector3Type" Description="Rotation of spawn (in degrees)."/>
-        <Parameter Name="Local Scale" Type="Data::NumberType" DefaultValue="1" Description="Scale of spawn."/>
-    </Input>
+        <Input Name="Request Spawn" OutputName="Spawn Requested">
+            <Parameter Name="SpawnTicket" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance assosiated with spawnable asset."/>
+            <Parameter Name="ParentId" Type="AZ::EntityId" Description="Optional parent to assign spawned container entity to."/>
+            <Parameter Name="Local Translation" Type="Data::Vector3Type" Description="Position to spawn."/>
+            <Parameter Name="Local Rotation" Type="Data::Vector3Type" Description="Rotation of spawn (in degrees)."/>
+            <Parameter Name="Local Scale" Type="Data::NumberType" DefaultValue="1" Description="Scale of spawn."/>
+        </Input>
 
-    <Output Name="On Spawn Completed" Description="Called when spawning entities is completed.">
-        <Parameter Name="SpawnTicketOut" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the spawn result."/>
-        <Parameter Name="SpawnedEntitiesList" Type="AZStd::vector&lt;Data::EntityIDType&gt;" Description="List of spawned entities sorted by hierarchy with the root being first."/>
-    </Output>/>
-  </Class>
+        <Output Name="On Spawn Completed" Description="Called when spawning entities is completed.">
+            <Parameter Name="SpawnTicketOut" Type="AzFramework::EntitySpawnTicket" Description="Ticket instance of the spawn result."/>
+            <Parameter Name="SpawnedEntitiesList" Type="AZStd::vector&lt;Data::EntityIDType&gt;" Description="List of spawned entities sorted by hierarchy with the root being first."/>
+        </Output>/>
+    </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/Format.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/Format.ScriptCanvasGrammar.xml
@@ -2,20 +2,18 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/String/Format.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Format"
-	       QualifiedName="ScriptCanvas::Nodes::String::Format"
-	       PreferredClassName="Build String"
-           Uuid="{B16259BA-9CF6-4143-B09B-5A0F3B4585E6}"
-           Base="ScriptCanvas::Nodes::Internal::StringFormatted"
-           Category="String"
-           Version="0"
-           DynamicSlotOrdering="True"
-           GeneratePropertyFriend="True"
-           Description="Formats and creates a string from the provided text.\nAny word within {} will create a data pin on this node.">
+	    QualifiedName="ScriptCanvas::Nodes::String::Format"
+	    PreferredClassName="Build String"
+        Uuid="{B16259BA-9CF6-4143-B09B-5A0F3B4585E6}"
+        Base="ScriptCanvas::Nodes::Internal::StringFormatted"
+        Category="String"
+        DynamicSlotOrdering="True"
+        Description="Formats and creates a string from the provided text.\nAny word within {} will create a data pin on this node.">
         <Property Name="String"
-                  Description="The resulting string."
-                  Type="AZStd::string"
-                  DisplayGroup="PrintDisplayGroup"
-                  IsInput="False"
-                  IsOutput="True" />
+            Description="The resulting string."
+            Type="AZStd::string"
+            DisplayGroup="PrintDisplayGroup"
+            IsInput="False"
+            IsOutput="True" />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/Format.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/Format.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/String/Format.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Format"
-	    QualifiedName="ScriptCanvas::Nodes::String::Format"
-	    PreferredClassName="Build String"
+        QualifiedName="ScriptCanvas::Nodes::String::Format"
+        PreferredClassName="Build String"
         Uuid="{B16259BA-9CF6-4143-B09B-5A0F3B4585E6}"
         Base="ScriptCanvas::Nodes::Internal::StringFormatted"
         Category="String"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/Print.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/Print.ScriptCanvasGrammar.xml
@@ -2,8 +2,8 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/String/Print.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Print"
-	    QualifiedName="ScriptCanvas::Nodes::String::Print"
-	    PreferredClassName="Print"
+        QualifiedName="ScriptCanvas::Nodes::String::Print"
+        PreferredClassName="Print"
         Uuid="{E1940FB4-83FE-4594-9AFF-375FF7603338}"
         Base="ScriptCanvas::Nodes::Internal::StringFormatted"
         Category="Utilities/Debug"

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/Print.ScriptCanvasGrammar.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/String/Print.ScriptCanvasGrammar.xml
@@ -2,14 +2,13 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/String/Print.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="Print"
-	       QualifiedName="ScriptCanvas::Nodes::String::Print"
-	       PreferredClassName="Print"
-           Uuid="{E1940FB4-83FE-4594-9AFF-375FF7603338}"
-           Base="ScriptCanvas::Nodes::Internal::StringFormatted"
-           Category="Utilities/Debug"
-           Version="0"
-           DynamicSlotOrdering="True"
-           EditAttributes="AZ::Edit::Attributes::CategoryStyle@.string;ScriptCanvas::Attributes::Node::TitlePaletteOverride@StringNodeTitlePalette"
-           Description="Formats and prints the provided text in the debug console.\nAny word within {} will create a data pin on this node.">
+	    QualifiedName="ScriptCanvas::Nodes::String::Print"
+	    PreferredClassName="Print"
+        Uuid="{E1940FB4-83FE-4594-9AFF-375FF7603338}"
+        Base="ScriptCanvas::Nodes::Internal::StringFormatted"
+        Category="Utilities/Debug"
+        DynamicSlotOrdering="True"
+        EditAttributes="AZ::Edit::Attributes::CategoryStyle@.string;ScriptCanvas::Attributes::Node::TitlePaletteOverride@StringNodeTitlePalette"
+        Description="Formats and prints the provided text in the debug console.\nAny word within {} will create a data pin on this node.">
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/DelayNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/DelayNodeable.ScriptCanvasNodeable.xml
@@ -1,29 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/DelayNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Class Name="DelayNodeable"
-      QualifiedName="ScriptCanvas::Nodeables::Time::DelayNodeable"
-      PreferredClassName="Delay"
-      Uuid="{32C41074-B35E-DF94-AD36-E75684370F4A}"
-      Base="ScriptCanvas::Nodeable"
-      Category="Timing"
-      Version="0"
-      GeneratePropertyFriend="True"
-      Namespace="ScriptCanvas"
-      Description="While active, will signal the output at the given interval.">
-    <Input Name="Start" Description="When signaled, execution is delayed at this node according to the specified properties.">
-      <Parameter Name="Start: Time" Type="Data::NumberType" DefaultValue="0.0" Description="Amount of time to delay, in seconds."/>
-      <Parameter Name="Start: Loop" Type="Data::BooleanType" DefaultValue="false" Description="If true, the delay will restart after triggering the Out slot."/>
-      <Parameter Name="Start: Hold" Type="Data::NumberType" DefaultValue="0.0" Description="Amount of time to wait before restarting, in seconds."/>
-    </Input>/>
-    <Input Name="Reset" Description="When signaled, execution is delayed at this node according to the specified properties.">
-      <Parameter Name="Reset: Time" Type="Data::NumberType" DefaultValue="0.0" Description="Amount of time to delay, in seconds."/>
-      <Parameter Name="Reset: Loop" Type="Data::BooleanType" DefaultValue="false" Description="If true, the delay will restart after triggering the Out slot."/>
-      <Parameter Name="Reset: Hold" Type="Data::NumberType" DefaultValue="0.0" Description="Amount of time to wait before restarting, in seconds."/>
-    </Input>/>
-    <Input Name="Cancel" Description="Cancels the current delay."/>
-    <Output Name="Done" Description="Signaled when the delay reaches zero." >
-      <Parameter Name="Elapsed" Type="Data::NumberType" Description="The amount of time that has elapsed since the delay began."/>
-    </Output>
-  </Class>
+    <Class Name="DelayNodeable"
+        QualifiedName="ScriptCanvas::Nodeables::Time::DelayNodeable"
+        PreferredClassName="Delay"
+        Uuid="{32C41074-B35E-DF94-AD36-E75684370F4A}"
+        Category="Timing"
+        Namespace="ScriptCanvas"
+        Description="While active, will signal the output at the given interval.">
+        <Input Name="Start" Description="When signaled, execution is delayed at this node according to the specified properties.">
+            <Parameter Name="Start: Time" Type="Data::NumberType" DefaultValue="0.0" Description="Amount of time to delay, in seconds."/>
+            <Parameter Name="Start: Loop" Type="Data::BooleanType" DefaultValue="false" Description="If true, the delay will restart after triggering the Out slot."/>
+            <Parameter Name="Start: Hold" Type="Data::NumberType" DefaultValue="0.0" Description="Amount of time to wait before restarting, in seconds."/>
+        </Input>/>
+        <Input Name="Reset" Description="When signaled, execution is delayed at this node according to the specified properties.">
+            <Parameter Name="Reset: Time" Type="Data::NumberType" DefaultValue="0.0" Description="Amount of time to delay, in seconds."/>
+            <Parameter Name="Reset: Loop" Type="Data::BooleanType" DefaultValue="false" Description="If true, the delay will restart after triggering the Out slot."/>
+            <Parameter Name="Reset: Hold" Type="Data::NumberType" DefaultValue="0.0" Description="Amount of time to wait before restarting, in seconds."/>
+        </Input>/>
+        <Input Name="Cancel" Description="Cancels the current delay."/>
+        <Output Name="Done" Description="Signaled when the delay reaches zero." >
+            <Parameter Name="Elapsed" Type="Data::NumberType" Description="The amount of time that has elapsed since the delay began."/>
+        </Output>
+    </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/DurationNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/DurationNodeable.ScriptCanvasNodeable.xml
@@ -2,23 +2,19 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/DurationNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="DurationNodeable"
-           QualifiedName="ScriptCanvas::Nodeables::Time::DurationNodeable"
-           PreferredClassName="Duration"
-           Base="ScriptCanvas::Nodeable"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Timing"
-           GeneratePropertyFriend="True"
-           Namespace="ScriptCanvas"
-           Description="Triggers a signal every frame during the specified duration.">
+        QualifiedName="ScriptCanvas::Nodeables::Time::DurationNodeable"
+        PreferredClassName="Duration"
+        Category="Timing"
+        Namespace="ScriptCanvas"
+        Description="Triggers a signal every frame during the specified duration.">
 
-      <Input Name="Start" Description="">
-        <Parameter Name="Duration" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time to delay before the Done is signalled."/>
-      </Input>
+        <Input Name="Start" Description="">
+            <Parameter Name="Duration" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time to delay before the Done is signalled."/>
+        </Input>
 
-      <Output Name="OnTick" Description="Signaled every frame while the duration is active." >
-        <Parameter Name="Elapsed" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time that has elapsed since the countdown began."/>
-      </Output>
-      <Output Name="Done" Description="Signaled after waiting for the specified amount of times." />
-
+        <Output Name="OnTick" Description="Signaled every frame while the duration is active." >
+            <Parameter Name="Elapsed" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time that has elapsed since the countdown began."/>
+        </Output>
+        <Output Name="Done" Description="Signaled after waiting for the specified amount of times." />
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/HeartBeatNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/HeartBeatNodeable.ScriptCanvasNodeable.xml
@@ -2,24 +2,21 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/HeartBeatNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="HeartBeatNodeable"
-           QualifiedName="Nodeables::Time::HeartBeatNodeable"
-           PreferredClassName="HeartBeat"
-           Base="Nodeables::Time::BaseTimer"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Timing"
-           GeneratePropertyFriend="True"
-           Namespace="ScriptCanvas"
-           Description="While active, will signal the output at the given interval.">
+        QualifiedName="Nodeables::Time::HeartBeatNodeable"
+        PreferredClassName="HeartBeat"
+        Base="Nodeables::Time::BaseTimer"
+        Category="Timing"
+        Namespace="ScriptCanvas"
+        Description="While active, will signal the output at the given interval.">
 
-      <Input Name="Start" Description="">
-        <Parameter Name="Interval" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time between pulses"/>
-      </Input>
+        <Input Name="Start" Description="">
+            <Parameter Name="Interval" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time between pulses"/>
+        </Input>
 
-      <Input Name="Stop"/>
+        <Input Name="Stop"/>
 
-      <Output Name="Pulse" Description="Signaled at each specified interval." />
+        <Output Name="Pulse" Description="Signaled at each specified interval." />
 
-      <PropertyInterface Property="m_timeUnitsInterface" Name="Units" Type="Input" Description="Units to represent the time in."/>
-
+        <PropertyInterface Property="m_timeUnitsInterface" Name="Units" Type="Input" Description="Units to represent the time in."/>
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/RepeaterNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/RepeaterNodeable.ScriptCanvasNodeable.xml
@@ -2,27 +2,23 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/RepeaterNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="RepeaterNodeable"
-           QualifiedName="ScriptCanvas::Nodeables::Core::RepeaterNodeable"
-           PreferredClassName="Repeater"
-           Uuid="{4FBB5021-F3C8-E743-BF2E-BC6E5D57D48E}"
-           Base="Nodeables::Time::BaseTimer"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Timing"
-           GeneratePropertyFriend="True"
-           Namespace="ScriptCanvas"
-           Description="Repeats the output signal the given number of times using the specified delay to space the signals out.">
+        QualifiedName="ScriptCanvas::Nodeables::Core::RepeaterNodeable"
+        PreferredClassName="Repeater"
+        Uuid="{4FBB5021-F3C8-E743-BF2E-BC6E5D57D48E}"
+        Base="Nodeables::Time::BaseTimer"
+        Category="Timing"
+        Namespace="ScriptCanvas"
+        Description="Repeats the output signal the given number of times using the specified delay to space the signals out.">
 
+        <!-- Input tag is for an execution input that has optional data (parameters) -->
+        <Input Name="Start" Description="">
+            <Parameter Name="Repetitions" Type="Data::NumberType" DefaultValue="0.0" Description="How many times to repeat."/>
+            <Parameter Name="Interval" Type="Data::NumberType" DefaultValue="0.0" Description="The Interval between repetitions. If zero, all repititions execute immediately, before On Start"/>
+        </Input>
 
-      <!-- Input tag is for an execution input that has optional data (parameters) -->
-      <Input Name="Start" Description="">
-        <Parameter Name="Repetitions" Type="Data::NumberType" DefaultValue="0.0" Description="How many times to repeat."/>
-        <Parameter Name="Interval" Type="Data::NumberType" DefaultValue="0.0" Description="The Interval between repetitions. If zero, all repititions execute immediately, before On Start"/>
-      </Input>
+        <Output Name="Complete" Description="Signaled upon node exit"/>
+        <Output Name="Action" Description="Signaled every repetition"/>
 
-      <Output Name="Complete" Description="Signaled upon node exit"/>
-      <Output Name="Action" Description="Signaled every repetition"/>
-
-      <PropertyInterface Property="m_timeUnitsInterface" Name="Units" Type="Input" Description="Units to represent the time in."/>
-
+        <PropertyInterface Property="m_timeUnitsInterface" Name="Units" Type="Input" Description="Units to represent the time in."/>
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/TimeDelayNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/TimeDelayNodeable.ScriptCanvasNodeable.xml
@@ -2,22 +2,19 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/TimeDelayNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="TimeDelayNodeable"
-           QualifiedName="Nodeables::Time::TimeDelayNodeable"
-           PreferredClassName="Time Delay"
-           Base="Nodeables::Time::BaseTimer"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Timing"
-           GeneratePropertyFriend="True"
-           Namespace="ScriptCanvas"
-           Description="Delays all incoming execution for the specified number of ticks">
+        QualifiedName="Nodeables::Time::TimeDelayNodeable"
+        PreferredClassName="Time Delay"
+        Base="Nodeables::Time::BaseTimer"
+        Category="Timing"
+        Namespace="ScriptCanvas"
+        Description="Delays all incoming execution for the specified number of ticks">
 
-      <Input Name="Start" Description="">
-        <Parameter Name="Delay" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time to delay before the Done is signalled."/>
-      </Input>
+        <Input Name="Start" Description="">
+            <Parameter Name="Delay" Type="Data::NumberType" DefaultValue="0.0" Description="The amount of time to delay before the Done is signalled."/>
+        </Input>
 
-      <Output Name="Done" Description="Signaled after waiting for the specified amount of times."/>
+        <Output Name="Done" Description="Signaled after waiting for the specified amount of times."/>
 
-      <PropertyInterface Property="m_timeUnitsInterface" Name="Units" Type="Input" Description="Units to represent the time in."/>
-
+        <PropertyInterface Property="m_timeUnitsInterface" Name="Units" Type="Input" Description="Units to represent the time in."/>
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/TimerNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Time/TimerNodeable.ScriptCanvasNodeable.xml
@@ -2,22 +2,18 @@
 
 <ScriptCanvas Include="Include/ScriptCanvas/Libraries/Time/TimerNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="TimerNodeable"
-           QualifiedName="Nodeables::Time::TimerNodeable"
-           PreferredClassName="Timer"
-           Base="ScriptCanvas::Nodeable"
-           Icon="Icons/ScriptCanvas/Placeholder.png"
-           Category="Timing"
-           GeneratePropertyFriend="True"
-           Namespace="ScriptCanvas"
-           Description="While active, will signal the output at the given interval.">
+        QualifiedName="Nodeables::Time::TimerNodeable"
+        PreferredClassName="Timer"
+        Category="Timing"
+        Namespace="ScriptCanvas"
+        Description="While active, will signal the output at the given interval.">
 
-      <Input Name="Start" Description="Starts the timer"/>
-      <Input Name="Stop" Description="Stops the timer"/>
+        <Input Name="Start" Description="Starts the timer"/>
+        <Input Name="Stop" Description="Stops the timer"/>
 
-      <Output Name="On Tick" Description="Signaled at each tick while the timer is in operation.">
-        <Parameter Name="Milliseconds" Type="Data::NumberType" Description="The amount of time that has elapsed since the timer started in milliseconds."/>
-        <Parameter Name="Seconds" Type="Data::NumberType" Description="The amount of time that has elapsed since the timer started in seconds."/>
-      </Output>
-
+        <Output Name="On Tick" Description="Signaled at each tick while the timer is in operation.">
+            <Parameter Name="Milliseconds" Type="Data::NumberType" Description="The amount of time that has elapsed since the timer started in milliseconds."/>
+            <Parameter Name="Seconds" Type="Data::NumberType" Description="The amount of time that has elapsed since the timer started in seconds."/>
+        </Output>
     </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvasTesting/Code/Source/Nodes/Nodeables/SharedDataSlotExample.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvasTesting/Code/Source/Nodes/Nodeables/SharedDataSlotExample.ScriptCanvasNodeable.xml
@@ -1,55 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScriptCanvas Include="Source/Nodes/Nodeables/SharedDataSlotExample.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Class Name="InputMethodSharedDataSlotExample"
-         QualifiedName="ScriptCanvasTesting::Nodeables::InputMethodSharedDataSlotExample"
-         PreferredClassName="InputMethodSharedDataSlotExample"
-         Base="ScriptCanvas::Nodeable"
-         Icon="Icons/ScriptCanvas/Placeholder.png"
-         Category="Tests"
-         GeneratePropertyFriend="True"
-         Namespace="None"
-         Description="Input Method Shared Data">
-    <Input Name="Append Hello" Description="" DisplayGroup="InputMethodGroup">
-      <Parameter Name="str" Type="const ScriptCanvas::Data::StringType&amp;"/>
-      <Return Name="Output" Type="ScriptCanvas::Data::StringType" Shared="true" DisplayGroup="InputMethodGroup"/>
-    </Input>
-    <Input Name="Concatenate Two" Description="" DisplayGroup="Concatenate Two">
-      <Parameter Name="a" Type="const ScriptCanvas::Data::StringType&amp;"/>
-      <Parameter Name="b" Type="const ScriptCanvas::Data::StringType&amp;"/>
-      <Return Name="Output" Type="ScriptCanvas::Data::StringType" Shared="true" DisplayGroup="InputMethodGroup"/>
-    </Input>
-    <Input Name="Concatenate Three" Description="" DisplayGroup="Concatenate Three">
-      <Parameter Name="a" Type="const ScriptCanvas::Data::StringType&amp;"/>
-      <Parameter Name="b" Type="const ScriptCanvas::Data::StringType&amp;"/>
-      <Parameter Name="c" Type="const ScriptCanvas::Data::StringType&amp;"/>
-      <Return Name="Output" Type="ScriptCanvas::Data::StringType" Shared="true" DisplayGroup="InputMethodGroup"/>
-    </Input>
-  </Class>
-  <Class Name="BranchMethodSharedDataSlotExample"
-         QualifiedName="ScriptCanvasTesting::Nodeables::BranchMethodSharedDataSlotExample"
-         PreferredClassName="BranchMethodSharedDataSlotExample"
-         Base="ScriptCanvas::Nodeable"
-         Icon="Icons/ScriptCanvas/Placeholder.png"
-         Category="Tests"
-         GeneratePropertyFriend="True"
-         Description="Branch Test">
-    <Branch Name="String Magicbox" Description="">
-      <Parameter Name="input" Type="ScriptCanvas::Data::NumberType" DefaultValue="0.0"/>
-    </Branch>
-    <Output Name="One String" DisplayGroup="String Magicbox">
-      <Parameter Name="string" Type="ScriptCanvas::Data::StringType"/>
-    </Output>
-    <Output Name="Two Strings" Type="ScriptCanvas::Data::StringType" DisplayGroup="String Magicbox">
-      <Parameter Name="string1" Type="ScriptCanvas::Data::StringType"/>
-      <Parameter Name="string2" Type="ScriptCanvas::Data::StringType"/>
-    </Output>
-    <Output Name="Three Strings" Type="Data::StringType" DisplayGroup="String Magicbox">
-      <Parameter Name="string1" Type="ScriptCanvas::Data::StringType"/>
-      <Parameter Name="string2" Type="ScriptCanvas::Data::StringType"/>
-      <Parameter Name="string3" Type="ScriptCanvas::Data::StringType"/>
-    </Output>
-    <Output Name="Square" Type="ScriptCanvas::Data::StringType"/>
-    <Output Name="Pants" Type="ScriptCanvas::Data::StringType"/>
-    <Output Name="Hello" Type="ScriptCanvas::Data::StringType" DisplayGroup="BranchExecutionGroup"/>
-  </Class>
+    <Class Name="InputMethodSharedDataSlotExample"
+        QualifiedName="ScriptCanvasTesting::Nodeables::InputMethodSharedDataSlotExample"
+        PreferredClassName="InputMethodSharedDataSlotExample"
+        Category="Tests"
+        Description="Input Method Shared Data">     
+        <Input Name="Append Hello" Description="" DisplayGroup="InputMethodGroup">
+            <Parameter Name="str" Type="const ScriptCanvas::Data::StringType&amp;"/>
+            <Return Name="Output" Type="ScriptCanvas::Data::StringType" Shared="true" DisplayGroup="InputMethodGroup"/>
+        </Input>
+        <Input Name="Concatenate Two" Description="" DisplayGroup="Concatenate Two">
+            <Parameter Name="a" Type="const ScriptCanvas::Data::StringType&amp;"/>
+            <Parameter Name="b" Type="const ScriptCanvas::Data::StringType&amp;"/>
+            <Return Name="Output" Type="ScriptCanvas::Data::StringType" Shared="true" DisplayGroup="InputMethodGroup"/>
+        </Input>
+        <Input Name="Concatenate Three" Description="" DisplayGroup="Concatenate Three">
+            <Parameter Name="a" Type="const ScriptCanvas::Data::StringType&amp;"/>
+            <Parameter Name="b" Type="const ScriptCanvas::Data::StringType&amp;"/>
+            <Parameter Name="c" Type="const ScriptCanvas::Data::StringType&amp;"/>
+            <Return Name="Output" Type="ScriptCanvas::Data::StringType" Shared="true" DisplayGroup="InputMethodGroup"/>
+        </Input>
+    </Class>
+    
+    <Class Name="BranchMethodSharedDataSlotExample"
+        QualifiedName="ScriptCanvasTesting::Nodeables::BranchMethodSharedDataSlotExample"
+        PreferredClassName="BranchMethodSharedDataSlotExample"
+        Category="Tests"
+        Description="Branch Test">
+        <Branch Name="String Magicbox" Description="">
+            <Parameter Name="input" Type="ScriptCanvas::Data::NumberType" DefaultValue="0.0"/>
+        </Branch>
+        <Output Name="One String" DisplayGroup="String Magicbox">
+            <Parameter Name="string" Type="ScriptCanvas::Data::StringType"/>
+        </Output>
+        <Output Name="Two Strings" Type="ScriptCanvas::Data::StringType" DisplayGroup="String Magicbox">
+            <Parameter Name="string1" Type="ScriptCanvas::Data::StringType"/>
+            <Parameter Name="string2" Type="ScriptCanvas::Data::StringType"/>
+        </Output>
+        <Output Name="Three Strings" Type="Data::StringType" DisplayGroup="String Magicbox">
+            <Parameter Name="string1" Type="ScriptCanvas::Data::StringType"/>
+            <Parameter Name="string2" Type="ScriptCanvas::Data::StringType"/>
+            <Parameter Name="string3" Type="ScriptCanvas::Data::StringType"/>
+        </Output>
+        <Output Name="Square" Type="ScriptCanvas::Data::StringType"/>
+        <Output Name="Pants" Type="ScriptCanvas::Data::StringType"/>
+        <Output Name="Hello" Type="ScriptCanvas::Data::StringType" DisplayGroup="BranchExecutionGroup"/>
+    </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvasTesting/Code/Source/Nodes/Nodeables/ValuePointerReferenceExample.ScriptCanvasNodeable.xml
+++ b/Gems/ScriptCanvasTesting/Code/Source/Nodes/Nodeables/ValuePointerReferenceExample.ScriptCanvasNodeable.xml
@@ -1,89 +1,54 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- These are examples on how to create different kinds of nodes, by default they do not show 
-on the Script Canvas node palette, to show them, remove the following attribute from the desired 
-node:
-
-EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
--->
-
 <ScriptCanvas Include="Source/Nodes/Nodeables/ValuePointerReferenceExample.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-  <Class Name="ReturnTypeExample"
-            QualifiedName="ScriptCanvasTesting::Nodeables::ReturnTypeExample"
-            PreferredClassName="Return Type Example"
-            Base="ScriptCanvas::Nodeable"
-            Icon="Icons/ScriptCanvas/Placeholder.png"
-            Category="Examples"
-            GeneratePropertyFriend="True"
-            Namespace="None"
-            EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-            Description="Example of returning by value, pointer and reference.">
-    <Input Name="Return By Value"  >
-      <Return Name="Value" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;" />
-    </Input>
-    <Input Name="Return By Pointer"  >
-      <Return Name="Pointer" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;*" />
-    </Input>
-    <Input Name="Return By Reference" >
-      <Return Name="Reference" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;&amp;" />
-    </Input>
-  </Class>
-  <Class Name="BranchInputTypeExample"
-            QualifiedName="ScriptCanvasTesting::Nodeables::BranchInputTypeExample"
-            PreferredClassName="Branch Input Type Example"
-            Base="ScriptCanvas::Nodeable"
-            Icon="Icons/ScriptCanvas/Placeholder.png"
-            Category="Examples"
-            GeneratePropertyFriend="True"
-            Namespace="None"
-            EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-            Description="Example of branch passing as input by value, pointer and reference.">
-    <Input Name="Get Internal Vector" Description="">
-      <Return Name="Result" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;" />
-    </Input>
-    <Input Name="Branches On Input Type" Description="" DisplayGroup="Branches On Input Type">
-      <Parameter Name="Input Type" Type="AZStd::string"/>
-      <Branch Name="By Value" Description="" DisplayGroup="Branches On Input Type">
-        <Return Name="Value Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;&amp;" DisplayGroup="Branches On Input Type"/>
-      </Branch>
-      <Branch Name="By Pointer" Description="" DisplayGroup="Branches On Input Type">
-        <Return Name="Pointer Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;*" DisplayGroup="Branches On Input Type"/>
-      </Branch>
-    </Input>
-  </Class>
-  <Class Name="InputTypeExample"
-            QualifiedName="ScriptCanvasTesting::Nodeables::InputTypeExample"
-            PreferredClassName="Input Type Example"
-            Base="ScriptCanvas::Nodeable"
-            Icon="Icons/ScriptCanvas/Placeholder.png"
-            Category="Examples"
-            GeneratePropertyFriend="True"
-            Namespace="None"
-            EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-            Description="Example of passing as input by value, pointer and reference.">
-    <Input Name="Clear By Value" Description="">
-      <Parameter Name="Value Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;"/>
-    </Input>
-    <Input Name="Clear By Pointer" Description="">
-      <Parameter Name="Pointer Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;*"/>
-    </Input>
-    <Input Name="Clear By Reference" Description="">
-      <Parameter Name="Reference Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;&amp;"/>
-    </Input>
-  </Class>
-  <Class Name="PropertyExample"
-            QualifiedName="ScriptCanvasTesting::Nodeables::PropertyExample"
-            PreferredClassName="Property Example"
-            Base="ScriptCanvas::Nodeable"
-            Icon="Icons/ScriptCanvas/Placeholder.png"
-            Category="Examples"
-            GeneratePropertyFriend="True"
-            Namespace="None"
-            EditAttributes="AZ::Script::Attributes::ExcludeFrom@AZ::Script::Attributes::ExcludeFlags::All"
-            Description="Example of using properties.">
-    <Input Name="In" Description=""/>
-    <Property Name="Numbers" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;"/>
-    <Property Name="Slang" Type="ScriptCanvas::Data::StringType"/>
-    <Property Name="Position" Type="ScriptCanvas::Data::Vector3Type"/>
-  </Class>
+    <Class Name="ReturnTypeExample"
+        QualifiedName="ScriptCanvasTesting::Nodeables::ReturnTypeExample"
+        PreferredClassName="Return Type Example"
+        Category="Examples"
+        Description="Example of returning by value, pointer and reference.">
+        <Input Name="Return By Value"  >
+            <Return Name="Value" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;" />
+        </Input>
+        <Input Name="Return By Pointer"  >
+            <Return Name="Pointer" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;*" />
+        </Input>
+        <Input Name="Return By Reference" >
+            <Return Name="Reference" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;&amp;" />
+        </Input>
+    </Class>
+    
+    <Class Name="BranchInputTypeExample"
+        QualifiedName="ScriptCanvasTesting::Nodeables::BranchInputTypeExample"
+        PreferredClassName="Branch Input Type Example"
+        Category="Examples"
+        Description="Example of branch passing as input by value, pointer and reference.">
+        <Input Name="Get Internal Vector" Description="">
+            <Return Name="Result" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;" />
+        </Input>
+        <Input Name="Branches On Input Type" Description="" DisplayGroup="Branches On Input Type">
+            <Parameter Name="Input Type" Type="AZStd::string"/>
+            <Branch Name="By Value" Description="" DisplayGroup="Branches On Input Type">
+                <Return Name="Value Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;&amp;" DisplayGroup="Branches On Input Type"/>
+            </Branch>
+            <Branch Name="By Pointer" Description="" DisplayGroup="Branches On Input Type">
+                <Return Name="Pointer Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;*" DisplayGroup="Branches On Input Type"/>
+            </Branch>
+        </Input>
+    </Class>
+    
+    <Class Name="InputTypeExample"
+        QualifiedName="ScriptCanvasTesting::Nodeables::InputTypeExample"
+        PreferredClassName="Input Type Example"
+        Category="Examples"
+        Description="Example of passing as input by value, pointer and reference.">
+        <Input Name="Clear By Value" Description="">
+            <Parameter Name="Value Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;"/>
+        </Input>
+        <Input Name="Clear By Pointer" Description="">
+            <Parameter Name="Pointer Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;*"/>
+        </Input>
+        <Input Name="Clear By Reference" Description="">
+            <Parameter Name="Reference Input" Type="AZStd::vector&lt;ScriptCanvas::Data::NumberType&gt;&amp;"/>
+        </Input>
+    </Class>
 </ScriptCanvas>

--- a/Gems/ScriptCanvasTesting/Code/Source/Nodes/Nodeables/ValuePointerReferenceExample.cpp
+++ b/Gems/ScriptCanvasTesting/Code/Source/Nodes/Nodeables/ValuePointerReferenceExample.cpp
@@ -62,15 +62,5 @@ namespace ScriptCanvasTesting
         {
             input.clear();
         }
-
-        void PropertyExample::In()
-        {
-            for ([[maybe_unused]] auto& num : Numbers)
-            {
-                AZ_TracePrintf("ScriptCanvas", "%f", num);
-            }
-
-            AZ_TracePrintf("ScriptCanvas", "Slang: %s", Slang.c_str());
-        }
     }
 }

--- a/Gems/ScriptCanvasTesting/Code/Source/Nodes/Nodeables/ValuePointerReferenceExample.h
+++ b/Gems/ScriptCanvasTesting/Code/Source/Nodes/Nodeables/ValuePointerReferenceExample.h
@@ -44,11 +44,5 @@ namespace ScriptCanvasTesting
         {
             SCRIPTCANVAS_NODE(InputTypeExample);
         };
-
-        class PropertyExample
-            : public ScriptCanvas::Nodeable
-        {
-            SCRIPTCANVAS_NODE(PropertyExample);
-        };
     }
 }

--- a/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.ScriptCanvasNodeable.xml
@@ -2,27 +2,23 @@
 
 <ScriptCanvas Include="Source/InputHandlerNodeable.h" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <Class Name="InputHandlerNodeable"
-           Namespace="StartingPointInput"
-           QualifiedName="StartingPointInput::InputHandlerNodeable"
-           PreferredClassName="Input Handler"
-           Base="ScriptCanvas::Nodeable"
-           Icon="Icons/ScriptCanvas/Bus.png"
-           EditAttributes="AZ::Edit::Attributes::Category@Gameplay/Input"
-           GraphEntryPoint="True"
-           GeneratePropertyFriend="True"
-           Description="Handle processed input events found in input binding assets">
+        Namespace="StartingPointInput"
+        QualifiedName="StartingPointInput::InputHandlerNodeable"
+        PreferredClassName="Input Handler"
+        GraphEntryPoint="True"
+        Description="Handle processed input events found in input binding assets">
 
-      <Output Name="Pressed" Description="Signaled when the input event begins." >
-        <Parameter Name="value" Type="float" Shared="true"/>
-      </Output>
-      <Output Name="Held" Description="Signaled while the input event is active." >
-        <Parameter Name="value" Type="float" Shared="true"/>
-      </Output>
-      <Output Name="Released" Description="Signaled when the input event ends." >
-        <Parameter Name="value" Type="float" Shared="true"/>
-      </Output>
-      <Input Name="Connect Event" Description="Connect to input event name as defined in an input binding asset.">
-        <Parameter Name="Event Name" Type="AZStd::string" Description="Event name as defined in an input binding asset.  Example 'Fireball'."/>
-      </Input>/>
+        <Output Name="Pressed" Description="Signaled when the input event begins." >
+            <Parameter Name="value" Type="float" Shared="true"/>
+        </Output>
+        <Output Name="Held" Description="Signaled while the input event is active." >
+            <Parameter Name="value" Type="float" Shared="true"/>
+        </Output>
+        <Output Name="Released" Description="Signaled when the input event ends." >
+            <Parameter Name="value" Type="float" Shared="true"/>
+        </Output>
+        <Input Name="Connect Event" Description="Connect to input event name as defined in an input binding asset.">
+            <Parameter Name="Event Name" Type="AZStd::string" Description="Event name as defined in an input binding asset.  Example 'Fireball'."/>
+        </Input>/>
     </Class>
 </ScriptCanvas>

--- a/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.ScriptCanvasNodeable.xml
+++ b/Gems/StartingPointInput/Code/Source/InputHandlerNodeable.ScriptCanvasNodeable.xml
@@ -5,6 +5,7 @@
         Namespace="StartingPointInput"
         QualifiedName="StartingPointInput::InputHandlerNodeable"
         PreferredClassName="Input Handler"
+        Category="Input"
         GraphEntryPoint="True"
         Description="Handle processed input events found in input binding assets">
 


### PR DESCRIPTION
## Details
* Clean up xml file by removing some useless Class attributes, like Icon, GeneratePropertyFriend, etc.
* Simply xml file by supporting default value for some Class attributes, like, Base and Version (User doesn't need to provide unless they are specifically different)
* Formatting xml file with consistent style (consistent indentation and spacing)

## Testing
No functional change, no runtime behavior impact, all related nodes are able to get reflected and created through SC editor correctly

Signed-off-by: onecent1101 <liug@amazon.com>