### PR TITLE
Fix assertions encountered when closing a DPE

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.cpp
@@ -217,11 +217,12 @@ namespace AzToolsFramework
         connect(m_expanderWidget, &QCheckBox::stateChanged, this, &DPELayout::onCheckstateChanged);
     }
 
-    DPERowWidget::DPERowWidget(int depth, DPERowWidget* parentRow)
+    DPERowWidget::DPERowWidget(int depth, DPERowWidget* parentRow, DocumentPropertyEditor* parentDpe)
         : QWidget(nullptr) // parent will be set when the row is added to its layout
         , m_parentRow(parentRow)
         , m_depth(depth)
         , m_columnLayout(new DPELayout(depth, this))
+        , m_parentDpe(parentDpe)
     {
         // allow horizontal stretching, but use the vertical size hint exactly
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
@@ -276,7 +277,7 @@ namespace AzToolsFramework
             if (IsExpanded())
             {
                 // determine where to put this new row in the main DPE layout
-                auto newRow = new DPERowWidget(m_depth + 1, this);
+                auto newRow = new DPERowWidget(m_depth + 1, this, m_parentDpe);
                 DPERowWidget* priorWidgetInLayout = nullptr;
 
                 // search for an existing row sibling with a lower dom index
@@ -523,15 +524,7 @@ namespace AzToolsFramework
 
     DocumentPropertyEditor* DPERowWidget::GetDPE() const
     {
-        DocumentPropertyEditor* theDPE = nullptr;
-        QWidget* ancestorWidget = parentWidget();
-        while (ancestorWidget && !theDPE)
-        {
-            theDPE = qobject_cast<DocumentPropertyEditor*>(ancestorWidget);
-            ancestorWidget = ancestorWidget->parentWidget();
-        }
-        AZ_Assert(theDPE, "the top level widget in any DPE hierarchy must be the DocumentPropertyEditor itself!");
-        return theDPE;
+        return m_parentDpe;
     }
 
     void DPERowWidget::AddDomChildWidget(int domIndex, QWidget* childWidget)
@@ -862,7 +855,7 @@ namespace AzToolsFramework
 
         if (indexInRange)
         {
-            auto newRow = new DPERowWidget(0, nullptr);
+            auto newRow = new DPERowWidget(0, nullptr, this);
 
             if (rowIndex == 0)
             {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DocumentPropertyEditor.h
@@ -66,7 +66,7 @@ namespace AzToolsFramework
         friend class DocumentPropertyEditor;
 
     public:
-        explicit DPERowWidget(int depth, DPERowWidget* parentRow);
+        explicit DPERowWidget(int depth, DPERowWidget* parentRow, DocumentPropertyEditor* parentDpe);
         ~DPERowWidget();
 
         void Clear(); //!< destroy all layout contents and clear DOM children
@@ -94,6 +94,8 @@ namespace AzToolsFramework
         DPERowWidget* m_parentRow = nullptr;
         int m_depth = 0; //!< number of levels deep in the tree. Used for indentation
         DPELayout* m_columnLayout = nullptr;
+
+        DocumentPropertyEditor* m_parentDpe = nullptr;
 
         //! widget children in DOM specified order; mix of row and column widgets
         AZStd::deque<QWidget*> m_domOrderedChildren;


### PR DESCRIPTION
This is still a DRAFT! Need Alex's feedback before doing anything else with this.

**Description**
This PR proposes a fix for assertions that are triggered when a DPE window is closed in the editor.

Previously, closing the DPE would trigger an assertion many times as `DPERowWidget`s failed to find their DPE parent. This might be due to the parent never being set, but setting the parent did not resolve the issue. This PR is likely either a temporary or partial fix.

The approach this PR takes is to store a pointer to the parent DPE and pass it along through the hierarchy as new widgets are created in the tree. This way there is no need to traverse back up the tree looking for the base DPE.

**Testing**
- Closed the DPE without a short hang followed by assertion spam
- Verified DPE functions as usual otherwise