### PR TITLE
Add back LibraryDefinition to support backward compatibility

### DIFF
--- a/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
+++ b/Gems/ScriptCanvas/Code/Editor/View/Widgets/NodePalette/NodePaletteModel.h
@@ -77,7 +77,7 @@ namespace ScriptCanvasEditor
 
         void RepopulateModel();
 
-        void RegisterCustomNode(const AZ::SerializeContext::ClassData* classData);
+        void RegisterCustomNode(const AZ::SerializeContext::ClassData* classData, const AZStd::string& categoryPath = "Nodes");
         void RegisterClassNode(const AZStd::string& categoryPath, const AZStd::string& methodClass, const AZStd::string& methodName, const AZ::BehaviorMethod* behaviorMethod, const AZ::BehaviorContext* behaviorContext, ScriptCanvas::PropertyStatus propertyStatus, bool isOverload);
         void RegisterGlobalMethodNode(const AZ::BehaviorContext& behaviorContext, const AZ::BehaviorMethod& behaviorMethod);
         void RegisterGlobalConstant(const AZ::BehaviorContext& behaviorContext, const AZ::BehaviorProperty* behaviorProperty, const AZ::BehaviorMethod& behaviorMethod);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/AutoGen/ScriptCanvasAutoGenRegistry.cpp
@@ -46,7 +46,7 @@ namespace ScriptCanvas
     void AutoGenRegistryManager::Init()
     {
         auto registry = GetInstance();
-        auto nodeRegistry = GetNodeRegistry();
+        auto nodeRegistry = NodeRegistry::GetInstance();
         if (registry && nodeRegistry)
         {
             for (auto& iter : registry->m_registries)
@@ -62,7 +62,7 @@ namespace ScriptCanvas
     void AutoGenRegistryManager::Init(const char* registryName)
     {
         auto registry = GetInstance();
-        auto nodeRegistry = GetNodeRegistry();
+        auto nodeRegistry = NodeRegistry::GetInstance();
         if (registry && nodeRegistry)
         {
             auto registryNames = registry->GetRegistryNames(registryName);

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Core/NodeFunctionGeneric.h
@@ -189,6 +189,7 @@ namespace ScriptCanvas
         static void AddToRegistry([[maybe_unused]] NodeRegistry& nodeRegistry)
         {
             // Deprecated, do nothing here
+            AZ_Warning("ScriptCanvas", false, "NodeFunctionGeneric is deprecated, please migrate to autogen function node.");
         }
 
         template<typename t_Library>

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.cpp
@@ -20,7 +20,7 @@ namespace ScriptCanvas
 {
     void InitLibraries()
     {
-        auto nodeRegistry = GetNodeRegistry();
+        auto nodeRegistry = NodeRegistry::GetInstance();
         ComparisonLibrary::InitNodeRegistry(nodeRegistry);
         CoreLibrary::InitNodeRegistry(nodeRegistry);
         LogicLibrary::InitNodeRegistry(nodeRegistry);
@@ -29,7 +29,7 @@ namespace ScriptCanvas
 
     void ResetLibraries()
     {
-        ResetNodeRegistry();
+        NodeRegistry::ResetInstance();
     }
 
     void ReflectLibraries(AZ::ReflectContext* reflectContext)
@@ -62,5 +62,10 @@ namespace ScriptCanvas
         libraryDescriptors.insert(libraryDescriptors.end(), componentDescriptors.begin(), componentDescriptors.end());
 
         return libraryDescriptors;
+    }
+
+    AZ::EnvironmentVariable<NodeRegistry> GetNodeRegistry()
+    {
+        return AZ::Environment::FindVariable<NodeRegistry>(s_nodeRegistryName);
     }
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.h
@@ -26,4 +26,50 @@ namespace ScriptCanvas
     void ReflectLibraries(AZ::ReflectContext*);
 
     AZStd::vector<AZ::ComponentDescriptor*> GetLibraryDescriptors();
+
+    //! Deprecated, following is to support backward compatibility
+    AZ::EnvironmentVariable<NodeRegistry> GetNodeRegistry();
+
+    namespace Library
+    {
+        struct LibraryDefinition
+        {
+            AZ_RTTI(LibraryDefinition, "{C7A74062-1577-4925-897F-BB7600D2016D}");
+
+            virtual ~LibraryDefinition() = default;
+
+            static const NodeRegistry::NodeList GetNodes(const AZ::Uuid& libraryType)
+            {
+                NodeRegistry& registry = (*GetNodeRegistry());
+                const auto& libraryIterator = registry.m_nodeMap.find(libraryType);
+                if (libraryIterator != registry.m_nodeMap.end())
+                {
+                    const NodeRegistry::NodeList& nodeTypes = libraryIterator->second;
+                    return nodeTypes;
+                }
+
+                return NodeRegistry::NodeList();
+            }
+
+            static bool HasNode(const AZ::Uuid& libraryId, const AZ::Uuid& nodeId)
+            {
+                NodeRegistry::NodeList nodes = GetNodes(libraryId);
+                for (const auto& node : nodes)
+                {
+                    if (node.first == nodeId)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+
+        template<typename NodeGroup, typename NodeType>
+        void AddNodeToRegistry(NodeRegistry& nodeRegistry, const AZStd::string_view& nameOverride = {})
+        {
+            auto& nodes = nodeRegistry.m_nodeMap[AZ::AzTypeInfo<NodeGroup>::Uuid()];
+            nodes.push_back({ AZ::AzTypeInfo<NodeType>::Uuid(), nameOverride.empty() ? AZ::AzTypeInfo<NodeType>::Name() : nameOverride });
+        }
+    }
 }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/Libraries.h
@@ -40,6 +40,7 @@ namespace ScriptCanvas
 
             static const NodeRegistry::NodeList GetNodes(const AZ::Uuid& libraryType)
             {
+                AZ_Warning("ScriptCanvas", false, "LibraryDefinition is deprecated, please migrate to autogen node registry.");
                 NodeRegistry& registry = (*GetNodeRegistry());
                 const auto& libraryIterator = registry.m_nodeMap.find(libraryType);
                 if (libraryIterator != registry.m_nodeMap.end())
@@ -53,6 +54,7 @@ namespace ScriptCanvas
 
             static bool HasNode(const AZ::Uuid& libraryId, const AZ::Uuid& nodeId)
             {
+                AZ_Warning("ScriptCanvas", false, "LibraryDefinition is deprecated, please migrate to autogen node registry.");
                 NodeRegistry::NodeList nodes = GetNodes(libraryId);
                 for (const auto& node : nodes)
                 {
@@ -68,6 +70,7 @@ namespace ScriptCanvas
         template<typename NodeGroup, typename NodeType>
         void AddNodeToRegistry(NodeRegistry& nodeRegistry, const AZStd::string_view& nameOverride = {})
         {
+            AZ_Warning("ScriptCanvas", false, "LibraryDefinition is deprecated, please migrate to autogen node registry.");
             auto& nodes = nodeRegistry.m_nodeMap[AZ::AzTypeInfo<NodeGroup>::Uuid()];
             nodes.push_back({ AZ::AzTypeInfo<NodeType>::Uuid(), nameOverride.empty() ? AZ::AzTypeInfo<NodeType>::Name() : nameOverride });
         }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/ScriptCanvasNodeRegistry.cpp
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/ScriptCanvasNodeRegistry.cpp
@@ -16,7 +16,7 @@ namespace ScriptCanvas
 {
     static AZ::EnvironmentVariable<NodeRegistry> g_nodeRegistry;
 
-    NodeRegistry* GetNodeRegistry()
+    NodeRegistry* NodeRegistry::GetInstance()
     {
         // Look up variable in AZ::Environment first
         // This is need if the Environment variable was already created in a different module memory space
@@ -34,7 +34,7 @@ namespace ScriptCanvas
         return &(g_nodeRegistry.Get());
     }
 
-    void ResetNodeRegistry()
+    void NodeRegistry::ResetInstance()
     {
         g_nodeRegistry.Reset();
     }

--- a/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/ScriptCanvasNodeRegistry.h
+++ b/Gems/ScriptCanvas/Code/Include/ScriptCanvas/Libraries/ScriptCanvasNodeRegistry.h
@@ -25,13 +25,16 @@ namespace ScriptCanvas
     {
         AZ_TYPE_INFO(NodeRegistry, "{C1613BD5-3104-44E4-98FE-A917A90B2014}");
 
+        static NodeRegistry* GetInstance();
+        static void ResetInstance();
+
         //! Collection to store ScriptCanvas derived node uuid
         AZStd::vector<AZ::Uuid> m_nodes;
+
+        //! Deprecated field, keep it for backward compatible
+        using NodeList = AZStd::vector<AZStd::pair<AZ::Uuid, AZStd::string>>;
+        AZStd::unordered_map<AZ::Uuid, NodeList> m_nodeMap;
     };
-
-    NodeRegistry* GetNodeRegistry();
-
-    void ResetNodeRegistry();
 
     static const char* s_nodeRegistryName = "ScriptCanvasNodeRegistry";
 } // namespace ScriptCanvas

--- a/Gems/ScriptCanvas/Code/Tests/AutoGen/ScriptCanvasAutoGenRegistryTest.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/AutoGen/ScriptCanvasAutoGenRegistryTest.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzCore/RTTI/ReflectContext.h>
+#include <AutoGen/ScriptCanvasAutoGenRegistry.h>
+#include <Tests/Framework/ScriptCanvasUnitTestFixture.h>
+
+namespace ScriptCanvasUnitTest
+{
+    using ScriptCanvasAutoGenRegistry = ScriptCanvasUnitTestFixture;
+
+    class MockRegistry
+        : public ScriptCanvas::ScriptCanvasRegistry
+    {
+    public:
+        MockRegistry() = default;
+        virtual ~MockRegistry() = default;
+
+        MOCK_METHOD1(Init, void(ScriptCanvas::NodeRegistry*));
+        MOCK_METHOD1(Reflect, void(AZ::ReflectContext*));
+        MOCK_METHOD0(GetComponentDescriptors, AZStd::vector<AZ::ComponentDescriptor*>());
+    };
+
+    TEST_F(ScriptCanvasAutoGenRegistry, GetInstance_Call_ExpectToBeValid)
+    {
+        auto autogenRegistry = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        EXPECT_TRUE(autogenRegistry);
+    }
+
+    TEST_F(ScriptCanvasAutoGenRegistry, GetInstance_Call_ExpectToBeConsistent)
+    {
+        auto autogenRegistry1 = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        auto autogenRegistry2 = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        EXPECT_EQ(autogenRegistry1, autogenRegistry2);
+    }
+
+    TEST_F(ScriptCanvasAutoGenRegistry, Init_CallWithCorrectName_ExpectToBeCalledOnce)
+    {
+        auto autogenRegistry = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        MockRegistry mockRegistry;
+        autogenRegistry->RegisterRegistry("MockFunctionRegistry", &mockRegistry);
+
+        EXPECT_CALL(mockRegistry, Init(::testing::_)).Times(1);
+        ScriptCanvas::AutoGenRegistryManager::Init("Mock");
+
+        autogenRegistry->UnregisterRegistry("MockFunctionRegistry");
+    }
+
+    TEST_F(ScriptCanvasAutoGenRegistry, Init_CallWithIncorrectName_ExpectNotToBeCalled)
+    {
+        auto autogenRegistry = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        MockRegistry mockRegistry;
+        autogenRegistry->RegisterRegistry("MockFunctionRegistry", &mockRegistry);
+
+        EXPECT_CALL(mockRegistry, Init(::testing::_)).Times(0);
+        ScriptCanvas::AutoGenRegistryManager::Init("Test");
+
+        autogenRegistry->UnregisterRegistry("MockFunctionRegistry");
+    }
+
+    TEST_F(ScriptCanvasAutoGenRegistry, Reflect_CallWithCorrectName_ExpectToBeCalledOnce)
+    {
+        auto autogenRegistry = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        MockRegistry mockRegistry;
+        autogenRegistry->RegisterRegistry("MockFunctionRegistry", &mockRegistry);
+        AZ::ReflectContext reflectContext;
+
+        EXPECT_CALL(mockRegistry, Reflect(::testing::_)).Times(1);
+        ScriptCanvas::AutoGenRegistryManager::Reflect(&reflectContext, "Mock");
+
+        autogenRegistry->UnregisterRegistry("MockFunctionRegistry");
+    }
+
+    TEST_F(ScriptCanvasAutoGenRegistry, Reflect_CallWithIncorrectName_ExpectNotToBeCalled)
+    {
+        auto autogenRegistry = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        MockRegistry mockRegistry;
+        autogenRegistry->RegisterRegistry("MockFunctionRegistry", &mockRegistry);
+        AZ::ReflectContext reflectContext;
+
+        EXPECT_CALL(mockRegistry, Reflect(::testing::_)).Times(0);
+        ScriptCanvas::AutoGenRegistryManager::Reflect(&reflectContext, "Test");
+
+        autogenRegistry->UnregisterRegistry("MockFunctionRegistry");
+    }
+
+    TEST_F(ScriptCanvasAutoGenRegistry, GetComponentDescriptors_CallWithCorrectName_ExpectToBeCalledOnce)
+    {
+        auto autogenRegistry = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        MockRegistry mockRegistry;
+        autogenRegistry->RegisterRegistry("MockFunctionRegistry", &mockRegistry);
+
+        EXPECT_CALL(mockRegistry, GetComponentDescriptors()).Times(1).WillOnce(testing::Return(AZStd::vector<AZ::ComponentDescriptor*>{nullptr}));
+        auto actualResult = ScriptCanvas::AutoGenRegistryManager::GetComponentDescriptors("Mock");
+
+        EXPECT_TRUE(actualResult.size() == 1);
+        autogenRegistry->UnregisterRegistry("MockFunctionRegistry");
+    }
+
+    TEST_F(ScriptCanvasAutoGenRegistry, GetComponentDescriptors_CallWithIncorrectName_ExpectNotToBeCalled)
+    {
+        auto autogenRegistry = ScriptCanvas::AutoGenRegistryManager::GetInstance();
+        MockRegistry mockRegistry;
+        autogenRegistry->RegisterRegistry("MockFunctionRegistry", &mockRegistry);
+
+        EXPECT_CALL(mockRegistry, GetComponentDescriptors()).Times(0);
+        auto actualResult = ScriptCanvas::AutoGenRegistryManager::GetComponentDescriptors("Test");
+
+        EXPECT_TRUE(actualResult.size() == 0);
+        autogenRegistry->UnregisterRegistry("MockFunctionRegistry");
+    }
+} // namespace ScriptCanvasUnitTest

--- a/Gems/ScriptCanvas/Code/Tests/Libraries/ScriptCanvasNodeRegistryTest.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Libraries/ScriptCanvasNodeRegistryTest.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Libraries/ScriptCanvasNodeRegistry.h>
+#include <Tests/Framework/ScriptCanvasUnitTestFixture.h>
+
+namespace ScriptCanvasUnitTest
+{
+    using ScriptCanvasNodeRegistryTest = ScriptCanvasUnitTestFixture;
+
+    TEST_F(ScriptCanvasNodeRegistryTest, GetInstance_Call_ExpectToBeValid)
+    {
+        auto nodeRegistry = ScriptCanvas::NodeRegistry::GetInstance();
+        EXPECT_TRUE(nodeRegistry);
+    }
+
+    TEST_F(ScriptCanvasNodeRegistryTest, GetInstance_Call_ExpectToBeConsistent)
+    {
+        auto nodeRegistry1 = ScriptCanvas::NodeRegistry::GetInstance();
+        auto nodeRegistry2 = ScriptCanvas::NodeRegistry::GetInstance();
+        EXPECT_EQ(nodeRegistry1, nodeRegistry2);
+    }
+} // namespace ScriptCanvasUnitTest

--- a/Gems/ScriptCanvas/Code/scriptcanvasgem_tests_files.cmake
+++ b/Gems/ScriptCanvas/Code/scriptcanvasgem_tests_files.cmake
@@ -7,6 +7,7 @@
 #
 
 set(FILES
+    Tests/AutoGen/ScriptCanvasAutoGenRegistryTest.cpp
     Tests/Framework/ScriptCanvasUnitTestFixture.h
     Tests/Libraries/Entity/ScriptCanvasUnitTest_EntityFunctions.cpp
     Tests/Libraries/Math/ScriptCanvasUnitTest_AABB.cpp
@@ -23,5 +24,6 @@ set(FILES
     Tests/Libraries/Math/ScriptCanvasUnitTest_Vector3.cpp
     Tests/Libraries/Math/ScriptCanvasUnitTest_Vector4.cpp
     Tests/Libraries/String/ScriptCanvasUnitTest_StringFunctions.cpp
+    Tests/Libraries/ScriptCanvasNodeRegistryTest.cpp
     Tests/ScriptCanvasTest.cpp
 )

--- a/Gems/ScriptCanvasDeveloper/Code/Editor/Source/Developer.cpp
+++ b/Gems/ScriptCanvasDeveloper/Code/Editor/Source/Developer.cpp
@@ -15,7 +15,7 @@ namespace ScriptCanvas::Developer
 {
     void InitNodeRegistry()
     {
-        NodeRegistry* registry = GetNodeRegistry();
+        NodeRegistry* registry = NodeRegistry::GetInstance();
         registry->m_nodes.push_back(AZ::AzTypeInfo<ScriptCanvas::Developer::Nodes::Mock>::Uuid());
         registry->m_nodes.push_back(AZ::AzTypeInfo<ScriptCanvas::Developer::Nodes::WrapperMock>::Uuid());
     }


### PR DESCRIPTION
## Details
* The main purpose of this deprecated class is for node registration, so during migration phase, the system will support both autogen registry and LibraryDefinition for node registration. As there is external plugin using LibraryDefinition, have to keep it for backward compatibility.
* Add unit test for autogen and node registry

Reference:
https://github.com/PopcornFX/O3DEPopcornFXPlugin/blob/main/Code/Source/ScriptCanvas/PopcornFXLibrary.h

## Testing
Tested locally to make sure external plugin can still be compiled and built
All unit tests pass