### PR TITLE
Add item size caching and invalidation to DPELayout

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -43,10 +43,15 @@ namespace AzToolsFramework
         bool IsExpanded() const;
 
         // QLayout overrides
+        void invalidate() override;
         QSize sizeHint() const override;
         QSize minimumSize() const override;
         void setGeometry(const QRect& rect) override;
         Qt::Orientations expandingDirections() const override;
+
+    Q_SIGNALS:
+        void LayoutSizeWasCalculated(int width, int height) const;
+        void MinLayoutSizeWasCalculated(int width, int height) const;
 
     protected slots:
         void onCheckstateChanged(int expanderState);
@@ -59,7 +64,16 @@ namespace AzToolsFramework
         bool m_showExpander = false;
         bool m_expanded = true;
         QCheckBox* m_expanderWidget = nullptr;
+
+    private slots:
+        void CacheLayoutSize(int width, int height);
+        void CacheMinLayoutSize(int width, int height);
+
+    private:
+        QSize m_cachedLayoutSize;
+        QSize m_cachedMinLayoutSize;
     };
+
     class DPERowWidget : public QWidget
     {
         Q_OBJECT


### PR DESCRIPTION
This is currently a DRAFT! Waiting to get feedback or see if I learn something that changes my understanding of this PR.

**Description**
This PR changes `DPELayout` to cache `sizeHint` and `minimumSize` calculations and return those calculations until `QLayout::invalidate` is called.

If a cached value is present then it will be returned. If the cached value (a `QSize` member) is invalid then it will recalculate the layout size.

**Testing**
- Added logging statements to see when the functions were being called, and when cached values were returned/recalculated.
- Verified the DPE still works with some tif assets found in the AutomatedTesting project.
