### PR TITLE
LYN-10531: Draw Data

### DIFF
--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMaskRenderer.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMaskRenderer.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Draw/EditorStateMaskRenderer.h>
+
+namespace AZ::Render
+{
+    EditorStateMaskRenderer::EditorStateMaskRenderer(Name name, Data::Instance<RPI::Material> maskMaterial)
+        : m_drawTag(name)
+        , m_maskMaterial(maskMaterial)
+    {
+    }
+
+    void EditorStateMaskRenderer::RenderMaskEntities(const AzToolsFramework::EntityIdSet& entityIds)
+    {
+        if (entityIds.empty())
+        {
+            m_drawableEntities.clear();
+            return;
+        }
+
+        // Erase any drawable entity meshes not in the provided list of entities
+        for (auto it = m_drawableEntities.begin(); it != m_drawableEntities.end();)
+        {
+            if (!entityIds.contains(it->first))
+            {
+                it = m_drawableEntities.erase(it);
+            }
+            else
+            {
+                it++;
+            }
+        }
+
+        // Construct the drawable entity meshes for entities not in the drawable entity cache
+        for (const auto& entityId : entityIds)
+        {
+            if (m_drawableEntities.find(entityId) == m_drawableEntities.end())
+            {
+                m_drawableEntities.emplace(
+                    AZStd::piecewise_construct, AZStd::forward_as_tuple(entityId),
+                    AZStd::forward_as_tuple(entityId, m_maskMaterial, m_drawTag));
+            }
+        }
+
+        // Render all of the drawable entities that can draw (not being able to draw is not a failure)
+        for (auto& [entityId, drawable] : m_drawableEntities)
+        {
+            if (drawable.CanDraw())
+            {
+                drawable.Draw();
+            }
+        }
+    }
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMaskRenderer.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMaskRenderer.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Draw/DrawableMeshEntity.h>
+#include <Pass/EditorStatePassSystem.h>
+
+#include <AzCore/std/containers/unordered_map.h>
+
+namespace AZ::Render
+{
+    //! Handles the rendering of supported drawable entity components to the mask with the given draw tag.
+    class EditorStateMaskRenderer
+    {
+    public:
+        //! Constructs the mask renderer for the specified draw tag.
+        EditorStateMaskRenderer(Name name, Data::Instance<RPI::Material> maskMaterial);
+
+        //! Renders the specified entities to this mask.
+        void RenderMaskEntities(const AzToolsFramework::EntityIdSet& entityIds);
+    private:
+
+        //! The drawable components of the entities tagged for rendering to this mask.
+        AZStd::unordered_map<EntityId, DrawableMeshEntity> m_drawableEntities;
+
+        Name m_drawTag; //!< The draw tag for this mask.
+        Data::Instance<RPI::Material> m_maskMaterial = nullptr; //!< The material for this mask.
+    };
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Draw/EditorStateMeshDrawPacket.h>
+
+#include <Atom/RPI.Public/RPIUtils.h>
+#include <Atom/RPI.Public/Shader/ShaderResourceGroup.h>
+#include <Atom/RPI.Public/Shader/ShaderSystemInterface.h>
+#include <Atom/RPI.Public/Scene.h> 
+#include <Atom/RPI.Reflect/Material/MaterialFunctor.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
+#include <Atom/RHI/RHISystemInterface.h>
+#include <AzCore/Console/Console.h>
+
+namespace AZ::Render
+{
+    EditorStateMeshDrawPacket::EditorStateMeshDrawPacket(
+        RPI::ModelLod& modelLod,
+        size_t modelLodMeshIndex,
+        Data::Instance<RPI::Material> materialOverride,
+        AZ::Name drawList,
+        Data::Instance<RPI::ShaderResourceGroup> objectSrg,
+        const RPI::MaterialModelUvOverrideMap& materialModelUvMap
+    )
+        : m_modelLod(&modelLod)
+        , m_modelLodMeshIndex(modelLodMeshIndex)
+        , m_objectSrg(objectSrg)
+        , m_material(materialOverride)
+        , m_materialModelUvMap(materialModelUvMap)
+    {
+        if (!m_material)
+        {
+            const RPI::ModelLod::Mesh& mesh = m_modelLod->GetMeshes()[m_modelLodMeshIndex];
+            m_material = mesh.m_material;
+        }
+
+        RHI::RHISystemInterface* rhiSystem = RHI::RHISystemInterface::Get();
+        RHI::DrawListTagRegistry* drawListTagRegistry = rhiSystem->GetDrawListTagRegistry();
+        m_drawListTag = drawListTagRegistry->AcquireTag(drawList);
+    }
+
+    Data::Instance<RPI::Material> EditorStateMeshDrawPacket::GetMaterial()
+    {
+        return m_material;
+    }
+
+    bool EditorStateMeshDrawPacket::SetShaderOption(const Name& shaderOptionName, RPI::ShaderOptionValue value)
+    {
+        // check if the material owns this option in any of its shaders, if so it can't be set externally
+        for (auto& shaderItem : m_material->GetShaderCollection())
+        {
+            const RPI::ShaderOptionGroupLayout* layout = shaderItem.GetShaderOptions()->GetShaderOptionLayout();
+            RPI::ShaderOptionIndex index = layout->FindShaderOptionIndex(shaderOptionName);
+            if (index.IsValid())
+            {
+                if (shaderItem.MaterialOwnsShaderOption(index))
+                {
+                    return false;
+                }
+            }
+        }
+
+        for (auto& shaderItem : m_material->GetShaderCollection())
+        {
+            const RPI::ShaderOptionGroupLayout* layout = shaderItem.GetShaderOptions()->GetShaderOptionLayout();
+            RPI::ShaderOptionIndex index = layout->FindShaderOptionIndex(shaderOptionName);
+            if (index.IsValid())
+            {
+                // try to find an existing option entry in the list
+                auto itEntry = AZStd::find_if(m_shaderOptions.begin(), m_shaderOptions.end(), [&shaderOptionName](const ShaderOptionPair& entry)
+                {
+                    return entry.first == shaderOptionName;
+                });
+
+                // store the option name and value, they will be used in DoUpdate() to select the appropriate shader variant
+                if (itEntry == m_shaderOptions.end())
+                {
+                    m_shaderOptions.push_back({ shaderOptionName, value });
+                }
+                else
+                {
+                    itEntry->second = value;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    bool EditorStateMeshDrawPacket::Update(const RPI::Scene& parentScene, bool forceUpdate /*= false*/)
+    {
+        // Why we need to check "!m_material->NeedsCompile()"...
+        //    Frame A:
+        //      - Material::SetPropertyValue("foo",...). This bumps the material's CurrentChangeId()
+        //      - Material::Compile() updates all the material's outputs (SRG data, shader selection, shader options, etc).
+        //      - Material::SetPropertyValue("bar",...). This bumps the materials' CurrentChangeId() again.
+        //      - We do not process Material::Compile() a second time because because you can only call SRG::Compile() once per frame. Material::Compile()
+        //        will be processed on the next frame. (See implementation of Material::Compile())
+        //      - EditorStateMeshDrawPacket::Update() is called. It runs DoUpdate() to rebuild the draw packet, but everything is still in the state when "foo" was
+        //        set. The "bar" changes haven't been applied yet. It also sets m_materialChangeId to GetCurrentChangeId(), which corresponds to "bar" not "foo".
+        //    Frame B:
+        //      - Something calls Material::Compile(). This finally updates the material's outputs with the latest data corresponding to "bar".
+        //      - EditorStateMeshDrawPacket::Update() is called. But since the GetCurrentChangeId() hasn't changed since last time, DoUpdate() is not called.
+        //      - The mesh continues rendering with only the "foo" change applied, indefinitely.
+
+        if (forceUpdate || (!m_material->NeedsCompile() && m_materialChangeId != m_material->GetCurrentChangeId()))
+        {
+            DoUpdate(parentScene);
+            m_materialChangeId = m_material->GetCurrentChangeId();
+            return true;
+        }
+
+        return false;
+    }
+
+    bool EditorStateMeshDrawPacket::DoUpdate(const RPI::Scene& parentScene)
+    {
+        const RPI::ModelLod::Mesh& mesh = m_modelLod->GetMeshes()[m_modelLodMeshIndex];
+
+        if (!m_material)
+        {
+            AZ_Warning("EditorStateMeshDrawPacket", false, "No material provided for mesh. Skipping.");
+            return false;
+        }
+
+        RHI::DrawPacketBuilder drawPacketBuilder;
+        drawPacketBuilder.Begin(nullptr);
+
+        drawPacketBuilder.SetDrawArguments(mesh.m_drawArguments);
+        drawPacketBuilder.SetIndexBufferView(mesh.m_indexBufferView);
+        drawPacketBuilder.AddShaderResourceGroup(m_objectSrg->GetRHIShaderResourceGroup());
+        drawPacketBuilder.AddShaderResourceGroup(m_material->GetRHIShaderResourceGroup());
+
+        // We build the list of used shaders in a local list rather than m_activeShaders so that
+        // if DoUpdate() fails it won't modify any member data.
+        EditorStateMeshDrawPacket::ShaderList shaderList;
+        shaderList.reserve(m_activeShaders.size());
+
+        // We have to keep a list of these outside the loops that collect all the shaders because the DrawPacketBuilder
+        // keeps pointers to StreamBufferViews until DrawPacketBuilder::End() is called. And we use a fixed_vector to guarantee
+        // that the memory won't be relocated when new entries are added.
+        AZStd::fixed_vector<RPI::ModelLod::StreamBufferViewList, RHI::DrawPacketBuilder::DrawItemCountMax> streamBufferViewsPerShader;
+
+        m_perDrawSrgs.clear();
+
+        auto appendShader = [&](const RPI::ShaderCollection::Item& shaderItem)
+        {
+            if (!parentScene.HasOutputForPipelineState(m_drawListTag))
+            {
+                // drawListTag not found in this scene, so don't render this item
+                return false;
+            }
+
+            Data::Instance<RPI::Shader> shader = RPI::Shader::FindOrCreate(shaderItem.GetShaderAsset());
+            if (!shader)
+            {
+                AZ_Error("EditorStateMeshDrawPacket", false, "Shader '%s'. Failed to find or create instance", shaderItem.GetShaderAsset()->GetName().GetCStr());
+                return false;
+            }
+
+            // Set all unspecified shader options to default values, so that we get the most specialized variant possible.
+            // (because FindVariantStableId treats unspecified options as a request specifically for a variant that doesn't specify those options)
+            // [GFX TODO][ATOM-3883] We should consider updating the FindVariantStableId algorithm to handle default values for us, and remove this step here.
+            RPI::ShaderOptionGroup shaderOptions = *shaderItem.GetShaderOptions();
+            shaderOptions.SetUnspecifiedToDefaultValues();
+
+            // [GFX_TODO][ATOM-14476]: according to this usage, we should make the shader input contract uniform across all shader variants.
+            m_modelLod->CheckOptionalStreams(
+                shaderOptions,
+                shader->GetInputContract(),
+                m_modelLodMeshIndex,
+                m_materialModelUvMap,
+                m_material->GetAsset()->GetMaterialTypeAsset()->GetUvNameMap());
+
+            // apply shader options from this draw packet to the ShaderItem
+            for (auto& meshShaderOption : m_shaderOptions)
+            {
+                Name& name = meshShaderOption.first;
+                RPI::ShaderOptionValue& value = meshShaderOption.second;
+
+                RPI::ShaderOptionIndex index = shaderOptions.FindShaderOptionIndex(name);
+                if (index.IsValid())
+                {
+                    shaderOptions.SetValue(name, value);
+                }
+            }
+
+            const RPI::ShaderVariantId finalVariantId = shaderOptions.GetShaderVariantId();
+            const RPI::ShaderVariant& variant = shader->GetVariant(finalVariantId);
+
+            RHI::PipelineStateDescriptorForDraw pipelineStateDescriptor;
+            variant.ConfigurePipelineState(pipelineStateDescriptor);
+
+            // Render states need to merge the runtime variation.
+            // This allows materials to customize the render states that the shader uses.
+            const RHI::RenderStates& renderStatesOverlay = *shaderItem.GetRenderStatesOverlay();
+            RHI::MergeStateInto(renderStatesOverlay, pipelineStateDescriptor.m_renderStates);
+
+            streamBufferViewsPerShader.push_back();
+            auto& streamBufferViews = streamBufferViewsPerShader.back();
+
+            RPI::UvStreamTangentBitmask uvStreamTangentBitmask;
+
+            if (!m_modelLod->GetStreamsForMesh(
+                pipelineStateDescriptor.m_inputStreamLayout,
+                streamBufferViews,
+                &uvStreamTangentBitmask,
+                shader->GetInputContract(),
+                m_modelLodMeshIndex,
+                m_materialModelUvMap,
+                m_material->GetAsset()->GetMaterialTypeAsset()->GetUvNameMap()))
+            {
+                return false;
+            }
+
+            auto drawSrgLayout = shader->GetAsset()->GetDrawSrgLayout(shader->GetSupervariantIndex());
+            Data::Instance<RPI::ShaderResourceGroup> drawSrg;
+            if (drawSrgLayout)
+            {
+                // If the DrawSrg exists we must create and bind it, otherwise the CommandList will fail validation for SRG being null
+                drawSrg = RPI::ShaderResourceGroup::Create(shader->GetAsset(), shader->GetSupervariantIndex(), drawSrgLayout->GetName());
+
+                if (!variant.IsFullyBaked() && drawSrgLayout->HasShaderVariantKeyFallbackEntry())
+                {
+                    drawSrg->SetShaderVariantKeyFallbackValue(shaderOptions.GetShaderVariantKeyFallbackValue());
+                }
+
+                // Pass UvStreamTangentBitmask to the shader if the draw SRG has it.
+                {
+                    AZ::Name shaderUvStreamTangentBitmask = AZ::Name(RPI::UvStreamTangentBitmask::SrgName);
+                    auto index = drawSrg->FindShaderInputConstantIndex(shaderUvStreamTangentBitmask);
+
+                    if (index.IsValid())
+                    {
+                        drawSrg->SetConstant(index, uvStreamTangentBitmask.GetFullTangentBitmask());
+                    }
+                }
+
+                drawSrg->Compile();
+            }
+
+            parentScene.ConfigurePipelineState(m_drawListTag, pipelineStateDescriptor);
+
+            const RHI::PipelineState* pipelineState = shader->AcquirePipelineState(pipelineStateDescriptor);
+            if (!pipelineState)
+            {
+                AZ_Error("EditorStateMeshDrawPacket", false, "Shader '%s'. Failed to acquire default pipeline state", shaderItem.GetShaderAsset()->GetName().GetCStr());
+                return false;
+            }
+
+            RHI::DrawPacketBuilder::DrawRequest drawRequest;
+            drawRequest.m_listTag = m_drawListTag;
+            drawRequest.m_pipelineState = pipelineState;
+            drawRequest.m_streamBufferViews = streamBufferViews;
+            drawRequest.m_stencilRef = m_stencilRef;
+            drawRequest.m_sortKey = m_sortKey;
+            if (drawSrg)
+            {
+                drawRequest.m_uniqueShaderResourceGroup = drawSrg->GetRHIShaderResourceGroup();
+                m_perDrawSrgs.push_back(drawSrg);
+            }
+            drawPacketBuilder.AddDrawItem(drawRequest);
+
+            shaderList.emplace_back(AZStd::move(shader));
+
+            return true;
+        };
+
+        // [GFX TODO][ATOM-5625] This really needs to be optimized to put the burden on setting global shader options, not applying global shader options.
+        // For example, make the shader system collect a map of all shaders and ShaderVaraintIds, and look up the shader option names at set-time.
+        RPI::ShaderSystemInterface* shaderSystem = RPI::ShaderSystemInterface::Get();
+        for (auto iter : shaderSystem->GetGlobalShaderOptions())
+        {
+            const AZ::Name& shaderOptionName = iter.first;
+            RPI::ShaderOptionValue value = iter.second;
+            if (!m_material->SetSystemShaderOption(shaderOptionName, value).IsSuccess())
+            {
+                AZ_Warning("EditorStateMeshDrawPacket", false, "Shader option '%s' is owned by this this material. Global value for this option was ignored.", shaderOptionName.GetCStr());
+            }
+        }
+
+        for (auto& shaderItem : m_material->GetShaderCollection())
+        {
+            if (shaderItem.IsEnabled())
+            {
+                if (shaderList.size() == RHI::DrawPacketBuilder::DrawItemCountMax)
+                {
+                    AZ_Error("EditorStateMeshDrawPacket", false, "Material has more than the limit of %d active shader items.", RHI::DrawPacketBuilder::DrawItemCountMax);
+                    return false;
+                }
+
+                appendShader(shaderItem);
+            }
+        }
+
+        m_drawPacket = drawPacketBuilder.End();
+
+        if (m_drawPacket)
+        {
+            m_activeShaders = shaderList;
+            m_materialSrg = m_material->GetRHIShaderResourceGroup();
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    const RHI::DrawPacket* EditorStateMeshDrawPacket::GetRHIDrawPacket() const
+    {
+        return m_drawPacket.get();
+    }
+} // namespace AZ::Render

--- a/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.h
+++ b/Gems/AtomLyIntegration/EditorModeFeedback/Code/Source/Draw/EditorStateMeshDrawPacket.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Atom/RPI.Public/Shader/Shader.h>
+#include <Atom/RPI.Public/Material/Material.h>
+#include <Atom/RPI.Public/Model/ModelLod.h>
+#include <Atom/RHI/DrawPacket.h>
+#include <Atom/RHI/DrawPacketBuilder.h>
+
+#include <AzCore/Math/Obb.h>
+
+namespace AZ::RPI
+{
+    class Scene;
+}
+
+namespace AZ::Render
+{
+    //! Holds and manages an RHI DrawPacket for a specific mesh, and the resources that are needed to build and maintain it.
+    //! @note This class is based on the meshDrawPacket class and could be paired down even further to leave only the pertinent
+    //! parts of the interface and implementation.
+    class EditorStateMeshDrawPacket
+    {
+    public:
+        using ShaderList = AZStd::vector<Data::Instance<RPI::Shader>>;
+
+        EditorStateMeshDrawPacket() = default;
+        EditorStateMeshDrawPacket(
+            RPI::ModelLod& modelLod,
+            size_t modelLodMeshIndex,
+            Data::Instance<RPI::Material> materialOverride,
+            AZ::Name drawList,
+            Data::Instance<RPI::ShaderResourceGroup> objectSrg,
+            const RPI::MaterialModelUvOverrideMap& materialModelUvMap = {});
+
+        AZ_DEFAULT_COPY(EditorStateMeshDrawPacket);
+        AZ_DEFAULT_MOVE(EditorStateMeshDrawPacket);
+
+        bool Update(const RPI::Scene& parentScene, bool forceUpdate = false);
+
+        const RHI::DrawPacket* GetRHIDrawPacket() const;
+
+        void SetStencilRef(uint8_t stencilRef) { m_stencilRef = stencilRef; }
+        void SetSortKey(RHI::DrawItemSortKey sortKey) { m_sortKey = sortKey; };
+        bool SetShaderOption(const Name& shaderOptionName, RPI::ShaderOptionValue value);
+
+        Data::Instance<RPI::Material> GetMaterial();
+
+    private:
+        bool DoUpdate(const RPI::Scene& parentScene);
+
+        RPI::ConstPtr<RHI::DrawPacket> m_drawPacket;
+
+        // Note, many of the following items are held locally in the EditorStateMeshDrawPacket solely to keep them resident in memory as long as they are needed
+        // for the m_drawPacket. RHI::DrawPacket uses raw pointers only, but we use smart pointers here to hold on to the data.
+
+        // Maintains references to the shader instances to keep their PSO caches resident (see Shader::Shutdown())
+        ShaderList m_activeShaders;
+
+        // The model that contains the mesh being represented by the DrawPacket
+        Data::Instance<RPI::ModelLod> m_modelLod;
+
+        // The index of the mesh within m_modelLod that is represented by the DrawPacket
+        size_t m_modelLodMeshIndex;
+
+        // The per-object shader resource group
+        Data::Instance<RPI::ShaderResourceGroup> m_objectSrg;
+
+        // We hold ConstPtr<RHI::ShaderResourceGroup> instead of Instance<RPI::ShaderResourceGroup> because the Material class
+        // does not allow public access to its Instance<RPI::ShaderResourceGroup>.
+        RPI::ConstPtr<RHI::ShaderResourceGroup> m_materialSrg;
+
+        AZStd::fixed_vector<Data::Instance<RPI::ShaderResourceGroup>, RHI::DrawPacketBuilder::DrawItemCountMax> m_perDrawSrgs;
+
+        // A reference to the material, used to rebuild the DrawPacket if needed
+        Data::Instance<RPI::Material> m_material;
+
+        // Tracks whether the Material has change since the DrawPacket was last built
+        RPI::Material::ChangeId m_materialChangeId = RPI::Material::DEFAULT_CHANGE_ID;
+
+        // Set the sort key for the draw packet
+        RHI::DrawItemSortKey m_sortKey = 0;
+
+        // Set the stencil value for this draw packet
+        uint8_t m_stencilRef = 0;
+
+        //! A map matches the index of UV names of this material to the custom names from the model.
+        RPI::MaterialModelUvOverrideMap m_materialModelUvMap;
+
+        //! List of shader options set for this specific draw packet
+        typedef AZStd::pair<Name, RPI::ShaderOptionValue> ShaderOptionPair;
+        typedef AZStd::vector<ShaderOptionPair> ShaderOptionVector;
+        ShaderOptionVector m_shaderOptions;
+        RHI::DrawListTag m_drawListTag;
+    };
+} // namespace AZ::Render


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR adds the new draw data classes that the editor mode pass system depends on.

**Note:** The class `EditorStateMeshDrawPacket` is based on the class `MeshDrawPacket`, thus it contains logic required by `MeshDrawPacket` that could be removed in the next iteration of development to pair down `EditorStateMeshDrawPacket` to only the logic required by the editor mode pass system. The rationale behind this to allow draw packets to be easily built for specific draw tags, with the ultimate goal of removing the mask material whose only purpose is to hold the shader and draw tag for the mask passes.

## How was this PR tested?

This PR is part of a series of PRs destined for a staging branch. Manual testing has been performed in the editor.
