### PR TITLE
Prevent AssetBrowserModel tick bus from ticking when window is closed

### DIFF
--- a/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
+++ b/Code/Editor/AzAssetBrowser/AzAssetBrowserWindow.cpp
@@ -95,6 +95,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
     m_ui->m_searchWidget->SetFilterInputInterval(AZStd::chrono::milliseconds(250));
 
     m_assetBrowserModel->SetFilterModel(m_filterModel.data());
+    m_assetBrowserModel->EnableTickBus();
 
     m_ui->m_collapseAllButton->setAutoRaise(true); // hover highlight
     m_ui->m_collapseAllButton->setIcon(QIcon(AzAssetBrowser::CollapseAllIcon));
@@ -171,6 +172,7 @@ AzAssetBrowserWindow::AzAssetBrowserWindow(QWidget* parent)
 
 AzAssetBrowserWindow::~AzAssetBrowserWindow()
 {
+    m_assetBrowserModel->DisableTickBus();
     m_ui->m_assetBrowserTreeViewWidget->SaveState();
 }
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.cpp
@@ -45,6 +45,16 @@ namespace AzToolsFramework
             AZ::TickBus::Handler::BusDisconnect();
         }
 
+        void AssetBrowserModel::EnableTickBus()
+        {
+            m_isTickBusEnabled = true;
+        }
+
+        void AssetBrowserModel::DisableTickBus()
+        {
+            m_isTickBusEnabled = false;
+        }
+
         QModelIndex AssetBrowserModel::findIndex(const QString& absoluteAssetPath) const
         {
             // Split the path based on either platform's slash
@@ -407,7 +417,8 @@ namespace AzToolsFramework
         void AssetBrowserModel::OnTick(float /*deltaTime*/, AZ::ScriptTimePoint /*time*/) 
         {
             // if any entries changed since last tick, notify the views
-            if (EntryCache* cache = EntryCache::GetInstance())
+            EntryCache* cache = EntryCache::GetInstance();
+            if (m_isTickBusEnabled && cache)
             {
                 if (!cache->m_dirtyThumbnailsSet.empty())
                 {

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/AssetBrowser/AssetBrowserModel.h
@@ -54,6 +54,9 @@ namespace AzToolsFramework
             explicit AssetBrowserModel(QObject* parent = nullptr);
             ~AssetBrowserModel();
 
+            void EnableTickBus();
+            void DisableTickBus();
+
             QModelIndex findIndex(const QString& absoluteAssetPath) const;
 
             //////////////////////////////////////////////////////////////////////////
@@ -100,6 +103,7 @@ namespace AzToolsFramework
             bool m_loaded;
             bool m_addingEntry;
             bool m_removingEntry;
+            bool m_isTickBusEnabled = false;
 
             bool GetEntryIndex(AssetBrowserEntry* entry, QModelIndex& index) const;
             int GetLeftmostColumnInFilter() const;


### PR DESCRIPTION
**Description**
This PR fixes the failing AssetBrowser related python AR tests.

The `AssetBrowserModel` has a tickbus that continued to tick after the python tests had closed the AssetBrowser in editor. That led to an attempted access on an out of scope `AssetBrowserFilterModel`. This commit adds a flag to enable/disable the base model's tickbus and an API for doing so externally (from `AssetBrowserWindow` in this case).

Another approach was to listen to the `EditorEventsBus` and enable/disable the base model's tickbus when the "Asset Browser" pane was opened/closed. I chose the more straightforward flag approach instead.

**Testing**
- Ran python AR tests pass locally.
- Verified basic functionality in AssetBrowser is entact.
- Verified AssetBrowser window can be opened and closed in the editor.