### PR TITLE
Amzn tmryan/jjjones asset browser update branch/add script assets through asset browser

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserRequestHandler.cpp
@@ -597,7 +597,10 @@ void AzAssetBrowserRequestHandler::Drop(QDropEvent* event, AzQtComponents::DragA
     }
 }
 
-void AzAssetBrowserRequestHandler::AddSourceFileOpeners(const char* fullSourceFileName, const AZ::Uuid& sourceUUID, AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers)
+void AzAssetBrowserRequestHandler::AddSourceFileOpeners(
+    [[maybe_unused]] const char* fullSourceFileName,
+    const AZ::Uuid& sourceUUID,
+    AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers)
 {
     using namespace AzToolsFramework;
 
@@ -608,32 +611,8 @@ void AzAssetBrowserRequestHandler::AddSourceFileOpeners(const char* fullSourceFi
     {
         return;
     }
-    QString assetGroup;
-    AZ::AssetTypeInfoBus::EventResult(assetGroup, fullDetails->GetPrimaryAssetType(), &AZ::AssetTypeInfo::GetGroup);
 
-    if (AZStd::wildcard_match("*.lua", fullSourceFileName))
-    {
-        AZStd::string fullName(fullSourceFileName);
-        // LUA files can be opened with the O3DE LUA editor.
-        openers.push_back(
-            {
-                "O3DE_LUA_Editor",
-                "Open in Open 3D Engine LUA Editor...",
-                QIcon(),
-                [](const char* fullSourceFileNameInCallback, const AZ::Uuid& /*sourceUUID*/)
-                {
-                    // we know how to handle LUA files (open with the lua Editor.
-                    EditorRequestBus::Broadcast(&EditorRequests::LaunchLuaEditor, fullSourceFileNameInCallback);
-                }
-            });
-    }
-
-    if (!openers.empty())
-    {
-        return; // we found one
-    }
-    
-    // if we still havent found one, check to see if it is a default "generic" serializable asset
+    // check to see if it is a default "generic" serializable asset
     // and open the asset editor if so. Check whether the Generic Asset handler handles this kind of asset.
     // to do so we need the actual type of that asset, which requires an asset type, not a source type.
     AZ::Data::AssetManager& manager = AZ::Data::AssetManager::Instance();

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -160,7 +160,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     connect(m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::ClearTypeFilter,
         m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearTypeFilter);
 
-    connect(m_assetBrowserModel, &AzAssetBrowser::AssetBrowserModel::AssetCreatedFromEditor,
+    connect(m_assetBrowserModel, &AzAssetBrowser::AssetBrowserModel::RequestOpenItemForEditing,
         m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::OpenItemForEditing);
 
     connect(this, &AzAssetBrowserWindow::SizeChangedSignal,

--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -100,8 +100,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     m_ui->m_collapseAllButton->setAutoRaise(true); // hover highlight
     m_ui->m_collapseAllButton->setIcon(QIcon(AzAssetBrowser::CollapseAllIcon));
 
-    connect(
-        m_ui->m_collapseAllButton, &QToolButton::clicked, this,
+    connect(m_ui->m_collapseAllButton, &QToolButton::clicked, this,
         [this]()
         {
             m_ui->m_assetBrowserTreeViewWidget->collapseAll();
@@ -119,30 +118,30 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
         m_tableModel->setDynamicSortFilter(true);
         m_ui->m_assetBrowserTableViewWidget->setModel(m_tableModel.data());
 
-        connect(
-            m_filterModel.data(), &AzAssetBrowser::AssetBrowserFilterModel::filterChanged, this,
-            &AzAssetBrowserWindow::UpdateWidgetAfterFilter);
-        connect(
-            m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::selectionChangedSignal, this,
-            &AzAssetBrowserWindow::SelectionChangedSlot);
-        connect(m_ui->m_assetBrowserTableViewWidget, &QAbstractItemView::doubleClicked, this, &AzAssetBrowserWindow::DoubleClickedItem);
-        connect(
-            m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::ClearStringFilter, m_ui->m_searchWidget,
-            &AzAssetBrowser::SearchWidget::ClearStringFilter);
-        connect(
-            m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::ClearTypeFilter, m_ui->m_searchWidget,
-            &AzAssetBrowser::SearchWidget::ClearTypeFilter);
+        connect(m_filterModel.data(), &AzAssetBrowser::AssetBrowserFilterModel::filterChanged,
+            this, &AzAssetBrowserWindow::UpdateWidgetAfterFilter);
+
+        connect(m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::selectionChangedSignal,
+            this, &AzAssetBrowserWindow::SelectionChangedSlot);
+
+        connect(m_ui->m_assetBrowserTableViewWidget, &QAbstractItemView::doubleClicked,
+            this, &AzAssetBrowserWindow::DoubleClickedItem);
+
+        connect(m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::ClearStringFilter,
+            m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearStringFilter);
+
+        connect(m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::ClearTypeFilter,
+            m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearTypeFilter);
 
         m_ui->m_assetBrowserTableViewWidget->SetName("AssetBrowserTableView_main");
     }
 
     m_ui->m_assetBrowserTreeViewWidget->setModel(m_filterModel.data());
 
-    connect(
-        m_ui->m_searchWidget->GetFilter().data(), &AzAssetBrowser::AssetBrowserEntryFilter::updatedSignal, m_filterModel.data(),
-        &AzAssetBrowser::AssetBrowserFilterModel::filterUpdatedSlot);
-    connect(
-        m_filterModel.data(), &AzAssetBrowser::AssetBrowserFilterModel::filterChanged, this,
+    connect(m_ui->m_searchWidget->GetFilter().data(), &AzAssetBrowser::AssetBrowserEntryFilter::updatedSignal,
+        m_filterModel.data(), &AzAssetBrowser::AssetBrowserFilterModel::filterUpdatedSlot);
+
+    connect(m_filterModel.data(), &AzAssetBrowser::AssetBrowserFilterModel::filterChanged, this,
         [this]()
         {
             const bool hasFilter = !m_ui->m_searchWidget->GetFilterString().isEmpty();
@@ -150,22 +149,22 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
             m_ui->m_assetBrowserTreeViewWidget->UpdateAfterFilter(hasFilter, selectFirstFilteredIndex);
         });
 
-    connect(
-        m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::selectionChangedSignal, this,
-        &AzAssetBrowserWindow::SelectionChangedSlot);
+    connect(m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::selectionChangedSignal,
+        this, &AzAssetBrowserWindow::SelectionChangedSlot);
 
     connect(m_ui->m_assetBrowserTreeViewWidget, &QAbstractItemView::doubleClicked, this, &AzAssetBrowserWindow::DoubleClickedItem);
 
-    connect(
-        m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::ClearStringFilter, m_ui->m_searchWidget,
-        &AzAssetBrowser::SearchWidget::ClearStringFilter);
-    connect(
-        m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::ClearTypeFilter, m_ui->m_searchWidget,
-        &AzAssetBrowser::SearchWidget::ClearTypeFilter);
+    connect(m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::ClearStringFilter,
+        m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearStringFilter);
 
-    connect(
-        this, &AzAssetBrowserWindow::SizeChangedSignal, m_ui->m_assetBrowserTableViewWidget,
-        &AzAssetBrowser::AssetBrowserTableView::UpdateSizeSlot);
+    connect(m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::ClearTypeFilter,
+        m_ui->m_searchWidget, &AzAssetBrowser::SearchWidget::ClearTypeFilter);
+
+    connect(m_assetBrowserModel, &AzAssetBrowser::AssetBrowserModel::AssetCreatedFromEditor,
+        m_ui->m_assetBrowserTreeViewWidget, &AzAssetBrowser::AssetBrowserTreeView::OpenItemForEditing);
+
+    connect(this, &AzAssetBrowserWindow::SizeChangedSignal,
+        m_ui->m_assetBrowserTableViewWidget, &AzAssetBrowser::AssetBrowserTableView::UpdateSizeSlot);
 
     m_ui->m_assetBrowserTreeViewWidget->SetName("AssetBrowserTreeView_main");
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Application/ToolsApplication.cpp
@@ -74,6 +74,7 @@
 #include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
 #include <AzToolsFramework/Viewport/ViewBookmarkSystemComponent.h>
 #include <Entity/EntityUtilityComponent.h>
+#include <AzToolsFramework/Script/LuaEditorSystemComponent.h>
 #include <AzToolsFramework/Script/LuaSymbolsReporterSystemComponent.h>
 #include <Prefab/ProceduralPrefabSystemComponent.h>
 
@@ -296,6 +297,7 @@ namespace AzToolsFramework
                 azrtti_typeid<AzToolsFramework::SliceRequestComponent>(),
                 azrtti_typeid<AzToolsFramework::EntityUtilityComponent>(),
                 azrtti_typeid<AzToolsFramework::Script::LuaSymbolsReporterSystemComponent>(),
+                azrtti_typeid<AzToolsFramework::Script::LuaEditorSystemComponent>(),
             });
 
         return components;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
@@ -287,10 +287,6 @@ namespace AzToolsFramework
 
             virtual void BeginRemoveEntry(AssetBrowserEntry* entry) = 0;
             virtual void EndRemoveEntry() = 0;
-
-            //! Notifies the Asset Browser's model that an asset was created through the Asset Browser.
-            //! @param assetPath The full filepath for the asset.
-            virtual void HandleAssetCreatedInEditor(const AZStd::string& /*assetPath*/, const AZ::Crc32& /*creatorBusId*/) {}
         };
 
         using AssetBrowserModelRequestBus = AZ::EBus<AssetBrowserModelRequests>;
@@ -353,11 +349,11 @@ namespace AzToolsFramework
             //! Notifies the handler that a new asset was created from the editor so they can handle renaming or other behavior as necessary.
             //! @param assetPath The full path to the asset that was created.
             //! @param creatorBusId The file creator's bus handler address. A default constructed Crc32 implies no one is listening.
-            virtual void HandleAssetCreatedInEditor(const AZStd::string& /*assetPath*/, const AZ::Crc32& /*creatorBusId*/) {}
+            virtual void HandleAssetCreatedInEditor(const AZStd::string_view /*assetPath*/, const AZ::Crc32& /*creatorBusId*/) {}
 
             //! Notifies a given handler that an asset which was recently created has been given a non-default name.
             //! @param assetPath The full path to the asset that had its initial name change.
-            virtual void HandleInitialFilenameChange(const AZStd::string& /*fullFilepath*/) {}
+            virtual void HandleInitialFilenameChange(const AZStd::string_view /*fullFilepath*/) {}
 
             //! The ebus address to use when notifying the Asset Browser component that a new file was created through the Asset Browser.
             //! Note that addresses for individual asset creators should be specified in their respective code.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserBus.h
@@ -251,6 +251,10 @@ namespace AzToolsFramework
             //! finally, if its not a generic asset, it tries the operating system.
             virtual void OpenAssetInAssociatedEditor(const AZ::Data::AssetId& /*assetId*/, bool& /*alreadyHandled*/) {}
 
+            //! Notifies handlers that a new asset was created from the editor so they can handle
+            //! renaming or other behavior as necessary.
+            virtual void NotifyAssetWasCreatedInEditor([[maybe_unused]] const AZStd::string& assetPath) {}
+
             //! Allows you to recognise the source files that your plugin cares about and provide information about the source file
             //! for display in the Asset Browser.  This allows you to override the default behavior if you wish to.
             //! note that you'll get SourceFileDetails for every file in view, and you should only return something if its YOUR
@@ -287,6 +291,10 @@ namespace AzToolsFramework
 
             virtual void BeginRemoveEntry(AssetBrowserEntry* entry) = 0;
             virtual void EndRemoveEntry() = 0;
+
+            //! Notifies the Asset Browser's model that an asset was created through the editor.
+            //! @param assetPath The full filepath for the asset.
+            virtual void NotifyAssetWasCreatedInEditor([[maybe_unused]] const AZStd::string& assetPath) {}
         };
 
         using AssetBrowserModelRequestBus = AZ::EBus<AssetBrowserModelRequests>;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
@@ -97,6 +97,8 @@ namespace AzToolsFramework
                 m_thread.join(); // wait for the thread to finish
                 m_thread = AZStd::thread(); // destroy
             }
+            AssetBrowserFileCreationNotificationBus::Handler::BusDisconnect(
+                AssetBrowserFileCreationNotifications::FileCreationNotificationBusId);
             AssetBrowserInteractionNotificationBus::Handler::BusDisconnect();
             AssetDatabaseLocationNotificationBus::Handler::BusDisconnect();
             AssetBrowserComponentRequestBus::Handler::BusDisconnect();
@@ -269,15 +271,14 @@ namespace AzToolsFramework
             return SourceFileDetails();
         }
 
-        void AssetBrowserComponent::HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId)
+        void AssetBrowserComponent::HandleAssetCreatedInEditor(const AZStd::string_view assetPath, const AZ::Crc32& creatorBusId)
         {
             if (assetPath.empty())
             {
                 return;
             }
 
-            AzToolsFramework::AssetBrowser::AssetBrowserModelRequestBus::Broadcast(
-                &AzToolsFramework::AssetBrowser::AssetBrowserModelRequests::HandleAssetCreatedInEditor, assetPath, creatorBusId);
+            m_assetBrowserModel->HandleAssetCreatedInEditor(assetPath, creatorBusId);
         }
 
         void AssetBrowserComponent::AddFile(const AZ::s64& fileId) 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
@@ -68,6 +68,8 @@ namespace AzToolsFramework
             AZ::TickBus::Handler::BusConnect();
             AssetSystemBus::Handler::BusConnect();
             AssetBrowserInteractionNotificationBus::Handler::BusConnect();
+            AssetBrowserFileCreationNotificationBus::Handler::BusConnect(
+                AssetBrowserFileCreationNotifications::FileCreationNotificationBusId);
 
             using namespace Thumbnailer;
             ThumbnailerRequestBus::Broadcast(&ThumbnailerRequests::RegisterThumbnailProvider, MAKE_TCACHE(FolderThumbnailCache));
@@ -267,7 +269,7 @@ namespace AzToolsFramework
             return SourceFileDetails();
         }
 
-        void AssetBrowserComponent::NotifyAssetWasCreatedInEditor(const AZStd::string& assetPath)
+        void AssetBrowserComponent::HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId)
         {
             if (assetPath.empty())
             {
@@ -275,7 +277,7 @@ namespace AzToolsFramework
             }
 
             AzToolsFramework::AssetBrowser::AssetBrowserModelRequestBus::Broadcast(
-                &AzToolsFramework::AssetBrowser::AssetBrowserModelRequests::NotifyAssetWasCreatedInEditor, assetPath);
+                &AzToolsFramework::AssetBrowser::AssetBrowserModelRequests::HandleAssetCreatedInEditor, assetPath, creatorBusId);
         }
 
         void AssetBrowserComponent::AddFile(const AZ::s64& fileId) 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.cpp
@@ -267,6 +267,16 @@ namespace AzToolsFramework
             return SourceFileDetails();
         }
 
+        void AssetBrowserComponent::NotifyAssetWasCreatedInEditor(const AZStd::string& assetPath)
+        {
+            if (assetPath.empty())
+            {
+                return;
+            }
+
+            AzToolsFramework::AssetBrowser::AssetBrowserModelRequestBus::Broadcast(
+                &AzToolsFramework::AssetBrowser::AssetBrowserModelRequests::NotifyAssetWasCreatedInEditor, assetPath);
+        }
 
         void AssetBrowserComponent::AddFile(const AZ::s64& fileId) 
         {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
@@ -50,6 +50,7 @@ namespace AzToolsFramework
             , public AZ::TickBus::Handler
             , public AssetSystemBus::Handler
             , public AssetBrowserInteractionNotificationBus::Handler
+            , public AssetBrowserFileCreationNotificationBus::Handler
         {
         public:
             AZ_COMPONENT(AssetBrowserComponent, "{4BC5F93F-2F9E-412E-B00A-396C68CFB5FB}")
@@ -100,7 +101,11 @@ namespace AzToolsFramework
             //////////////////////////////////////////////////////////////////////////
             // AssetBrowserInteractionNotificationBus
             SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;
-            void NotifyAssetWasCreatedInEditor(const AZStd::string& assetPath) override;
+            //////////////////////////////////////////////////////////////////////////
+
+            //////////////////////////////////////////////////////////////////////////
+            // AssetBrowserFileCreationNotificationsBus
+            void HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId /*= AZ::Crc32()*/) override;
             //////////////////////////////////////////////////////////////////////////
 
             void AddFile(const AZ::s64& fileId);
@@ -108,6 +113,7 @@ namespace AzToolsFramework
 
             void PopulateAssets();
             void UpdateAssets();
+
         private:
             AZStd::shared_ptr<AssetDatabase::AssetDatabaseConnection> m_databaseConnection;
             AZStd::shared_ptr<RootAssetBrowserEntry> m_rootEntry;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
@@ -50,7 +50,7 @@ namespace AzToolsFramework
             , public AZ::TickBus::Handler
             , public AssetSystemBus::Handler
             , public AssetBrowserInteractionNotificationBus::Handler
-            , public AssetBrowserFileCreationNotificationBus::Handler
+            , private AssetBrowserFileCreationNotificationBus::Handler
         {
         public:
             AZ_COMPONENT(AssetBrowserComponent, "{4BC5F93F-2F9E-412E-B00A-396C68CFB5FB}")
@@ -103,11 +103,6 @@ namespace AzToolsFramework
             SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;
             //////////////////////////////////////////////////////////////////////////
 
-            //////////////////////////////////////////////////////////////////////////
-            // AssetBrowserFileCreationNotificationsBus
-            void HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId /*= AZ::Crc32()*/) override;
-            //////////////////////////////////////////////////////////////////////////
-
             void AddFile(const AZ::s64& fileId);
             void RemoveFile(const AZ::s64& fileId);
 
@@ -134,12 +129,17 @@ namespace AzToolsFramework
 
             AzFramework::SocketConnection::TMessageCallbackHandle m_cbHandle = 0;
 
+            AzQtComponents::StyledBusyLabel* m_styledBusyLabel;
+
             //! Notify to start the query thread
             void NotifyUpdateThread();
 
             void HandleFileInfoNotification(const void* buffer, unsigned int bufferSize);
 
-            AzQtComponents::StyledBusyLabel* m_styledBusyLabel;
+            //////////////////////////////////////////////////////////////////////////
+            // AssetBrowserFileCreationNotificationBus
+            void HandleAssetCreatedInEditor(const AZStd::string_view assetPath, const AZ::Crc32& creatorBusId /*= AZ::Crc32()*/) override;
+            //////////////////////////////////////////////////////////////////////////
         };
     }
 } // namespace AssetBrowser

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserComponent.h
@@ -100,6 +100,7 @@ namespace AzToolsFramework
             //////////////////////////////////////////////////////////////////////////
             // AssetBrowserInteractionNotificationBus
             SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;
+            void NotifyAssetWasCreatedInEditor(const AZStd::string& assetPath) override;
             //////////////////////////////////////////////////////////////////////////
 
             void AddFile(const AZ::s64& fileId);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -390,22 +390,7 @@ namespace AzToolsFramework
                 {
                     // Gets the newest child with the assumption that BeginAddEntry still adds entries at GetChildCount
                     AssetBrowserEntry* newestChildEntry = parent->GetChild(parent->GetChildCount() - 1);
-                    const AZStd::string& childFullPath = AZ::IO::Path(newestChildEntry->GetFullPath()).AsPosix();
-
-                    if (m_watchedIncomingAssetPaths.contains(childFullPath))
-                    {
-                        m_watchedIncomingAssetPaths.erase(childFullPath);
-
-                        QTimer::singleShot(0, this,
-                            [&, newestChildEntry]()
-                            {
-                                QModelIndex index;
-                                if (GetEntryIndex(newestChildEntry, index))
-                                {
-                                    emit AssetCreatedFromEditor(index);
-                                }
-                            });
-                    }
+                    WatchForExpectedAssets(newestChildEntry);
                 }
 
                 // we have to also invalidate our parent all the way up the chain.
@@ -506,6 +491,27 @@ namespace AzToolsFramework
             index = createIndex(row, column, entry);
             return true;
         }
+
+        void AssetBrowserModel::WatchForExpectedAssets(AssetBrowserEntry* entry)
+        {
+            const AZStd::string& childFullPath = AZ::IO::Path(entry->GetFullPath()).AsPosix();
+            if (m_watchedIncomingAssetPaths.contains(childFullPath))
+            {
+                m_watchedIncomingAssetPaths.erase(childFullPath);
+
+                QTimer::singleShot(
+                    0, this,
+                    [&, entry]()
+                    {
+                        QModelIndex index;
+                        if (GetEntryIndex(entry, index))
+                        {
+                            emit AssetCreatedFromEditor(index);
+                        }
+                    });
+            }
+        }
+
     } // namespace AssetBrowser
 } // namespace AzToolsFramework
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -81,7 +81,6 @@ namespace AzToolsFramework
             void EndAddEntry(AssetBrowserEntry* parent) override;
             void BeginRemoveEntry(AssetBrowserEntry* entry) override;
             void EndRemoveEntry() override;
-            void HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId /*= AZ::Crc32()*/) override;
 
             //////////////////////////////////////////////////////////////////////////
             // TickBus
@@ -98,8 +97,10 @@ namespace AzToolsFramework
             static void SourceIndexesToAssetIds(const QModelIndexList& indexes, AZStd::vector<AZ::Data::AssetId>& assetIds);
             static void SourceIndexesToAssetDatabaseEntries(const QModelIndexList& indexes, AZStd::vector<AssetBrowserEntry*>& entries);
 
+            void HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId = AZ::Crc32());
+
         Q_SIGNALS:
-            void AssetCreatedFromEditor(const QModelIndex& index);
+            void RequestOpenItemForEditing(const QModelIndex& index);
 
         private:
             //Non owning pointer 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -17,6 +17,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
+#include <AzCore/std/containers/set.h>
 #include <AzCore/Component/TickBus.h>
 
 AZ_PUSH_DISABLE_WARNING(4127 4251 4800, "-Wunknown-warning-option") // 4127: conditional expression is constant
@@ -80,6 +81,7 @@ namespace AzToolsFramework
             void EndAddEntry(AssetBrowserEntry* parent) override;
             void BeginRemoveEntry(AssetBrowserEntry* entry) override;
             void EndRemoveEntry() override;
+            void NotifyAssetWasCreatedInEditor(const AZStd::string& assetPath) override;
 
             //////////////////////////////////////////////////////////////////////////
             // TickBus
@@ -95,7 +97,10 @@ namespace AzToolsFramework
 
             static void SourceIndexesToAssetIds(const QModelIndexList& indexes, AZStd::vector<AZ::Data::AssetId>& assetIds);
             static void SourceIndexesToAssetDatabaseEntries(const QModelIndexList& indexes, AZStd::vector<AssetBrowserEntry*>& entries);
-            
+
+        Q_SIGNALS:
+            void AssetCreatedFromEditor(const QModelIndex& index);
+
         private:
             //Non owning pointer 
             AssetBrowserFilterModel* m_filterModel = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -109,9 +109,9 @@ namespace AzToolsFramework
             bool m_addingEntry;
             bool m_removingEntry;
             bool m_isTickBusEnabled = false;
-
+			
             bool GetEntryIndex(AssetBrowserEntry* entry, QModelIndex& index) const;
-            int GetLeftmostColumnInFilter() const;
+			void WatchForExpectedAssets(AssetBrowserEntry* entry);
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -17,7 +17,7 @@ AZ_POP_DISABLE_WARNING
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Asset/AssetCommon.h>
 #include <AzCore/std/smart_ptr/shared_ptr.h>
-#include <AzCore/std/containers/set.h>
+#include <AzCore/std/containers/unordered_map.h>
 #include <AzCore/Component/TickBus.h>
 
 AZ_PUSH_DISABLE_WARNING(4127 4251 4800, "-Wunknown-warning-option") // 4127: conditional expression is constant
@@ -81,7 +81,7 @@ namespace AzToolsFramework
             void EndAddEntry(AssetBrowserEntry* parent) override;
             void BeginRemoveEntry(AssetBrowserEntry* entry) override;
             void EndRemoveEntry() override;
-            void NotifyAssetWasCreatedInEditor(const AZStd::string& assetPath) override;
+            void HandleAssetCreatedInEditor(const AZStd::string& assetPath, const AZ::Crc32& creatorBusId /*= AZ::Crc32()*/) override;
 
             //////////////////////////////////////////////////////////////////////////
             // TickBus
@@ -108,10 +108,12 @@ namespace AzToolsFramework
             bool m_loaded;
             bool m_addingEntry;
             bool m_removingEntry;
-            bool m_isTickBusEnabled = false;
-			
+			bool m_isTickBusEnabled = false;
+            AZStd::unordered_map<AssetBrowserEntry*, AZ::Crc32> m_assetEntriesToCreatorBusIds;
+            AZStd::unordered_map<AZStd::string, AZ::Crc32> m_newlyCreatedAssetPathsToCreatorBusIds;
+
             bool GetEntryIndex(AssetBrowserEntry* entry, QModelIndex& index) const;
-			void WatchForExpectedAssets(AssetBrowserEntry* entry);
+            void WatchForExpectedAssets(AssetBrowserEntry* entry);
         };
     } // namespace AssetBrowser
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -305,6 +305,22 @@ namespace AzToolsFramework
             return GetEntryFromIndex<SourceAssetBrowserEntry>(index) == nullptr;
         }
 
+        void AssetBrowserTreeView::OpenItemForEditing(const QModelIndex& index)
+        {
+            QModelIndex proxyIndex = m_assetBrowserSortFilterProxyModel->mapFromSource(index);
+
+            if (proxyIndex.isValid())
+            {
+                selectionModel()->clear();
+                selectionModel()->select(proxyIndex, QItemSelectionModel::Select);
+                setCurrentIndex(proxyIndex);
+
+                scrollTo(proxyIndex);
+
+                RenameEntry();
+            }
+        }
+
         bool AssetBrowserTreeView::SelectProduct(const QModelIndex& idxParent, AZ::Data::AssetId assetID)
         {
             int elements = model()->rowCount(idxParent);
@@ -319,6 +335,7 @@ namespace AzToolsFramework
                     setCurrentIndex(rowIdx);
                     return true;
                 }
+
                 if (SelectProduct(rowIdx, assetID))
                 {
                     expand(rowIdx);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -311,11 +311,10 @@ namespace AzToolsFramework
 
             if (proxyIndex.isValid())
             {
-                selectionModel()->clear();
-                selectionModel()->select(proxyIndex, QItemSelectionModel::Select);
+                selectionModel()->select(proxyIndex, QItemSelectionModel::ClearAndSelect);
                 setCurrentIndex(proxyIndex);
 
-                scrollTo(proxyIndex);
+                scrollTo(proxyIndex, QAbstractItemView::ScrollHint::PositionAtCenter);
 
                 RenameEntry();
             }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.cpp
@@ -483,6 +483,11 @@ namespace AzToolsFramework
         {
             auto entries = GetSelectedAssets();
 
+            if (entries.empty())
+            {
+                return;
+            }
+
             // Create the callback to pass to the SourceControlAPI
             AzToolsFramework::SourceControlResponseCallback callback =
                 []([[maybe_unused]] bool success, [[maybe_unused]] const AzToolsFramework::SourceControlFileInfo& info)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/Views/AssetBrowserTreeView.h
@@ -38,6 +38,7 @@ namespace AzToolsFramework
             , public AssetBrowserComponentNotificationBus::Handler
         {
             Q_OBJECT
+
         public:
             explicit AssetBrowserTreeView(QWidget* parent = nullptr);
             ~AssetBrowserTreeView() override;
@@ -90,12 +91,15 @@ namespace AzToolsFramework
             void ClearStringFilter();
             void ClearTypeFilter();
 
-        protected Q_SLOTS:
-            void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;
-            void rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end) override;
+        public Q_SLOTS:
+            void OpenItemForEditing(const QModelIndex& index);
 
         protected:
             QModelIndexList selectedIndexes() const override;
+
+        protected Q_SLOTS:
+            void selectionChanged(const QItemSelection& selected, const QItemSelection& deselected) override;
+            void rowsAboutToBeRemoved(const QModelIndex& parent, int start, int end) override;
 
         private:
             QPointer<AssetBrowserModel> m_assetBrowserModel;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AzToolsFrameworkModule.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AzToolsFrameworkModule.cpp
@@ -56,6 +56,7 @@
 #include <AzToolsFramework/AssetBrowser/AssetBrowserComponent.h>
 #include <AzToolsFramework/ViewportSelection/EditorInteractionSystemComponent.h>
 #include <AzToolsFramework/Entity/EntityUtilityComponent.h>
+#include <AzToolsFramework/Script/LuaEditorSystemComponent.h>
 #include <AzToolsFramework/Script/LuaSymbolsReporterSystemComponent.h>
 #include <AzToolsFramework/Viewport/SharedViewBookmarkComponent.h>
 #include <AzToolsFramework/Viewport/LocalViewBookmarkComponent.h>
@@ -119,6 +120,7 @@ namespace AzToolsFramework
             AzToolsFramework::AzToolsFrameworkConfigurationSystemComponent::CreateDescriptor(),
             AzToolsFramework::Components::EditorEntityUiSystemComponent::CreateDescriptor(),
             AzToolsFramework::Script::LuaSymbolsReporterSystemComponent::CreateDescriptor(),
+            AzToolsFramework::Script::LuaEditorSystemComponent::CreateDescriptor(),
         });
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
@@ -102,7 +102,7 @@ namespace AzToolsFramework
 
                 MakeFilenameUnique(fullSourceFolderNameInCallback, defaultScriptName, fullFilepath);
 
-                AZStd::string scriptBoilerplate = GenerateLuaComponentBoilerplate(defaultScriptName);
+                AZStd::string scriptBoilerplate = GenerateLuaComponentBoilerplate(AZ::IO::Path(fullFilepath).Stem().Native());
 
                 auto outcome = SaveLuaScriptFile(fullFilepath, scriptBoilerplate);
                 if (outcome.IsSuccess())
@@ -123,9 +123,9 @@ namespace AzToolsFramework
         }
 
         void LuaEditorSystemComponent::AddSourceFileOpeners(
-            [[maybe_unused]] const char* fullSourceFileName,
+            const char* fullSourceFileName,
             [[maybe_unused]] const AZ::Uuid& sourceUUID,
-            [[maybe_unused]] AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers)
+            AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers)
         {
             if (AZ::IO::Path(fullSourceFileName).Extension() == LuaExtension)
             {
@@ -139,7 +139,7 @@ namespace AzToolsFramework
             }
         }
 
-        void LuaEditorSystemComponent::HandleInitialFilenameChange(const AZStd::string& fullFilepath)
+        void LuaEditorSystemComponent::HandleInitialFilenameChange(const AZStd::string_view fullFilepath)
         {
             AZ::IO::Path filepath = AZ::IO::Path(fullFilepath);
             if (filepath.Extension() == LuaExtension)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/Script/LuaEditorSystemComponent.h>
+
+#include <AzCore/IO/FileIO.h>
+#include <AzCore/IO/SystemFile.h>
+#include <AzCore/Serialization/SerializeContext.h>
+#include <AzCore/std/string/conversions.h>
+#include <AzFramework/StringFunc/StringFunc.h>
+#include <AzToolsFramework/API/ToolsApplicationAPI.h>
+#include <QIcon>
+
+namespace AzToolsFramework
+{
+    namespace Script
+    {
+        void LuaEditorSystemComponent::Reflect(AZ::ReflectContext* context)
+        {
+            AZ::SerializeContext* serialize = azrtti_cast<AZ::SerializeContext*>(context);
+            if (serialize)
+            {
+                serialize->Class<LuaEditorSystemComponent, AZ::Component>();
+            }
+        }
+
+        void LuaEditorSystemComponent::Activate()
+        {
+            AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusConnect();
+        }
+
+        void LuaEditorSystemComponent::Deactivate()
+        {
+            AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler::BusDisconnect();
+        }
+
+        void LuaEditorSystemComponent::GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& provided)
+        {
+            provided.push_back(AZ_CRC_CE("LuaEditorSystemComponent"));
+        }
+
+        void LuaEditorSystemComponent::GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required)
+        {
+            required.push_back(AZ_CRC_CE("ScriptService"));
+        }
+
+        void LuaEditorSystemComponent::GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible)
+        {
+            incompatible.push_back(AZ_CRC_CE("LuaEditorSystemComponent"));
+        }
+
+        void LuaEditorSystemComponent::AddSourceFileCreators(
+            [[maybe_unused]] const char* fullSourceFolderName,
+            [[maybe_unused]] const AZ::Uuid& sourceUUID,
+            AzToolsFramework::AssetBrowser::SourceFileCreatorList& creators)
+        {
+            auto luaAssetCreator = [&](const char* fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
+            {
+                AZStd::string defaultScriptName = "NewScript";
+
+                AZStd::string fullFilepath;
+                AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback,
+                    defaultScriptName.c_str(),
+                    m_luaExtension,
+                    fullFilepath);
+
+                MakeFilenameUnique(fullSourceFolderNameInCallback, defaultScriptName, fullFilepath);
+
+                auto outcome = SaveLuaScriptFile(fullFilepath, "");
+                if (outcome.IsSuccess())
+                {
+                    AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Broadcast(
+                        &AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotifications::NotifyAssetWasCreatedInEditor, fullFilepath);
+                }
+                else
+                {
+                    AZ_Error(LogName, false, outcome.GetError().c_str());
+                }
+            };
+
+            creators.push_back({ "Lua_creator", "Lua Script", QIcon(), luaAssetCreator });
+
+            auto luaComponentAssetCreator = [&](const char* fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
+            {
+                AZStd::string defaultScriptName = "NewComponent";
+
+                AZStd::string fullFilepath;
+                AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback,
+                    defaultScriptName.c_str(),
+                    m_luaExtension,
+                    fullFilepath);
+
+                MakeFilenameUnique(fullSourceFolderNameInCallback, defaultScriptName, fullFilepath);
+
+                AZStd::string scriptBoilerplate = GenerateLuaComponentBoilerplate(defaultScriptName);
+
+                auto outcome = SaveLuaScriptFile(fullFilepath, scriptBoilerplate);
+                if (outcome.IsSuccess())
+                {
+                    AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Broadcast(
+                        &AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotifications::NotifyAssetWasCreatedInEditor, fullFilepath);
+                }
+                else
+                {
+                    AZ_Error(LogName, false, outcome.GetError().c_str());
+                }
+            };
+
+            creators.push_back({ "LuaComponent_creator", "Lua Component Script", QIcon(), luaComponentAssetCreator });
+        }
+
+        void LuaEditorSystemComponent::AddSourceFileOpeners(
+            [[maybe_unused]] const char* fullSourceFileName,
+            [[maybe_unused]] const AZ::Uuid& sourceUUID,
+            [[maybe_unused]] AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers)
+        {
+            if (AZ::IO::Path(fullSourceFileName).Extension() == m_luaExtension)
+            {
+                auto luaScriptOpener = [](const char* fullSourceFileNameInCallback, [[maybe_unused]] const AZ::Uuid&)
+                {
+                    AzToolsFramework::EditorRequestBus::Broadcast(
+                        &AzToolsFramework::EditorRequests::LaunchLuaEditor, fullSourceFileNameInCallback);
+                };
+
+                openers.push_back({ "O3DE_LUA_Editor", "Open in Open 3D Engine LUA Editor...", QIcon(), luaScriptOpener });
+            }
+        }
+
+        AZStd::string LuaEditorSystemComponent::GenerateLuaComponentBoilerplate(const AZStd::string& filename)
+        {
+            constexpr const char* namePlaceholder = "$SCRIPT_NAME";
+            AZStd::string luaComponentBoilerplate = R"LUA(-- $SCRIPT_NAME.lua
+
+local $SCRIPT_NAME = 
+{
+    Properties =
+    {
+        -- Property definitions
+    }
+}
+
+function $SCRIPT_NAME:OnActivate()
+    -- Activation Code
+end
+
+function $SCRIPT_NAME:OnDeactivate()
+    -- Deactivation Code
+end
+
+return $SCRIPT_NAME)LUA";
+
+            AZ::StringFunc::Replace(luaComponentBoilerplate, namePlaceholder, filename.c_str());
+            return luaComponentBoilerplate;
+        }
+
+        void LuaEditorSystemComponent::MakeFilenameUnique(
+            const AZStd::string& directoryPath,
+            const AZStd::string& filename,
+            AZStd::string& outFullFilepath)
+        {
+            int fileCounter = 0;
+            while (AZ::IO::FileIOBase::GetInstance()->Exists(outFullFilepath.c_str()))
+            {
+                fileCounter++;
+                AZStd::string filenameDigit = AZStd::to_string(fileCounter);
+
+                AZ::StringFunc::Path::ConstructFull(directoryPath.c_str(),
+                    (filename + filenameDigit).c_str(),
+                    m_luaExtension,
+                    outFullFilepath);
+            }
+        }
+
+        AZ::Outcome<void, AZStd::string> LuaEditorSystemComponent::SaveLuaScriptFile(
+            const AZStd::string& fullFilepath,
+            const AZStd::string& fileContents)
+        {
+            AZ::IO::SystemFile scriptFile = AZ::IO::SystemFile();
+            scriptFile.Open(fullFilepath.c_str(), static_cast<int>(AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeText));
+            if (scriptFile.IsOpen())
+            {
+                auto bytesWritten = scriptFile.Write(fileContents.c_str(), strlen(fileContents.c_str()));
+
+                scriptFile.Close();
+
+                if (bytesWritten == strlen(fileContents.c_str()))
+                {
+                    return AZ::Success();
+                }
+                else
+                {
+                    return AZ::Failure(AZStd::string::format("Failed to write contents to Lua file: %s", fullFilepath.c_str()));
+                }
+            }
+            else
+            {
+                return AZ::Failure(AZStd::string::format("Failed to open file when writing Lua script: %s", fullFilepath.c_str()));
+            }
+        }
+
+    } // namespace AzComponents
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.cpp
@@ -61,12 +61,13 @@ namespace AzToolsFramework
             [[maybe_unused]] const AZ::Uuid& sourceUUID,
             AzToolsFramework::AssetBrowser::SourceFileCreatorList& creators)
         {
-            auto luaAssetCreator = [&](const char* fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
+            auto luaAssetCreator = [&](const AZStd::string& fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
             {
                 AZStd::string defaultScriptName = "NewScript";
 
                 AZStd::string fullFilepath;
-                AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback,
+                AZ::StringFunc::Path::ConstructFull(
+                    fullSourceFolderNameInCallback.c_str(),
                     defaultScriptName.c_str(),
                     LuaExtension,
                     fullFilepath);
@@ -90,12 +91,12 @@ namespace AzToolsFramework
 
             creators.push_back({ "Lua_creator", "Lua Script", QIcon(), luaAssetCreator });
 
-            auto luaComponentAssetCreator = [&](const char* fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
+            auto luaComponentAssetCreator = [&](const AZStd::string& fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
             {
                 AZStd::string defaultScriptName = "NewComponent";
 
                 AZStd::string fullFilepath;
-                AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback,
+                AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback.c_str(),
                     defaultScriptName.c_str(),
                     LuaExtension,
                     fullFilepath);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/Component.h>
+#include <AzToolsFramework/AssetBrowser/AssetBrowserBus.h>
+
+namespace AzToolsFramework
+{
+    namespace Script
+    {
+        class LuaEditorSystemComponent
+            : public AZ::Component
+            , private AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler
+        {
+        public:
+            AZ_COMPONENT(LuaEditorSystemComponent, "{8F3DFC84-2D59-416C-B04D-56C550114D9B}");
+
+            LuaEditorSystemComponent() = default;
+            ~LuaEditorSystemComponent() = default;
+
+            static void Reflect(AZ::ReflectContext* context);
+
+            ////////////////////////////////////////////////////////////////////////
+            //  AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus
+            void AddSourceFileCreators(
+                const char* fullSourceFolderName,
+                const AZ::Uuid& sourceUUID,
+                AzToolsFramework::AssetBrowser::SourceFileCreatorList& creators) override;
+            void AddSourceFileOpeners(
+                const char* fullSourceFileName,
+                const AZ::Uuid& sourceUUID,
+                AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers) override;
+            ////////////////////////////////////////////////////////////////////////
+
+            static constexpr char LogName[] = "LuaEditorSystemComponent";
+
+        protected:
+            void Activate() override;
+            void Deactivate() override;
+
+            static void GetProvidedServices(AZ::ComponentDescriptor::DependencyArrayType& services);
+            static void GetRequiredServices(AZ::ComponentDescriptor::DependencyArrayType& required);
+            static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
+
+        private:
+            AZStd::string GenerateLuaComponentBoilerplate(const AZStd::string& filename);
+            void MakeFilenameUnique(const AZStd::string& directoryPath, const AZStd::string& filename, AZStd::string& outFullFilepath);
+            AZ::Outcome<void, AZStd::string> SaveLuaScriptFile(const AZStd::string& fullFilepath, const AZStd::string& fileContents);
+
+            static constexpr char m_luaExtension[] = ".lua";
+        };
+} // namespace Component
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.h
@@ -42,9 +42,10 @@ namespace AzToolsFramework
 
             ////////////////////////////////////////////////////////////////////////
             // AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationsBus
-            void HandleInitialFilenameChange(const AZStd::string& fullFilepath) override;
+            void HandleInitialFilenameChange(const AZStd::string_view fullFilepath) override;
             ////////////////////////////////////////////////////////////////////////
 
+            //! Generates boilerplate for a basic Lua component script which has the given component name.
             static AZStd::string GenerateLuaComponentBoilerplate(const AZStd::string& componentName);
 
         protected:
@@ -56,11 +57,16 @@ namespace AzToolsFramework
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         private:
+            //! Appends the next available digit to the filename if the filename is already taken.
             void MakeFilenameUnique(const AZStd::string& directoryPath, const AZStd::string& filename, AZStd::string& outFullFilepath);
+
+            //! Saves the given contents to a Lua script on disk.
+            //! The file is created if it does not exist, otherwise the file contents will be overwritten.
             AZ::Outcome<void, AZStd::string> SaveLuaScriptFile(const AZStd::string& fullFilepath, const AZStd::string& fileContents);
 
             static constexpr char LuaExtension[] = ".lua";
             static constexpr char LogName[] = "LuaEditorSystemComponent";
+
             // The ebus address for Lua component script initial name change notifications
             static constexpr AZ::Crc32 LuaComponentScriptBusId = AZ::Crc32("LuaComponentScriptRenameHandler");
         };

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Script/LuaEditorSystemComponent.h
@@ -18,6 +18,7 @@ namespace AzToolsFramework
         class LuaEditorSystemComponent
             : public AZ::Component
             , private AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Handler
+            , private AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Handler
         {
         public:
             AZ_COMPONENT(LuaEditorSystemComponent, "{8F3DFC84-2D59-416C-B04D-56C550114D9B}");
@@ -28,7 +29,7 @@ namespace AzToolsFramework
             static void Reflect(AZ::ReflectContext* context);
 
             ////////////////////////////////////////////////////////////////////////
-            //  AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus
+            // AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus
             void AddSourceFileCreators(
                 const char* fullSourceFolderName,
                 const AZ::Uuid& sourceUUID,
@@ -39,7 +40,12 @@ namespace AzToolsFramework
                 AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers) override;
             ////////////////////////////////////////////////////////////////////////
 
-            static constexpr char LogName[] = "LuaEditorSystemComponent";
+            ////////////////////////////////////////////////////////////////////////
+            // AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationsBus
+            void HandleInitialFilenameChange(const AZStd::string& fullFilepath) override;
+            ////////////////////////////////////////////////////////////////////////
+
+            static AZStd::string GenerateLuaComponentBoilerplate(const AZStd::string& componentName);
 
         protected:
             void Activate() override;
@@ -50,11 +56,13 @@ namespace AzToolsFramework
             static void GetIncompatibleServices(AZ::ComponentDescriptor::DependencyArrayType& incompatible);
 
         private:
-            AZStd::string GenerateLuaComponentBoilerplate(const AZStd::string& filename);
             void MakeFilenameUnique(const AZStd::string& directoryPath, const AZStd::string& filename, AZStd::string& outFullFilepath);
             AZ::Outcome<void, AZStd::string> SaveLuaScriptFile(const AZStd::string& fullFilepath, const AZStd::string& fileContents);
 
-            static constexpr char m_luaExtension[] = ".lua";
+            static constexpr char LuaExtension[] = ".lua";
+            static constexpr char LogName[] = "LuaEditorSystemComponent";
+            // The ebus address for Lua component script initial name change notifications
+            static constexpr AZ::Crc32 LuaComponentScriptBusId = AZ::Crc32("LuaComponentScriptRenameHandler");
         };
 } // namespace Component
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -846,6 +846,8 @@ set(FILES
     PythonTerminal/ScriptTermDialog.ui
     Input/QtEventToAzInputMapper.h
     Input/QtEventToAzInputMapper.cpp
+    Script/LuaEditorSystemComponent.h
+    Script/LuaEditorSystemComponent.cpp
     Script/LuaSymbolsReporterBus.h
     Script/LuaSymbolsReporterSystemComponent.h
     Script/LuaSymbolsReporterSystemComponent.cpp

--- a/Code/Framework/AzToolsFramework/Tests/Script/LuaEditorSystemComponentTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Script/LuaEditorSystemComponentTests.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/Script/LuaEditorSystemComponent.h>
+
+#include <AzCore/Script/ScriptContext.h>
+#include <AzTest/AzTest.h>
+
+namespace UnitTest
+{
+    class LuaEditorSystemComponentTests
+        : public ::testing::Test
+    {
+    public:
+        void SetUp() {}
+        void TearDown() {}
+
+        void TestValidateLuaComponentBoilerplate()
+        {
+            AZ::ScriptContext scriptContext = AZ::ScriptContext();
+            AZStd::string luaComponentBoilerplate =
+                AzToolsFramework::Script::LuaEditorSystemComponent::GenerateLuaComponentBoilerplate("TEST_SCRIPT");
+            ASSERT_TRUE(scriptContext.Execute(luaComponentBoilerplate.c_str()));
+        }
+    };
+
+    TEST_F(LuaEditorSystemComponentTests, LuaEditorSystemComponent_ValidateLuaComponentBoilerplate)
+    {
+        TestValidateLuaComponentBoilerplate();
+    }
+} // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/UI/AssetBrowserTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/UI/AssetBrowserTests.cpp
@@ -24,6 +24,7 @@
 #include <AzToolsFramework/Entity/EditorEntityContextComponent.h>
 #include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <QAbstractItemModelTester>
+#include <AzToolsFramework/AssetBrowser/Entries/AssetBrowserEntryCache.h>
 
 namespace UnitTest
 {

--- a/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
+++ b/Code/Framework/AzToolsFramework/Tests/aztoolsframeworktests_files.cmake
@@ -132,6 +132,7 @@ set(FILES
     PropertyTreeEditorTests.cpp
     PythonBindingTests.cpp
     QtWidgetLimitsTests.cpp
+    Script/LuaEditorSystemComponentTests.cpp
     Script/ScriptComponentTests.cpp
     Script/ScriptEntityTests.cpp
     Slice.cpp

--- a/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/Components/EditorGraph.cpp
@@ -1418,6 +1418,7 @@ namespace ScriptCanvasEditor
             {
                 data->m_scriptCanvasEntity.reset(entity);
                 graph->MarkOwnership(*data);
+                graph->MarkVersion();
                 entity->Init();
                 entity->Activate();
                 return data;

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -215,6 +215,18 @@ namespace ScriptCanvasEditor
                 , scriptCanvasExtension.c_str()
                 , fullFilepath);
 
+            int fileCounter = 0;
+            while (AZ::IO::FileIOBase::GetInstance()->Exists(fullFilepath.c_str()))
+            {
+                fileCounter++;
+                AZStd::string filenameDigit = AZStd::to_string(fileCounter);
+
+                AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback
+                    , (defaultFilename + filenameDigit).c_str()
+                    , scriptCanvasExtension.c_str()
+                    , fullFilepath);
+            }
+
             AZ::IO::Path fullAzFilePath = fullFilepath;
             ScriptCanvas::DataPtr graph = EditorGraph::Create();
             const AZ::Uuid assetId = AZ::Uuid::CreateRandom();

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -219,10 +219,10 @@ namespace ScriptCanvasEditor
             while (AZ::IO::FileIOBase::GetInstance()->Exists(fullFilepath.c_str()))
             {
                 fileCounter++;
-                AZStd::string filenameDigit = AZStd::to_string(fileCounter);
+                AZStd::string incrementalFilename = defaultFilename + AZStd::to_string(fileCounter);
 
                 AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback
-                    , (defaultFilename + filenameDigit).c_str()
+                    , incrementalFilename.c_str()
                     , scriptCanvasExtension.c_str()
                     , fullFilepath);
             }
@@ -242,9 +242,11 @@ namespace ScriptCanvasEditor
                 }
                 else
                 {
-                    AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus::Broadcast(
-                        &AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotifications::NotifyAssetWasCreatedInEditor,
-                        source.Path().Native());
+                    AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
+                        AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId
+                        , &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor
+                        , source.Path().Native()
+                        , AZ::Crc32());
                 }
 
                 fileStream.Close();
@@ -255,10 +257,7 @@ namespace ScriptCanvasEditor
             }
         };
 
-        creators.push_back({ "ScriptCanvas_creator"
-            , "ScriptCanvas"
-            , QIcon()
-            , scriptCavnasAssetCreator });
+        creators.push_back({ "ScriptCanvas_creator", "ScriptCanvas", QIcon(), scriptCavnasAssetCreator });
     }
 
     void SystemComponent::AddSourceFileOpeners

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -204,13 +204,13 @@ namespace ScriptCanvasEditor
         , [[maybe_unused]] const AZ::Uuid& sourceUUID
         , AzToolsFramework::AssetBrowser::SourceFileCreatorList& creators)
     {
-        auto scriptCavnasAssetCreator = [](const char* fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
+        auto scriptCavnasAssetCreator = [](const AZStd::string& fullSourceFolderNameInCallback, [[maybe_unused]] const AZ::Uuid& sourceUUID)
         {
             AZStd::string defaultFilename = "NewScript";
             AZStd::string scriptCanvasExtension = ScriptCanvasEditor::SourceDescription::GetFileExtension();
 
             AZStd::string fullFilepath;
-            AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback
+            AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback.c_str()
                 , defaultFilename.c_str()
                 , scriptCanvasExtension.c_str()
                 , fullFilepath);
@@ -221,7 +221,7 @@ namespace ScriptCanvasEditor
                 fileCounter++;
                 AZStd::string incrementalFilename = defaultFilename + AZStd::to_string(fileCounter);
 
-                AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback
+                AZ::StringFunc::Path::ConstructFull(fullSourceFolderNameInCallback.c_str()
                     , incrementalFilename.c_str()
                     , scriptCanvasExtension.c_str()
                     , fullFilepath);

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.cpp
@@ -230,7 +230,8 @@ namespace ScriptCanvasEditor
             AZ::IO::Path fullAzFilePath = fullFilepath;
             ScriptCanvas::DataPtr graph = EditorGraph::Create();
             const AZ::Uuid assetId = AZ::Uuid::CreateRandom();
-            SourceHandle source = SourceHandle(graph, assetId, fullAzFilePath);
+            SourceHandle source = SourceHandle(graph, assetId);
+            source = SourceHandle::MarkAbsolutePath(source, fullAzFilePath);
 
             AZ::IO::FileIOStream fileStream(fullAzFilePath.c_str(), AZ::IO::OpenMode::ModeWrite | AZ::IO::OpenMode::ModeText);
             if (fileStream.IsOpen())
@@ -245,7 +246,7 @@ namespace ScriptCanvasEditor
                     AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotificationBus::Event(
                         AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::FileCreationNotificationBusId
                         , &AzToolsFramework::AssetBrowser::AssetBrowserFileCreationNotifications::HandleAssetCreatedInEditor
-                        , source.Path().Native()
+                        , source.AbsolutePath().Native()
                         , AZ::Crc32());
                 }
 
@@ -257,7 +258,7 @@ namespace ScriptCanvasEditor
             }
         };
 
-        creators.push_back({ "ScriptCanvas_creator", "ScriptCanvas", QIcon(), scriptCavnasAssetCreator });
+        creators.push_back({ "ScriptCanvas_creator", "ScriptCanvas Graph", QIcon(), scriptCavnasAssetCreator });
     }
 
     void SystemComponent::AddSourceFileOpeners

--- a/Gems/ScriptCanvas/Code/Editor/SystemComponent.h
+++ b/Gems/ScriptCanvas/Code/Editor/SystemComponent.h
@@ -83,6 +83,7 @@ namespace ScriptCanvasEditor
         ////////////////////////////////////////////////////////////////////////
         //  AzToolsFramework::AssetBrowser::AssetBrowserInteractionNotificationBus...
         AzToolsFramework::AssetBrowser::SourceFileDetails GetSourceFileDetails(const char* fullSourceFileName) override;
+        void AddSourceFileCreators(const char* fullSourceFolderName, const AZ::Uuid& sourceUUID, AzToolsFramework::AssetBrowser::SourceFileCreatorList& creators) override;
         void AddSourceFileOpeners(const char* fullSourceFileName, const AZ::Uuid& sourceUUID, AzToolsFramework::AssetBrowser::SourceFileOpenerList& openers) override;
         ////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
**Description**
This PR contains changes for:
- Adding the ability to notify the model/view that a new asset was created
  - This is useful for cases such as creating a new file that needs to be opened for editing in the view
- Adding the ability to create empty ScriptCanvas assets from the AssetBrowser
- Adding the ability to create empty Lua scripts and Lua component scripts from the AssetBrowser
  - These changes also include:
    - LuaEditorSystemComponent in AzToolsFramework which contains the Lua asset creator code, can serve as a general Lua system component in the Editor, and moves us towards potentially having a Lua editor gem some day
    - AssetBrowserFileCreationNotificationBus with API for notifying the AssetBrowser that a new file was created through it, and for notifying individual asset creators that a file's initial name has changed (for cases like fixing up a Lua script's boilerplate with its user-given name)
- Fixes a crash caused by using a hotkey such as delete with an empty view selection model

**Testing**
- Ran AzToolsFramework unit tests locally
- Ran Editor AR tests locally
- Manually verified that new AssetBrowser functionality is working as intended with no regressions