### PR TITLE
Add more nodes to the palette and more options for their data

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
@@ -253,17 +253,18 @@ namespace ScriptCanvasEditor::Nodes
         return nodeIdPair;
     }
 
-    NodeIdPair CreateDataDrivenNode(const AZStd::any& nodeData, [[maybe_unused]] const AZ::Crc32& nodeId, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
+    NodeIdPair CreateDataDrivenNode(const AZStd::any& nodeData, const AZ::Crc32& nodeLexicalId, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
     {
         // TODO: Make this check what types nodeData can be cast to and decide what create function to run based on that
-        return CreateSmallOperatorNode(AZStd::any_cast<SmallOperatorCreationData>(nodeData), scriptCanvasId);
+        return CreateSmallOperatorNode(AZStd::any_cast<SmallOperatorCreationData>(nodeData), nodeLexicalId, scriptCanvasId);
     }
 
-    NodeIdPair CreateSmallOperatorNode(const SmallOperatorCreationData& nodeData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
+    NodeIdPair CreateSmallOperatorNode(const SmallOperatorCreationData& nodeData, const AZ::Crc32& nodeLexicalId, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
     {
         ScriptCanvas::Node* node = aznew ScriptCanvas::Node();
         node->SetNodeName(nodeData.m_title);
         node->SetNodeToolTip(nodeData.m_toolTip);
+        node->SetNodenodeLexicalId(nodeLexicalId);
 
         ScriptCanvas::DynamicDataSlotConfiguration inputPin;
         inputPin.m_name = " ";

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.cpp
@@ -37,7 +37,11 @@ namespace ScriptCanvasEditor::Nodes
         AZ::SerializeContext* serializeContext = azrtti_cast<AZ::SerializeContext*>(reflectContext);
         if (serializeContext)
         {
-            serializeContext->Class<SmallOperatorCreationData>()->Version(0)->Field("Title", &SmallOperatorCreationData::m_title);
+            serializeContext->Class<SmallOperatorCreationData>()
+                ->Version(0)
+                ->Field("Title", &SmallOperatorCreationData::m_title)
+                ->Field("ToolTip", &SmallOperatorCreationData::m_toolTip)
+                ->Field("DataType", &SmallOperatorCreationData::m_dataType);
         }
     }
 
@@ -249,7 +253,7 @@ namespace ScriptCanvasEditor::Nodes
         return nodeIdPair;
     }
 
-    NodeIdPair CreateDataDrivenNode(const AZStd::any& nodeData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
+    NodeIdPair CreateDataDrivenNode(const AZStd::any& nodeData, [[maybe_unused]] const AZ::Crc32& nodeId, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
     {
         // TODO: Make this check what types nodeData can be cast to and decide what create function to run based on that
         return CreateSmallOperatorNode(AZStd::any_cast<SmallOperatorCreationData>(nodeData), scriptCanvasId);
@@ -257,45 +261,31 @@ namespace ScriptCanvasEditor::Nodes
 
     NodeIdPair CreateSmallOperatorNode(const SmallOperatorCreationData& nodeData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId)
     {
-        NodeIdPair nodeIdPair;
-
-        ScriptCanvas::Node* node{};
-        AZ::Entity* scriptCanvasEntity{ aznew AZ::Entity };
-        scriptCanvasEntity->Init();
-        nodeIdPair.m_scriptCanvasId = scriptCanvasEntity->GetId();
-
-        AZ::Entity* nodeEntity = nullptr;
-        AZ::ComponentApplicationBus::BroadcastResult(nodeEntity, &AZ::ComponentApplicationRequests::FindEntity, scriptCanvasEntity->GetId());
-
-        node = aznew ScriptCanvas::Node();
+        ScriptCanvas::Node* node = aznew ScriptCanvas::Node();
         node->SetNodeName(nodeData.m_title);
+        node->SetNodeToolTip(nodeData.m_toolTip);
 
         ScriptCanvas::DynamicDataSlotConfiguration inputPin;
-
         inputPin.m_name = " ";
         inputPin.m_toolTip = "Input";
         inputPin.m_canHaveInputField = false;
         inputPin.SetConnectionType(ScriptCanvas::ConnectionType::Input);
-        inputPin.m_displayType = ScriptCanvas::Data::Type::Number();
-
-        node->AddSlot(inputPin, true);
+        inputPin.m_displayType = nodeData.m_dataType;
 
         ScriptCanvas::DynamicDataSlotConfiguration outputPin;
-
         outputPin.m_name = " ";
         outputPin.m_toolTip = "Output";
         outputPin.SetConnectionType(ScriptCanvas::ConnectionType::Output);
-        outputPin.m_displayType = ScriptCanvas::Data::Type::Number(); 
+        outputPin.m_displayType = nodeData.m_dataType; 
 
-        node->AddSlot(outputPin, true);
-
-        if (node && nodeEntity)
-        {
-            nodeEntity->SetName(node->GetNodeName());
-            nodeEntity->AddComponent(node);
-        }
-
+        AZ::Entity* nodeEntity{ aznew AZ::Entity };
+        nodeEntity->Init();
+        nodeEntity->SetName(node->GetNodeName());
+        nodeEntity->AddComponent(node);
         ScriptCanvas::GraphRequestBus::Event(scriptCanvasId, &ScriptCanvas::GraphRequests::AddNode, nodeEntity->GetId());
+
+        node->AddSlot(inputPin, true);
+        node->AddSlot(outputPin, true);
 
         AZ::EntityId graphCanvasGraphId;
         EditorGraphRequestBus::EventResult(graphCanvasGraphId, scriptCanvasId, &EditorGraphRequests::GetGraphCanvasGraphId);
@@ -303,11 +293,12 @@ namespace ScriptCanvasEditor::Nodes
         NodeReplacementConfiguration nodeConfiguration;
         nodeConfiguration.m_nodeSubStyle = GraphCanvas::Styling::Elements::Small;
 
+        NodeIdPair nodeIdPair;
+        nodeIdPair.m_scriptCanvasId = nodeEntity->GetId();
         nodeIdPair.m_graphCanvasId = DisplayGeneralScriptCanvasNode(graphCanvasGraphId, node, nodeConfiguration);
 
         return nodeIdPair;
     }
-
 
     NodeIdPair CreateScriptEventReceiverNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const AZ::Data::AssetId& assetId)
     {

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
@@ -53,9 +53,8 @@ namespace ScriptCanvasEditor::Nodes
     NodeIdPair CreateEbusWrapperNode(AZStd::string_view busName, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
 
     // Create methods for data driven nodes
-    NodeIdPair CreateDataDrivenNode(
-        const AZStd::any& nodeData, const AZ::Crc32& nodeId, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
-    NodeIdPair CreateSmallOperatorNode(const SmallOperatorCreationData& smallOperatorNodeData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
+    NodeIdPair CreateDataDrivenNode(const AZStd::any& nodeData, const AZ::Crc32& nodeLexicalId, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
+    NodeIdPair CreateSmallOperatorNode(const SmallOperatorCreationData& smallOperatorNodeData, const AZ::Crc32& nodeLexicalId, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
 
     // Script Events
     NodeIdPair CreateScriptEventReceiverNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId, const AZ::Data::AssetId& assetId);

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeCreateUtils.h
@@ -28,6 +28,8 @@ namespace ScriptEvents
 
 namespace ScriptCanvasEditor::Nodes
 {
+
+    // User defined data for small operator nodes
     struct SmallOperatorCreationData
     {
         AZ_RTTI(SmallOperatorCreationData, "{A7DE9ECF-81F9-4A03-B3E4-3510591A50BB}");
@@ -37,7 +39,9 @@ namespace ScriptCanvasEditor::Nodes
 
         virtual ~SmallOperatorCreationData() = default;
 
-        AZStd::string m_title;  // Right now only stores title, will make it store other stuff in the future
+        AZStd::string m_title;
+        AZStd::string m_toolTip;
+        ScriptCanvas::Data::Type m_dataType;
     };
 
     // Specific create methods which will also handle displaying the node.
@@ -49,7 +53,8 @@ namespace ScriptCanvasEditor::Nodes
     NodeIdPair CreateEbusWrapperNode(AZStd::string_view busName, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
 
     // Create methods for data driven nodes
-    NodeIdPair CreateDataDrivenNode(const AZStd::any& nodeData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
+    NodeIdPair CreateDataDrivenNode(
+        const AZStd::any& nodeData, const AZ::Crc32& nodeId, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
     NodeIdPair CreateSmallOperatorNode(const SmallOperatorCreationData& smallOperatorNodeData, const ScriptCanvas::ScriptCanvasId& scriptCanvasId);
 
     // Script Events

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -188,7 +188,7 @@ namespace ScriptCanvasEditor::Nodes
         GraphCanvas::NodeTitleRequestBus::Event(
             graphCanvasEntity->GetId(), &GraphCanvas::NodeTitleRequests::SetSubTitle, details.m_category);
 
-        if (node->GetNodeToolTip() == "")   // Old way of setting the node tooltip
+        if (node->GetNodeToolTip().empty())   // Old way of setting the node tooltip
         {
             // Add to the tooltip the C++ class for reference
             if (!details.m_tooltip.empty())
@@ -200,7 +200,9 @@ namespace ScriptCanvasEditor::Nodes
         }
         else
         {
-            GraphCanvas::NodeRequestBus::Event(graphCanvasEntity->GetId(), &GraphCanvas::NodeRequests::SetTooltip, node->GetNodeToolTip());
+            AZStd::string toolTip = node->GetNodeToolTip();
+            toolTip.append(AZStd::string::format("\n[C++] %s", node->GetNodeTypeName().c_str()));
+            GraphCanvas::NodeRequestBus::Event(graphCanvasEntity->GetId(), &GraphCanvas::NodeRequests::SetTooltip, toolTip);
         }
         
         if (!nodeConfiguration.m_titlePalette.empty())

--- a/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Nodes/NodeDisplayUtils.cpp
@@ -188,15 +188,21 @@ namespace ScriptCanvasEditor::Nodes
         GraphCanvas::NodeTitleRequestBus::Event(
             graphCanvasEntity->GetId(), &GraphCanvas::NodeTitleRequests::SetSubTitle, details.m_category);
 
-        // Add to the tooltip the C++ class for reference
-        if (!details.m_tooltip.empty())
+        if (node->GetNodeToolTip() == "")   // Old way of setting the node tooltip
         {
-            details.m_tooltip.append("\n");
+            // Add to the tooltip the C++ class for reference
+            if (!details.m_tooltip.empty())
+            {
+                details.m_tooltip.append("\n");
+            }
+            details.m_tooltip.append(AZStd::string::format("[C++] %s", node->GetNodeTypeName().c_str()));
+            GraphCanvas::NodeRequestBus::Event(graphCanvasEntity->GetId(), &GraphCanvas::NodeRequests::SetTooltip, details.m_tooltip);
         }
-        details.m_tooltip.append(AZStd::string::format("[C++] %s", node->GetNodeTypeName().c_str()));
-
-        GraphCanvas::NodeRequestBus::Event(graphCanvasEntity->GetId(), &GraphCanvas::NodeRequests::SetTooltip, details.m_tooltip);
-
+        else
+        {
+            GraphCanvas::NodeRequestBus::Event(graphCanvasEntity->GetId(), &GraphCanvas::NodeRequests::SetTooltip, node->GetNodeToolTip());
+        }
+        
         if (!nodeConfiguration.m_titlePalette.empty())
         {
             GraphCanvas::NodeTitleRequestBus::Event(

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -332,8 +332,8 @@ namespace ScriptCanvasEditor
         {
             serializeContext->Class<CreateDataDrivenNodeMimeEvent, GraphCanvas::GraphCanvasMimeEvent>()
                 ->Version(0)
-                ->Field("nodeLexicalId", &CreateDataDrivenNodeMimeEvent::m_nodeLexicalId)
-                ->Field("NodeData", &CreateDataDrivenNodeMimeEvent::m_userData);
+                ->Field("NodeLexicalId", &CreateDataDrivenNodeMimeEvent::m_nodeLexicalId)
+                ->Field("UserData", &CreateDataDrivenNodeMimeEvent::m_userData);
         }
     }
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -332,20 +332,20 @@ namespace ScriptCanvasEditor
         {
             serializeContext->Class<CreateDataDrivenNodeMimeEvent, GraphCanvas::GraphCanvasMimeEvent>()
                 ->Version(0)
-                ->Field("NodeId", &CreateDataDrivenNodeMimeEvent::m_nodeId)
+                ->Field("NodeDefaultsId", &CreateDataDrivenNodeMimeEvent::m_nodeDefaultsId)
                 ->Field("NodeData", &CreateDataDrivenNodeMimeEvent::m_userData);
         }
     }
 
     CreateDataDrivenNodeMimeEvent::CreateDataDrivenNodeMimeEvent(const AZ::Crc32& nodeId, const AZStd::any& nodeData)
-        : m_nodeId(nodeId)
+        : m_nodeDefaultsId(nodeId)
         , m_userData(nodeData)
     {
     }
 
     ScriptCanvasEditor::NodeIdPair CreateDataDrivenNodeMimeEvent::CreateNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId) const
     {
-        return Nodes::CreateDataDrivenNode(m_userData, m_nodeId, scriptCanvasId);
+        return Nodes::CreateDataDrivenNode(m_userData, m_nodeDefaultsId, scriptCanvasId);
     }
 
     //////////////////////////////
@@ -360,6 +360,6 @@ namespace ScriptCanvasEditor
 
     GraphCanvas::GraphCanvasMimeEvent* DataDrivenNodePaletteTreeItem::CreateMimeEvent() const
     {
-        return aznew CreateDataDrivenNodeMimeEvent(m_info.m_nodeId, m_info.m_userData);
+        return aznew CreateDataDrivenNodeMimeEvent(m_info.m_nodeDefaultsId, m_info.m_userData);
     }
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -332,20 +332,20 @@ namespace ScriptCanvasEditor
         {
             serializeContext->Class<CreateDataDrivenNodeMimeEvent, GraphCanvas::GraphCanvasMimeEvent>()
                 ->Version(0)
-                ->Field("MimeId", &CreateDataDrivenNodeMimeEvent::m_nodeId)
+                ->Field("NodeId", &CreateDataDrivenNodeMimeEvent::m_nodeId)
                 ->Field("NodeData", &CreateDataDrivenNodeMimeEvent::m_userData);
         }
     }
 
-    CreateDataDrivenNodeMimeEvent::CreateDataDrivenNodeMimeEvent(const AZ::Crc32& mimeId, const AZStd::any& nodeData)
-        : m_nodeId(mimeId)
+    CreateDataDrivenNodeMimeEvent::CreateDataDrivenNodeMimeEvent(const AZ::Crc32& nodeId, const AZStd::any& nodeData)
+        : m_nodeId(nodeId)
         , m_userData(nodeData)
     {
     }
 
     ScriptCanvasEditor::NodeIdPair CreateDataDrivenNodeMimeEvent::CreateNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId) const
     {
-        return Nodes::CreateDataDrivenNode(m_userData, scriptCanvasId);
+        return Nodes::CreateDataDrivenNode(m_userData, m_nodeId, scriptCanvasId);
     }
 
     //////////////////////////////

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.cpp
@@ -332,20 +332,20 @@ namespace ScriptCanvasEditor
         {
             serializeContext->Class<CreateDataDrivenNodeMimeEvent, GraphCanvas::GraphCanvasMimeEvent>()
                 ->Version(0)
-                ->Field("NodeDefaultsId", &CreateDataDrivenNodeMimeEvent::m_nodeDefaultsId)
+                ->Field("nodeLexicalId", &CreateDataDrivenNodeMimeEvent::m_nodeLexicalId)
                 ->Field("NodeData", &CreateDataDrivenNodeMimeEvent::m_userData);
         }
     }
 
-    CreateDataDrivenNodeMimeEvent::CreateDataDrivenNodeMimeEvent(const AZ::Crc32& nodeId, const AZStd::any& nodeData)
-        : m_nodeDefaultsId(nodeId)
+    CreateDataDrivenNodeMimeEvent::CreateDataDrivenNodeMimeEvent(const AZ::Crc32& nodeLexicalId, const AZStd::any& nodeData)
+        : m_nodeLexicalId(nodeLexicalId)
         , m_userData(nodeData)
     {
     }
 
     ScriptCanvasEditor::NodeIdPair CreateDataDrivenNodeMimeEvent::CreateNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId) const
     {
-        return Nodes::CreateDataDrivenNode(m_userData, m_nodeDefaultsId, scriptCanvasId);
+        return Nodes::CreateDataDrivenNode(m_userData, m_nodeLexicalId, scriptCanvasId);
     }
 
     //////////////////////////////
@@ -360,6 +360,6 @@ namespace ScriptCanvasEditor
 
     GraphCanvas::GraphCanvasMimeEvent* DataDrivenNodePaletteTreeItem::CreateMimeEvent() const
     {
-        return aznew CreateDataDrivenNodeMimeEvent(m_info.m_nodeDefaultsId, m_info.m_userData);
+        return aznew CreateDataDrivenNodeMimeEvent(m_info.m_nodeLexicalId, m_info.m_userData);
     }
 }

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
@@ -177,7 +177,7 @@ namespace ScriptCanvasEditor
         static void Reflect(AZ::ReflectContext* reflectContext);
 
         CreateDataDrivenNodeMimeEvent() = default;
-        CreateDataDrivenNodeMimeEvent(const AZ::Crc32& mimeId, const AZStd::any& nodeData);
+        CreateDataDrivenNodeMimeEvent(const AZ::Crc32& nodeId, const AZStd::any& nodeData);
         ~CreateDataDrivenNodeMimeEvent() = default;
 
     protected:

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
@@ -177,14 +177,14 @@ namespace ScriptCanvasEditor
         static void Reflect(AZ::ReflectContext* reflectContext);
 
         CreateDataDrivenNodeMimeEvent() = default;
-        CreateDataDrivenNodeMimeEvent(const AZ::Crc32& nodeId, const AZStd::any& nodeData);
+        CreateDataDrivenNodeMimeEvent(const AZ::Crc32& nodeLexicalId, const AZStd::any& nodeData);
         ~CreateDataDrivenNodeMimeEvent() = default;
 
     protected:
         ScriptCanvasEditor::NodeIdPair CreateNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId) const override;
 
     private:
-        const AZ::Crc32 m_nodeDefaultsId;
+        const AZ::Crc32 m_nodeLexicalId;
         const AZStd::any m_userData;
     };
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/GeneralNodePaletteTreeItemTypes.h
@@ -184,7 +184,7 @@ namespace ScriptCanvasEditor
         ScriptCanvasEditor::NodeIdPair CreateNode(const ScriptCanvas::ScriptCanvasId& scriptCanvasId) const override;
 
     private:
-        const AZ::Crc32 m_nodeId;
+        const AZ::Crc32 m_nodeDefaultsId;
         const AZStd::any m_userData;
     };
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -744,140 +744,103 @@ namespace
     void PopulateDataDrivenNodes(ScriptCanvasEditor::NodePaletteModel& nodePaletteModel)
     {
         // Increment
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Increment"),
-            "++",
-            "Increments the input number by 1",
-            ScriptCanvas::Data::Type::Number(),
-            "Increment");
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation incrementInfo;
+        incrementInfo.m_lexiconId = AZ_CRC_CE("Increment");
+        incrementInfo.m_nodeTitle = "++";
+        incrementInfo.m_nodeToolTip = "Increments the input number by 1";
+        incrementInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
+        incrementInfo.m_paletteTitle = "Increment";
+        nodePaletteModel.RegisterSmallOperatorNode(incrementInfo);
 
         // Decrement
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Decrement"),
-            "--",
-            "Decrements the input number by 1",
-            ScriptCanvas::Data::Type::Number(),
-            "Decrement");
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation decrementInfo;
+        decrementInfo.m_lexiconId = AZ_CRC_CE("Decrement");
+        decrementInfo.m_nodeTitle = "--";
+        decrementInfo.m_nodeToolTip = "Decrements the input number by 1";
+        decrementInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
+        decrementInfo.m_paletteTitle = "Decrement";
+        nodePaletteModel.RegisterSmallOperatorNode(decrementInfo);
 
         // Double
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Double"),
-            "*2",
-            "Multiplies the input number by 2",
-            ScriptCanvas::Data::Type::Number(),
-            "Double");
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation doubleInfo;
+        doubleInfo.m_lexiconId = AZ_CRC_CE("Double");
+        doubleInfo.m_nodeTitle = "*2";
+        doubleInfo.m_nodeToolTip = "Multiplies the input number by 2";
+        doubleInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
+        doubleInfo.m_paletteTitle = "Double";
+        nodePaletteModel.RegisterSmallOperatorNode(doubleInfo);
 
         // Negative
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Negative"),
-            "*-1",
-            "Multiplies the input number by -1",
-            ScriptCanvas::Data::Type::Number(),
-            "Negative");
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation negativeInfo;
+        negativeInfo.m_lexiconId = AZ_CRC_CE("Negative");
+        negativeInfo.m_nodeTitle = "*-1";
+        negativeInfo.m_nodeToolTip = "Multiplies the input number by -1";
+        negativeInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
+        negativeInfo.m_paletteTitle = "Negative";
+        nodePaletteModel.RegisterSmallOperatorNode(negativeInfo);
 
         // Square
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Square"),
-            "^2",
-            "Raises the input number to the power of 2",
-            ScriptCanvas::Data::Type::Number(),
-            "Square");
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation squareInfo;
+        squareInfo.m_lexiconId = AZ_CRC_CE("Square");
+        squareInfo.m_nodeTitle = "^2";
+        squareInfo.m_nodeToolTip = "Raises the input number to the power of 2";
+        squareInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
+        squareInfo.m_paletteTitle = "Square";
+        nodePaletteModel.RegisterSmallOperatorNode(squareInfo);
 
         // Cube
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Cube"),
-            "^3",
-            "Raises the input number to the power of 3",
-            ScriptCanvas::Data::Type::Number(),
-            "Cube");
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation cubeInfo;
+        cubeInfo.m_lexiconId = AZ_CRC_CE("Cube");
+        cubeInfo.m_nodeTitle = "^3";
+        cubeInfo.m_nodeToolTip = "Raises the input number to the power of 3";
+        cubeInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
+        cubeInfo.m_paletteTitle = "Cube";
+        nodePaletteModel.RegisterSmallOperatorNode(cubeInfo);
 
         // Square Root
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Square Root"),
-            "sqrt",
-            "Gets the square root of the input number",
-            ScriptCanvas::Data::Type::Number(),
-            "Square Root");
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation squareRootInfo;
+        squareRootInfo.m_lexiconId = AZ_CRC_CE("Square Root");
+        squareRootInfo.m_nodeTitle = "sqrt";
+        squareRootInfo.m_nodeToolTip = "Gets the square root of the input number";
+        squareRootInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
+        squareRootInfo.m_paletteTitle = "Square Root";
+        nodePaletteModel.RegisterSmallOperatorNode(squareRootInfo);
 
         // Cube Root
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Cube Root"),
-            "cbrt",
-            "Gets the square root of the input number",
-            ScriptCanvas::Data::Type::Number(),
-            "Cube Root");
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation cubeRootInfo;
+        cubeRootInfo.m_lexiconId = AZ_CRC_CE("Cube Root");
+        cubeRootInfo.m_nodeTitle = "cbrt";
+        cubeRootInfo.m_nodeToolTip = "Gets the cube root of the input number";
+        cubeRootInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
+        cubeRootInfo.m_paletteTitle = "Cube Root";
+        nodePaletteModel.RegisterSmallOperatorNode(cubeRootInfo);
 
-        // Vector 2 Invert
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Invert Vector 2"),
-            "inv",
-            "Inverts the input vector 2",
-            ScriptCanvas::Data::Type::Vector2(),
-            "Invert Vector 2");
+        // Invert Vector 2
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation invertVector2Info;
+        invertVector2Info.m_lexiconId = AZ_CRC_CE("Invert Vector 2");
+        invertVector2Info.m_nodeTitle = "inv";
+        invertVector2Info.m_nodeToolTip = "Inverts the input vector 2";
+        invertVector2Info.m_nodeDataType = ScriptCanvas::Data::Type::Vector2();
+        invertVector2Info.m_paletteTitle = "Invert Vector 2";
+        nodePaletteModel.RegisterSmallOperatorNode(invertVector2Info);
 
-        // Vector 3 Invert
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Invert Vector 3"), 
-            "inv",
-            "Inverts the input vector 3",
-            ScriptCanvas::Data::Type::Vector3(),
-            "Invert Vector 3");
+        // Invert Vector 3
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation invertVector3Info;
+        invertVector3Info.m_lexiconId = AZ_CRC_CE("Invert Vector 3");
+        invertVector3Info.m_nodeTitle = "inv";
+        invertVector3Info.m_nodeToolTip = "Inverts the input vector 3";
+        invertVector3Info.m_nodeDataType = ScriptCanvas::Data::Type::Vector3();
+        invertVector3Info.m_paletteTitle = "Invert Vector 3";
+        nodePaletteModel.RegisterSmallOperatorNode(invertVector3Info);
 
-        // Vector 4 Invert
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Invert Vector 4"), 
-            "inv",
-            "Inverts the input vector 4",
-            ScriptCanvas::Data::Type::Vector4(),
-            "Invert Vector 4");
-
-        // Vector 2 Cross
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Cross Vector 2"), 
-            "x",
-            "Applies cross product to the input vector 2",
-            ScriptCanvas::Data::Type::Vector2(),
-            "Cross Vector 2");
-
-        // Vector 3 Cross
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Cross Vector 3"), 
-            "x",
-            "Applies cross product to the input vector 3",
-            ScriptCanvas::Data::Type::Vector3(),
-            "Cross Vector 3");
-
-        // Vector 4 Cross
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Cross Vector 4"), 
-            "x",
-            "Applies cross product to the input vector 4",
-            ScriptCanvas::Data::Type::Vector4(),
-            "Cross Vector 4");
-
-        // Vector 2 Dot
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Dot Vector 2"), 
-            "dot",
-            "Applies dot product to the input vector 2",
-            ScriptCanvas::Data::Type::Vector2(),
-            "Dot Vector 2");
-
-        // Vector 3 Dot
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Dot Vector 3"), 
-            "dot",
-            "Applies dot product to the input vector 3",
-            ScriptCanvas::Data::Type::Vector3(),
-            "Dot Vector 3");
-
-        // Vector 4 Dot
-        nodePaletteModel.RegisterSmallOperatorNode(
-            AZ_CRC_CE("Dot Vector 4"), 
-            "dot",
-            "Applies dot product to the input vector 4",
-            ScriptCanvas::Data::Type::Vector4(),
-            "Dot Vector 4");
+        // Invert Vector 4
+        ScriptCanvasEditor::RegisterSmallOperatorNodeInformation invertVector4Info;
+        invertVector4Info.m_lexiconId = AZ_CRC_CE("Invert Vector 4");
+        invertVector4Info.m_nodeTitle = "inv";
+        invertVector4Info.m_nodeToolTip = "Inverts the input vector 4";
+        invertVector4Info.m_nodeDataType = ScriptCanvas::Data::Type::Vector4();
+        invertVector4Info.m_paletteTitle = "Invert Vector 4";
+        nodePaletteModel.RegisterSmallOperatorNode(invertVector4Info);
 
     }
 
@@ -1025,26 +988,19 @@ namespace ScriptCanvasEditor
         NodePaletteModelNotificationBus::Event(m_paletteId, &NodePaletteModelNotifications::OnAssetModelRepopulated);
     }
 
-    void NodePaletteModel::RegisterSmallOperatorNode(
-        const AZ::Crc32& nodeDefaultsId,
-        const AZStd::string& nodeTitle,
-        const AZStd::string& nodeToolTip,
-        const ScriptCanvas::Data::Type& nodeDataType,
-        const AZStd::string& paletteTitle,
-        const AZStd::string& paletteToolTip,
-        const AZStd::string& palettePath)
+    void NodePaletteModel::RegisterSmallOperatorNode(const RegisterSmallOperatorNodeInformation& info)
     {
         ScriptCanvasEditor::Nodes::SmallOperatorCreationData nodeData;
-        nodeData.m_title = nodeTitle;
-        nodeData.m_toolTip = nodeToolTip;
-        nodeData.m_dataType = nodeDataType;
+        nodeData.m_title = info.m_nodeTitle;
+        nodeData.m_toolTip = info.m_nodeToolTip;
+        nodeData.m_dataType = info.m_nodeDataType;
         ScriptCanvasEditor::DataDrivenNodeModelInformation* paletteData = aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-        paletteData->m_displayName = paletteTitle.empty() ? nodeTitle : paletteTitle;
-        paletteData->m_toolTip = paletteToolTip.empty() ? nodeToolTip : paletteToolTip;
-        paletteData->m_categoryPath = palettePath;
-        paletteData->m_nodeDefaultsId = nodeDefaultsId;
+        paletteData->m_displayName = info.m_paletteTitle;
+        paletteData->m_toolTip = info.m_paletteToolTip;
+        paletteData->m_categoryPath = info.m_palettePath;
+        paletteData->m_nodeDefaultsId = info.m_lexiconId;
         paletteData->m_userData = nodeData;
-        RegisterDataDrivenNode(paletteData, nodeDefaultsId);
+        RegisterDataDrivenNode(paletteData, info.m_lexiconId);
     }
 
     // Register a node given its specific attributes

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -1026,7 +1026,7 @@ namespace ScriptCanvasEditor
     }
 
     void NodePaletteModel::RegisterSmallOperatorNode(
-        const AZ::Crc32& nodeId,
+        const AZ::Crc32& nodeDefaultsId,
         const AZStd::string& nodeTitle,
         const AZStd::string& nodeToolTip,
         const ScriptCanvas::Data::Type& nodeDataType,
@@ -1039,12 +1039,12 @@ namespace ScriptCanvasEditor
         nodeData.m_toolTip = nodeToolTip;
         nodeData.m_dataType = nodeDataType;
         ScriptCanvasEditor::DataDrivenNodeModelInformation* paletteData = aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-        paletteData->m_displayName = paletteTitle == "" ? nodeTitle : paletteTitle;
-        paletteData->m_toolTip = paletteToolTip == "" ? nodeToolTip : paletteToolTip;
+        paletteData->m_displayName = paletteTitle.empty() ? nodeTitle : paletteTitle;
+        paletteData->m_toolTip = paletteToolTip.empty() ? nodeToolTip : paletteToolTip;
         paletteData->m_categoryPath = palettePath;
-        paletteData->m_nodeId = nodeId;
+        paletteData->m_nodeDefaultsId = nodeDefaultsId;
         paletteData->m_userData = nodeData;
-        RegisterDataDrivenNode(paletteData, nodeId);
+        RegisterDataDrivenNode(paletteData, nodeDefaultsId);
     }
 
     // Register a node given its specific attributes

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -741,21 +741,144 @@ namespace
         }
     }
 
-    void PopulateDataDrivenNodes(
-        ScriptCanvasEditor::NodePaletteModel& nodePaletteModel)
+    void PopulateDataDrivenNodes(ScriptCanvasEditor::NodePaletteModel& nodePaletteModel)
     {
-        ScriptCanvasEditor::DataDrivenNodeModelInformation* increment = aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
-        increment->m_displayName = "++";
-        increment->m_categoryPath = "Math/Small Operators";
-        increment->m_toolTip = "Increments a value";
-        increment->m_nodeId = AZ_CRC_CE("++");
+        // Increment
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Increment"),
+            "++",
+            "Increments the input number by 1",
+            ScriptCanvas::Data::Type::Number(),
+            "Increment");
 
-        ScriptCanvasEditor::Nodes::SmallOperatorCreationData data;
-        data.m_title = "++";    // Right now the title is enough info to ensure data gets passed along properly. Later I will add data types too
+        // Decrement
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Decrement"),
+            "--",
+            "Decrements the input number by 1",
+            ScriptCanvas::Data::Type::Number(),
+            "Decrement");
 
-        increment->m_userData = data;   // This can be aaaaanything (that can be serialized)
+        // Double
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Double"),
+            "*2",
+            "Multiplies the input number by 2",
+            ScriptCanvas::Data::Type::Number(),
+            "Double");
 
-        nodePaletteModel.RegisterNode(increment, increment->m_nodeId);
+        // Negative
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Negative"),
+            "*-1",
+            "Multiplies the input number by -1",
+            ScriptCanvas::Data::Type::Number(),
+            "Negative");
+
+        // Square
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Square"),
+            "^2",
+            "Raises the input number to the power of 2",
+            ScriptCanvas::Data::Type::Number(),
+            "Square");
+
+        // Cube
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Cube"),
+            "^3",
+            "Raises the input number to the power of 3",
+            ScriptCanvas::Data::Type::Number(),
+            "Cube");
+
+        // Square Root
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Square Root"),
+            "sqrt",
+            "Gets the square root of the input number",
+            ScriptCanvas::Data::Type::Number(),
+            "Square Root");
+
+        // Cube Root
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Cube Root"),
+            "cbrt",
+            "Gets the square root of the input number",
+            ScriptCanvas::Data::Type::Number(),
+            "Cube Root");
+
+        // Vector 2 Invert
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Invert Vector 2"),
+            "inv",
+            "Inverts the input vector 2",
+            ScriptCanvas::Data::Type::Vector2(),
+            "Invert Vector 2");
+
+        // Vector 3 Invert
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Invert Vector 3"), 
+            "inv",
+            "Inverts the input vector 3",
+            ScriptCanvas::Data::Type::Vector3(),
+            "Invert Vector 3");
+
+        // Vector 4 Invert
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Invert Vector 4"), 
+            "inv",
+            "Inverts the input vector 4",
+            ScriptCanvas::Data::Type::Vector4(),
+            "Invert Vector 4");
+
+        // Vector 2 Cross
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Cross Vector 2"), 
+            "x",
+            "Applies cross product to the input vector 2",
+            ScriptCanvas::Data::Type::Vector2(),
+            "Cross Vector 2");
+
+        // Vector 3 Cross
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Cross Vector 3"), 
+            "x",
+            "Applies cross product to the input vector 3",
+            ScriptCanvas::Data::Type::Vector3(),
+            "Cross Vector 3");
+
+        // Vector 4 Cross
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Cross Vector 4"), 
+            "x",
+            "Applies cross product to the input vector 4",
+            ScriptCanvas::Data::Type::Vector4(),
+            "Cross Vector 4");
+
+        // Vector 2 Dot
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Dot Vector 2"), 
+            "dot",
+            "Applies dot product to the input vector 2",
+            ScriptCanvas::Data::Type::Vector2(),
+            "Dot Vector 2");
+
+        // Vector 3 Dot
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Dot Vector 3"), 
+            "dot",
+            "Applies dot product to the input vector 3",
+            ScriptCanvas::Data::Type::Vector3(),
+            "Dot Vector 3");
+
+        // Vector 4 Dot
+        nodePaletteModel.RegisterSmallOperatorNode(
+            AZ_CRC_CE("Dot Vector 4"), 
+            "dot",
+            "Applies dot product to the input vector 4",
+            ScriptCanvas::Data::Type::Vector4(),
+            "Dot Vector 4");
+
     }
 
     // Helper function for populating the node palette model.
@@ -902,13 +1025,33 @@ namespace ScriptCanvasEditor
         NodePaletteModelNotificationBus::Event(m_paletteId, &NodePaletteModelNotifications::OnAssetModelRepopulated);
     }
 
+    void NodePaletteModel::RegisterSmallOperatorNode(
+        const AZ::Crc32& nodeId,
+        const AZStd::string& nodeTitle,
+        const AZStd::string& nodeToolTip,
+        const ScriptCanvas::Data::Type& nodeDataType,
+        const AZStd::string& paletteTitle,
+        const AZStd::string& paletteToolTip,
+        const AZStd::string& palettePath)
+    {
+        ScriptCanvasEditor::Nodes::SmallOperatorCreationData nodeData;
+        nodeData.m_title = nodeTitle;
+        nodeData.m_toolTip = nodeToolTip;
+        nodeData.m_dataType = nodeDataType;
+        ScriptCanvasEditor::DataDrivenNodeModelInformation* paletteData = aznew ScriptCanvasEditor::DataDrivenNodeModelInformation();
+        paletteData->m_displayName = paletteTitle == "" ? nodeTitle : paletteTitle;
+        paletteData->m_toolTip = paletteToolTip == "" ? nodeToolTip : paletteToolTip;
+        paletteData->m_categoryPath = palettePath;
+        paletteData->m_nodeId = nodeId;
+        paletteData->m_userData = nodeData;
+        RegisterDataDrivenNode(paletteData, nodeId);
+    }
 
     // Register a node given its specific attributes
-    void NodePaletteModel::RegisterNode(NodePaletteModelInformation* nodeInformation, const ScriptCanvas::NodeTypeIdentifier& id)
+    void NodePaletteModel::RegisterDataDrivenNode(NodePaletteModelInformation* nodeInformation, const ScriptCanvas::NodeTypeIdentifier& id)
     {
         m_registeredNodes.emplace(AZStd::make_pair(id, nodeInformation));
     }
-
 
     void NodePaletteModel::RegisterCustomNode(AZStd::string_view categoryPath, const AZ::Uuid& uuid, AZStd::string_view name, const AZ::SerializeContext::ClassData* classData)
     {

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.cpp
@@ -745,7 +745,7 @@ namespace
     {
         // Increment
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation incrementInfo;
-        incrementInfo.m_lexiconId = AZ_CRC_CE("Increment");
+        incrementInfo.m_nodeLexicalId = AZ_CRC_CE("Increment");
         incrementInfo.m_nodeTitle = "++";
         incrementInfo.m_nodeToolTip = "Increments the input number by 1";
         incrementInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
@@ -754,7 +754,7 @@ namespace
 
         // Decrement
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation decrementInfo;
-        decrementInfo.m_lexiconId = AZ_CRC_CE("Decrement");
+        decrementInfo.m_nodeLexicalId = AZ_CRC_CE("Decrement");
         decrementInfo.m_nodeTitle = "--";
         decrementInfo.m_nodeToolTip = "Decrements the input number by 1";
         decrementInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
@@ -763,7 +763,7 @@ namespace
 
         // Double
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation doubleInfo;
-        doubleInfo.m_lexiconId = AZ_CRC_CE("Double");
+        doubleInfo.m_nodeLexicalId = AZ_CRC_CE("Double");
         doubleInfo.m_nodeTitle = "*2";
         doubleInfo.m_nodeToolTip = "Multiplies the input number by 2";
         doubleInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
@@ -772,7 +772,7 @@ namespace
 
         // Negative
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation negativeInfo;
-        negativeInfo.m_lexiconId = AZ_CRC_CE("Negative");
+        negativeInfo.m_nodeLexicalId = AZ_CRC_CE("Negative");
         negativeInfo.m_nodeTitle = "*-1";
         negativeInfo.m_nodeToolTip = "Multiplies the input number by -1";
         negativeInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
@@ -781,7 +781,7 @@ namespace
 
         // Square
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation squareInfo;
-        squareInfo.m_lexiconId = AZ_CRC_CE("Square");
+        squareInfo.m_nodeLexicalId = AZ_CRC_CE("Square");
         squareInfo.m_nodeTitle = "^2";
         squareInfo.m_nodeToolTip = "Raises the input number to the power of 2";
         squareInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
@@ -790,7 +790,7 @@ namespace
 
         // Cube
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation cubeInfo;
-        cubeInfo.m_lexiconId = AZ_CRC_CE("Cube");
+        cubeInfo.m_nodeLexicalId = AZ_CRC_CE("Cube");
         cubeInfo.m_nodeTitle = "^3";
         cubeInfo.m_nodeToolTip = "Raises the input number to the power of 3";
         cubeInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
@@ -799,7 +799,7 @@ namespace
 
         // Square Root
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation squareRootInfo;
-        squareRootInfo.m_lexiconId = AZ_CRC_CE("Square Root");
+        squareRootInfo.m_nodeLexicalId = AZ_CRC_CE("Square Root");
         squareRootInfo.m_nodeTitle = "sqrt";
         squareRootInfo.m_nodeToolTip = "Gets the square root of the input number";
         squareRootInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
@@ -808,7 +808,7 @@ namespace
 
         // Cube Root
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation cubeRootInfo;
-        cubeRootInfo.m_lexiconId = AZ_CRC_CE("Cube Root");
+        cubeRootInfo.m_nodeLexicalId = AZ_CRC_CE("Cube Root");
         cubeRootInfo.m_nodeTitle = "cbrt";
         cubeRootInfo.m_nodeToolTip = "Gets the cube root of the input number";
         cubeRootInfo.m_nodeDataType = ScriptCanvas::Data::Type::Number();
@@ -817,7 +817,7 @@ namespace
 
         // Invert Vector 2
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation invertVector2Info;
-        invertVector2Info.m_lexiconId = AZ_CRC_CE("Invert Vector 2");
+        invertVector2Info.m_nodeLexicalId = AZ_CRC_CE("Invert Vector 2");
         invertVector2Info.m_nodeTitle = "inv";
         invertVector2Info.m_nodeToolTip = "Inverts the input vector 2";
         invertVector2Info.m_nodeDataType = ScriptCanvas::Data::Type::Vector2();
@@ -826,7 +826,7 @@ namespace
 
         // Invert Vector 3
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation invertVector3Info;
-        invertVector3Info.m_lexiconId = AZ_CRC_CE("Invert Vector 3");
+        invertVector3Info.m_nodeLexicalId = AZ_CRC_CE("Invert Vector 3");
         invertVector3Info.m_nodeTitle = "inv";
         invertVector3Info.m_nodeToolTip = "Inverts the input vector 3";
         invertVector3Info.m_nodeDataType = ScriptCanvas::Data::Type::Vector3();
@@ -835,7 +835,7 @@ namespace
 
         // Invert Vector 4
         ScriptCanvasEditor::RegisterSmallOperatorNodeInformation invertVector4Info;
-        invertVector4Info.m_lexiconId = AZ_CRC_CE("Invert Vector 4");
+        invertVector4Info.m_nodeLexicalId = AZ_CRC_CE("Invert Vector 4");
         invertVector4Info.m_nodeTitle = "inv";
         invertVector4Info.m_nodeToolTip = "Inverts the input vector 4";
         invertVector4Info.m_nodeDataType = ScriptCanvas::Data::Type::Vector4();
@@ -998,9 +998,9 @@ namespace ScriptCanvasEditor
         paletteData->m_displayName = info.m_paletteTitle;
         paletteData->m_toolTip = info.m_paletteToolTip;
         paletteData->m_categoryPath = info.m_palettePath;
-        paletteData->m_nodeDefaultsId = info.m_lexiconId;
+        paletteData->m_nodeLexicalId = info.m_nodeLexicalId;
         paletteData->m_userData = nodeData;
-        RegisterDataDrivenNode(paletteData, info.m_lexiconId);
+        RegisterDataDrivenNode(paletteData, info.m_nodeLexicalId);
     }
 
     // Register a node given its specific attributes

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
@@ -79,8 +79,15 @@ namespace ScriptCanvasEditor
 
         void RepopulateModel();
 
-        
-        void RegisterNode(NodePaletteModelInformation* nodeInformation, const ScriptCanvas::NodeTypeIdentifier& id);
+        void RegisterSmallOperatorNode(
+            const AZ::Crc32& nodeId,
+            const AZStd::string& nodeTitle,
+            const AZStd::string& nodeToolTip,
+            const ScriptCanvas::Data::Type& nodeDataType,
+            const AZStd::string& paletteTitle = "",
+            const AZStd::string& paletteToolTip = "",
+            const AZStd::string& palettePath = "Math/Small Operators");
+        void RegisterDataDrivenNode(NodePaletteModelInformation* nodeInformation, const ScriptCanvas::NodeTypeIdentifier& id);
 
         void RegisterCustomNode(AZStd::string_view categoryPath, const AZ::Uuid& uuid, AZStd::string_view name, const AZ::SerializeContext::ClassData* classData);
         void RegisterClassNode(const AZStd::string& categoryPath, const AZStd::string& methodClass, const AZStd::string& methodName, const AZ::BehaviorMethod* behaviorMethod, const AZ::BehaviorContext* behaviorContext, ScriptCanvas::PropertyStatus propertyStatus, bool isOverload);

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
@@ -80,7 +80,7 @@ namespace ScriptCanvasEditor
         void RepopulateModel();
 
         void RegisterSmallOperatorNode(
-            const AZ::Crc32& nodeId,
+            const AZ::Crc32& nodeDefaultsId,
             const AZStd::string& nodeTitle,
             const AZStd::string& nodeToolTip,
             const ScriptCanvas::Data::Type& nodeDataType,
@@ -216,7 +216,7 @@ namespace ScriptCanvasEditor
         AZ_RTTI(DataDrivenNodeModelInformation, "{D44D697D-7462-456B-B305-E9931FC02E6B}", NodePaletteModelInformation);
         AZ_CLASS_ALLOCATOR(DataDrivenNodeModelInformation, AZ::SystemAllocator, 0);
 
-        AZ::Crc32 m_nodeId;
+        AZ::Crc32 m_nodeDefaultsId;
         AZStd::any m_userData;
     };
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
@@ -63,7 +63,7 @@ namespace ScriptCanvasEditor
 
     struct RegisterSmallOperatorNodeInformation
     {
-        AZ::Crc32 m_lexiconId;
+        AZ::Crc32 m_nodeLexicalId;
         AZStd::string m_nodeTitle;
         AZStd::string m_nodeToolTip;
         ScriptCanvas::Data::Type m_nodeDataType;
@@ -220,7 +220,7 @@ namespace ScriptCanvasEditor
         AZ_RTTI(DataDrivenNodeModelInformation, "{D44D697D-7462-456B-B305-E9931FC02E6B}", NodePaletteModelInformation);
         AZ_CLASS_ALLOCATOR(DataDrivenNodeModelInformation, AZ::SystemAllocator, 0);
 
-        AZ::Crc32 m_nodeDefaultsId;
+        AZ::Crc32 m_nodeLexicalId;
         AZStd::any m_userData;
     };
 

--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
@@ -61,6 +61,17 @@ namespace ScriptCanvasEditor
         AZStd::string m_tooltip;
     };
 
+    struct RegisterSmallOperatorNodeInformation
+    {
+        AZ::Crc32 m_lexiconId;
+        AZStd::string m_nodeTitle;
+        AZStd::string m_nodeToolTip;
+        ScriptCanvas::Data::Type m_nodeDataType;
+        AZStd::string m_paletteTitle = m_nodeTitle;
+        AZStd::string m_paletteToolTip = m_nodeToolTip;
+        AZStd::string m_palettePath = "Math/Small Operators";
+    };
+
     class NodePaletteModel
         : public GraphCanvas::CategorizerInterface
         , UpgradeNotificationsBus::Handler
@@ -79,14 +90,7 @@ namespace ScriptCanvasEditor
 
         void RepopulateModel();
 
-        void RegisterSmallOperatorNode(
-            const AZ::Crc32& nodeDefaultsId,
-            const AZStd::string& nodeTitle,
-            const AZStd::string& nodeToolTip,
-            const ScriptCanvas::Data::Type& nodeDataType,
-            const AZStd::string& paletteTitle = "",
-            const AZStd::string& paletteToolTip = "",
-            const AZStd::string& palettePath = "Math/Small Operators");
+        void RegisterSmallOperatorNode(const RegisterSmallOperatorNodeInformation& info);
         void RegisterDataDrivenNode(NodePaletteModelInformation* nodeInformation, const ScriptCanvas::NodeTypeIdentifier& id);
 
         void RegisterCustomNode(AZStd::string_view categoryPath, const AZ::Uuid& uuid, AZStd::string_view name, const AZ::SerializeContext::ClassData* classData);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -2990,9 +2990,21 @@ namespace ScriptCanvas
         return m_name;
     }
 
-    void Node::SetNodeName(AZStd::string name)
+    AZStd::string Node::GetNodeToolTip() const
+    {
+        return m_toolTip;
+    }
+
+    Node* Node::SetNodeName(AZStd::string name)
     {
         m_name = name;
+        return this;
+    }
+
+    Node* Node::SetNodeToolTip(AZStd::string toolTip)
+    {
+        m_toolTip = toolTip;
+        return this;
     }
 
     bool Node::IsEntryPoint() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.cpp
@@ -2990,21 +2990,24 @@ namespace ScriptCanvas
         return m_name;
     }
 
-    AZStd::string Node::GetNodeToolTip() const
+    const AZStd::string& Node::GetNodeToolTip() const
     {
         return m_toolTip;
     }
 
-    Node* Node::SetNodeName(AZStd::string name)
+    void Node::SetNodeName(const AZStd::string& name)
     {
         m_name = name;
-        return this;
     }
 
-    Node* Node::SetNodeToolTip(AZStd::string toolTip)
+    void Node::SetNodeToolTip(const AZStd::string& toolTip)
     {
         m_toolTip = toolTip;
-        return this;
+    }
+
+    void Node::SetNodenodeLexicalId(const AZ::Crc32& nodeLexicalId)
+    {
+        m_nodeLexicalId = nodeLexicalId;
     }
 
     bool Node::IsEntryPoint() const

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
@@ -436,6 +436,7 @@ namespace ScriptCanvas
     private:
         AZStd::string m_name = "";
         AZStd::string m_toolTip = "";
+        AZ::Crc32 m_nodeLexicalId;
         struct IteratorCache
         {
         public:
@@ -539,10 +540,11 @@ namespace ScriptCanvas
         virtual AZStd::string GetNodeTypeName() const;
         virtual AZStd::string GetDebugName() const;
         virtual AZStd::string GetNodeName() const;
-        virtual AZStd::string GetNodeToolTip() const;
+        virtual const AZStd::string& GetNodeToolTip() const;
 
-        virtual Node* SetNodeName(AZStd::string name);
-        virtual Node* SetNodeToolTip(AZStd::string toolTip);
+        virtual void SetNodeName(const AZStd::string& name);
+        virtual void SetNodeToolTip(const AZStd::string& toolTip);
+        virtual void SetNodenodeLexicalId(const AZ::Crc32& nodeLexicalId);
 
         AZStd::string GetSlotName(const SlotId& slotId) const;
 

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/Node.h
@@ -435,6 +435,7 @@ namespace ScriptCanvas
 
     private:
         AZStd::string m_name = "";
+        AZStd::string m_toolTip = "";
         struct IteratorCache
         {
         public:
@@ -538,7 +539,10 @@ namespace ScriptCanvas
         virtual AZStd::string GetNodeTypeName() const;
         virtual AZStd::string GetDebugName() const;
         virtual AZStd::string GetNodeName() const;
-        virtual void SetNodeName(AZStd::string name);
+        virtual AZStd::string GetNodeToolTip() const;
+
+        virtual Node* SetNodeName(AZStd::string name);
+        virtual Node* SetNodeToolTip(AZStd::string toolTip);
 
         AZStd::string GetSlotName(const SlotId& slotId) const;
 


### PR DESCRIPTION
Added more small operator nodes to the palette and allowed the user to enter the type of data that the node accepts and the tooltip of the node. Did some cleaning as well.

<img width="823" alt="moresmalloperators" src="https://user-images.githubusercontent.com/105814224/174866155-80e7cece-0d0d-46b7-8bbc-a8dcd812e931.png">
