### PR TITLE
Prevent filter model from being accessed before AssetBrowser is loaded

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -445,11 +445,20 @@ namespace AzToolsFramework
             }
 
             int row = entry->row();
-            int column = m_filterModel->LeftmostColumn();
+            int column = GetLeftmostColumnInFilter();
             index = createIndex(row, column, entry);
             return true;
         }
 
+        int AssetBrowserModel::GetLeftmostColumnInFilter() const
+        {
+            constexpr int defaultLeftmostColumn = 0;
+            if (m_filterModel)
+            {
+                return m_filterModel->LeftmostColumn();
+            }
+            return defaultLeftmostColumn;
+        }
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -100,7 +100,9 @@ namespace AzToolsFramework
             bool m_loaded;
             bool m_addingEntry;
             bool m_removingEntry;
+
             bool GetEntryIndex(AssetBrowserEntry* entry, QModelIndex& index) const;
+            int GetLeftmostColumnInFilter() const;
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework


### PR DESCRIPTION
Resolves #10583.

**Description**
Before this commit, it was possible to crash the editor if launched with the AssetBrowser window hidden/disabled. The root cause was the `AssetBrowserModel`'s tick bus calling into `::GetEntryIndex` and attempting to access `m_filterModel` before it had been set in `AssetBrowserWindow`.

This PR wraps the illegal access in a function that can return a default value instead. The best default value here seems to be 0 since the AssetBrowser is not loaded in this case and that would still allow the caller to function, so the wrapper will return column 0 when the `AssetBrowserWindow` hasn't been instantiated yet.

The function wrapper approach is taken instead of preventing the tick bus from functioning before the AssetBrowser window is opened because it's not immediately clear what all would be affected by that change.

**Testing**
- Ran unit tests
- Ran relevant AR tests
- Manual testing to verify functionality that was fixed by the precipitating change is intact (renaming/adding/deleting assets doesn't inhibit visual updates in the AssetBrowser, and entry icons are updated via the tick bus)

Signed-off-by: amzn-tmryan <104796591+amzn-tmryan@users.noreply.github.com>