### PR TITLE
TIAF Python Test Seeding: CMake and Console Changes.

### DIFF
--- a/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Include/Static/TestImpactCommandLineOptions.h
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Common/Code/Include/Static/TestImpactCommandLineOptions.h
@@ -91,6 +91,9 @@ namespace TestImpact
         //! Returns the test target standard output capture policy to use.
         Policy::TargetOutputCapture GetTargetOutputCapture() const;
 
+        //! Returns the individual test target timeout to use (if any).
+        const AZStd::optional<AZStd::chrono::milliseconds>& GetTestTargetTimeout() const;
+
         //! Returns the global test sequence timeout to use (if any).
         const AZStd::optional<AZStd::chrono::milliseconds>& GetGlobalTimeout() const;
 
@@ -102,6 +105,9 @@ namespace TestImpact
 
         //! Returns true if we have tests to exclude that have been loaded from the exclude file, otherwise false.
         bool HasExcludedTests() const;
+
+        //! Returns true if the safe mode option has been enabled, otherwise false.
+        bool HasSafeMode() const;
 
     private:
         RepoPath m_configurationFile;
@@ -116,9 +122,11 @@ namespace TestImpact
         Policy::TestFailure m_testFailurePolicy = Policy::TestFailure::Abort;
         Policy::IntegrityFailure m_integrityFailurePolicy = Policy::IntegrityFailure::Abort;
         Policy::TargetOutputCapture m_targetOutputCapture = Policy::TargetOutputCapture::None;
+        AZStd::optional<AZStd::chrono::milliseconds> m_testTargetTimeout;
         AZStd::optional<AZStd::chrono::milliseconds> m_globalTimeout;
         SuiteType m_suiteFilter;
         bool m_draftFailingTests = false;
         AZStd::vector<ExcludedTarget> m_excludedTests;
+        bool m_safeMode = false;
     };
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/TestImpactPythonRuntimeConfigurationFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/TestImpactPythonRuntimeConfigurationFactory.cpp
@@ -6,15 +6,68 @@
  *
  */
 
+#include <TestImpactFramework/TestImpactConfigurationException.h>
+#include <TestImpactFramework/TestImpactUtils.h>
+
 #include <TestImpactPythonRuntimeConfigurationFactory.h>
 #include <TestImpactRuntimeConfigurationFactory.h>
 
 namespace TestImpact
 {
+    namespace Config
+    {
+        // Keys for pertinent JSON elements
+        constexpr const char* Keys[] = {
+            "exclude",
+            "python",
+            "target",
+            "test_engine",
+            "test_runner",
+            "bin",
+            "workspace",
+        };
+
+        enum
+        {
+            TargetExclude,
+            Python,
+            TargetConfig,
+            TestEngine,
+            TestRunner,
+            PythonCmd,
+            Workspace,
+        };
+    } // namespace Config
+
+    PythonTestEngineConfig ParseTestEngineConfig(const rapidjson::Value& testEngine)
+    {
+        PythonTestEngineConfig testEngineConfig;
+        testEngineConfig.m_testRunner.m_pythonCmd = testEngine[Config::Keys[Config::TestRunner]][Config::Keys[Config::PythonCmd]].GetString();
+        return testEngineConfig;
+    }
+
+    PythonTargetConfig ParseTargetConfig(const rapidjson::Value& target)
+    {
+        PythonTargetConfig targetConfig;
+        targetConfig.m_excludedTargets = ParseTargetExcludeList(target[Config::Keys[Config::TargetExclude]].GetArray());
+
+        return targetConfig;
+    }
+
     PythonRuntimeConfig PythonRuntimeConfigurationFactory(const AZStd::string& configurationData)
     {
+        rapidjson::Document configurationFile;
+
+        if (configurationFile.Parse(configurationData.c_str()).HasParseError())
+        {
+            throw TestImpact::ConfigurationException("Could not parse runtimeConfig data, JSON has errors");
+        }
+
         PythonRuntimeConfig runtimeConfig;
         runtimeConfig.m_commonConfig = RuntimeConfigurationFactory(configurationData);
+        runtimeConfig.m_workspace = ParseWorkspaceConfig(configurationFile[Config::Keys[Config::Python]][Config::Keys[Config::Workspace]]);
+        runtimeConfig.m_testEngine = ParseTestEngineConfig(configurationFile[Config::Keys[Config::Python]][Config::Keys[Config::TestEngine]]);
+        runtimeConfig.m_target = ParseTargetConfig(configurationFile[Config::Keys[Config::Python]][Config::Keys[Config::TargetConfig]]);
 
         return runtimeConfig;
     }

--- a/cmake/LYWrappers.cmake
+++ b/cmake/LYWrappers.cmake
@@ -231,6 +231,15 @@ function(ly_add_target)
         )
     endif()
 
+    # Add the target dependencies so they can be walked later
+    if(ly_add_target_BUILD_DEPENDENCIES)
+        set_property(GLOBAL APPEND PROPERTY LY_ALL_TARGETS_${ly_add_target_NAME}_BUILD_DEPENDENCIES ${ly_add_target_BUILD_DEPENDENCIES})
+    endif()
+
+    if(ly_add_target_RUNTIME_DEPENDENCIES)
+        set_property(GLOBAL APPEND PROPERTY LY_ALL_TARGETS_${ly_add_target_NAME}_RUNTIME_DEPENDENCIES ${ly_add_target_RUNTIME_DEPENDENCIES})
+    endif()
+
     if (ly_add_target_SHARED OR ly_add_target_MODULE OR ly_add_target_EXECUTABLE OR ly_add_target_APPLICATION)
 
         if (ly_add_target_OUTPUT_SUBDIRECTORY)

--- a/cmake/TestImpactFramework/ConsoleFrontendConfig.in
+++ b/cmake/TestImpactFramework/ConsoleFrontendConfig.in
@@ -10,29 +10,7 @@
     },
     "repo": {
       "root": "${repo_dir}",
-      "tiaf_bin": "${tiaf_bin}"
-    },
-    "workspace": {
-      "temp": {
-        "root": "${temp_dir}",
-        "relative_paths": {
-          "artifact_dir": "RuntimeArtifact",
-          "enumeration_cache_dir": "EnumerationCache"
-        }
-      },
-      "active": {
-        "root": "${active_dir}",
-        "relative_paths": {
-          "test_impact_data_file": "TestImpactData.spartia",
-          "previous_test_run_data_file": "PreviousTestRunData.json"
-        }
-      },
-      "historic": {
-        "root": "${historic_dir}",
-        "relative_paths": {
-          "data": "historic_data.json"
-        }
-      }
+      "build": "${bin_dir}"
     },
     "artifacts": {
       "static": {
@@ -41,7 +19,7 @@
           "target_sources": {
             "static": {
               "include_filters": [
-                ".h", ".hpp", ".hxx", ".inl", ".c", ".cpp", ".cxx"
+                ".h", ".hpp", ".hxx", ".inl", ".c", ".cpp", ".cxx", ".py"
               ]
             },
             "autogen": {
@@ -71,9 +49,30 @@
     }
   },
   "native": {
+    "workspace": {
+      "temp": {
+        "run_artifact_dir": "${GTEST_XML_OUTPUT_DIR}",
+        "coverage_artifact_dir": "${native_temp_dir}/Coverage",
+        "enumeration_cache_dir": "${native_temp_dir}/EnumerationCache"
+      },
+      "active": {
+        "root": "${native_active_dir}",
+        "relative_paths": {
+          "test_impact_data_file": "TestImpactData.spartia",
+          "previous_test_run_data_file": "PreviousTestRunData.json"
+        }
+      },
+      "historic": {
+        "root": "${native_historic_dir}",
+        "relative_paths": {
+          "data": "historic_data.json"
+        }
+      }
+    },
+    "runtime_bin": "${native_runtime_bin}",
     "test_engine": {
       "test_runner": {
-          "bin": "${test_runner_bin}"
+          "bin": "${native_test_runner_bin}"
       },
       "instrumentation": {
         "bin": "${instrumentation_bin}"
@@ -98,10 +97,40 @@
     }
   },
   "python": {
-    "artifact": { 
-      "result": {
-        "external_run_output": "${PYTEST_XML_OUTPUT_DIR}"
+    "workspace": {
+      "temp": {
+        "run_artifact_dir": "${PYTEST_XML_OUTPUT_DIR}",
+        "coverage_artifact_dir": "${python_temp_dir}/Coverage",
+        "enumeration_cache_dir": "${python_temp_dir}/EnumerationCache"
+      },
+      "active": {
+        "root": "${python_active_dir}",
+        "relative_paths": {
+          "test_impact_data_file": "TestImpactData.spartia",
+          "previous_test_run_data_file": "PreviousTestRunData.json"
+        }
+      },
+      "historic": {
+        "root": "${python_historic_dir}",
+        "relative_paths": {
+          "data": "historic_data.json"
+        }
       }
+    },
+    "runtime_bin": "${python_runtime_bin}",
+    "test_engine": {
+      "test_runner": {
+          "bin": "${python_cmd}"
+      }
+    },
+    "target": {
+      "exclude": [
+        {
+          "target": "cli_test_driver",
+          "tests": [
+          ]
+        }
+      ]
     }
   }
 }

--- a/cmake/TestImpactFramework/LYTestImpactFramework.cmake
+++ b/cmake/TestImpactFramework/LYTestImpactFramework.cmake
@@ -10,13 +10,16 @@
 set(LY_TEST_IMPACT_INSTRUMENTATION_BIN "" CACHE PATH "Path to test impact framework instrumentation binary")
 
 # Name of test impact framework console static library target
-set(LY_TEST_IMPACT_CONSOLE_STATIC_TARGET "TestImpact.Frontend.Console.Native.Static")
+set(LY_TEST_IMPACT_CONSOLE_NATIVE_STATIC_TARGET "TestImpact.Frontend.Console.Native.Static")
 
 # Name of test impact framework python coverage gem target
 set(LY_TEST_IMPACT_PYTHON_COVERAGE_STATIC_TARGET "PythonCoverage.Editor.Static")
 
-# Name of test impact framework console target
-set(LY_TEST_IMPACT_CONSOLE_TARGET "TestImpact.Frontend.Console.Native")
+# Name of test impact framework native console target
+set(LY_TEST_IMPACT_NATIVE_CONSOLE_TARGET "TestImpact.Frontend.Console.Native")
+
+# Name of test impact framework native console target
+set(LY_TEST_IMPACT_PYTHON_CONSOLE_TARGET "TestImpact.Frontend.Console.Python")
 
 # Directory for test impact artifacts and data
 set(LY_TEST_IMPACT_WORKING_DIR "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/TestImpactFramework")
@@ -156,9 +159,11 @@ endfunction()
 #
 # \arg:COMPOSITE_TEST test in the form 'namespace::test'
 # \arg:COMPOSITE_SUITES composite list of suites for this target
+# \arg:TEST_NAMESPACE namespace of test
 # \arg:TEST_NAME name of test
 # \arg:TEST_SUITES extracted list of suites for this target in JSON format
-function(ly_test_impact_extract_google_test_params COMPOSITE_TEST COMPOSITE_SUITES TEST_NAME TEST_SUITES)
+function(ly_test_impact_extract_google_test_params COMPOSITE_TEST COMPOSITE_SUITES TEST_NAMESPACE TEST_NAME TEST_SUITES)
+
     # Namespace and test are mandatory
     string(REPLACE "::" ";" test_components ${COMPOSITE_TEST})
     list(LENGTH test_components num_test_components)
@@ -193,21 +198,28 @@ endfunction()
 #
 # \arg:COMPOSITE_TEST test in form 'namespace::test' or 'test'
 # \arg:COMPOSITE_SUITES composite list of suites for this target
+# \arg:TEST_NAMESPACE namespace of test
 # \arg:TEST_NAME name of test
 # \arg:TEST_SUITES extracted list of suites for this target in JSON format
-function(ly_test_impact_extract_python_test_params COMPOSITE_TEST COMPOSITE_SUITES TEST_NAME TEST_SUITES)
+function(ly_test_impact_extract_python_test_params COMPOSITE_TEST COMPOSITE_SUITES TEST_NAMESPACE TEST_NAME TEST_SUITES)
     get_property(script_path GLOBAL PROPERTY LY_ALL_TESTS_${COMPOSITE_TEST}_SCRIPT_PATH)
     get_property(test_command GLOBAL PROPERTY LY_ALL_TESTS_${COMPOSITE_TEST}_TEST_COMMAND)
+
+    # Strip the separating semicolons to yield the executable command string for this test
+    string(REPLACE ";" " " test_command "${test_command}")
     
     # namespace is optional, in which case this component will be simply the test name
     string(REPLACE "::" ";" test_components ${COMPOSITE_TEST})
     list(LENGTH test_components num_test_components)
     if(num_test_components GREATER 1)
+        list(GET test_components 0 test_namespace)
         list(GET test_components 1 test_name)
     else()
+        set(test_namespace "")
         set(test_name ${test_components})
     endif()
 
+    set(${TEST_NAMESPACE} ${test_namespace} PARENT_SCOPE)
     set(${TEST_NAME} ${test_name} PARENT_SCOPE)
     
     set(test_suites "")
@@ -227,7 +239,7 @@ function(ly_test_impact_extract_python_test_params COMPOSITE_TEST COMPOSITE_SUIT
             script_path
             "${LY_ROOT_FOLDER}"
         )
-        set(suite_params "{ \"suite\": \"${test_suite}\",  \"script\": \"${script_path}\", \"test_command\": \"${test_command}\", \"timeout\": ${test_timeout} }")
+        set(suite_params "{ \"suite\": \"${test_suite}\",  \"script\": \"${script_path}\", \"timeout\": ${test_timeout}, \"command\": \"${test_command}\" }")
         list(APPEND test_suites "${suite_params}")
     endforeach()
     string(REPLACE ";" ", " test_suites "${test_suites}")
@@ -253,25 +265,25 @@ function(ly_test_impact_write_test_enumeration_file TEST_ENUMERATION_TEMPLATE_FI
         get_property(test_type GLOBAL PROPERTY LY_ALL_TESTS_${test}_TEST_LIBRARY)
         if("${test_type}" STREQUAL "pytest")
             # Python tests
-            ly_test_impact_extract_python_test_params(${test} "${test_params}" test_name test_suites)
-            list(APPEND python_tests "        { \"name\": \"${test_name}\", \"suites\": [${test_suites}] }")
+            ly_test_impact_extract_python_test_params(${test} "${test_params}" test_namespace test_name test_suites)
+            list(APPEND python_tests "        { \"namespace\": \"${test_namespace}\", \"name\": \"${test_name}\", \"suites\": [${test_suites}] }")
         elseif("${test_type}" STREQUAL "pytest_editor")
             # Python editor tests            
-            ly_test_impact_extract_python_test_params(${test} "${test_params}" test_name test_suites)
-            list(APPEND python_editor_tests "        { \"name\": \"${test_name}\", \"suites\": [${test_suites}] }")
+            ly_test_impact_extract_python_test_params(${test} "${test_params}" test_namespace test_name test_suites)
+            list(APPEND python_editor_tests "        { \"namespace\": \"${test_namespace}\", \"name\": \"${test_name}\", \"suites\": [${test_suites}] }")
         elseif("${test_type}" STREQUAL "googletest")
             # Google tests
-            ly_test_impact_extract_google_test_params(${test} "${test_params}" test_name test_suites)
+            ly_test_impact_extract_google_test_params(${test} "${test_params}" test_namespace test_name test_suites)
             ly_test_impact_get_test_launch_method(${test} launch_method)
-            list(APPEND google_tests "        { \"name\": \"${test_name}\", \"launch_method\": \"${launch_method}\", \"suites\": [${test_suites}] }")
+            list(APPEND google_tests "        { \"namespace\": \"${test_namespace}\", \"name\": \"${test_name}\", \"launch_method\": \"${launch_method}\", \"suites\": [${test_suites}] }")
         elseif("${test_type}" STREQUAL "googlebenchmark")
             # Google benchmarks
-            ly_test_impact_extract_google_test_params(${test} "${test_params}" test_name test_suites)
-            list(APPEND google_benchmarks "        { \"name\": \"${test_name}\", \"launch_method\": \"${launch_method}\", \"suites\": [${test_suites}] }")
+            ly_test_impact_extract_google_test_params(${test} "${test_params}" test_namespace test_name test_suites)
+            list(APPEND google_benchmarks "        { \"namespace\": \"${test_namespace}\", \"name\": \"${test_name}\", \"launch_method\": \"${launch_method}\", \"suites\": [${test_suites}] }")
         else()
-            ly_test_impact_extract_python_test_params(${test} "${test_params}" test_name test_suites)
+            ly_test_impact_extract_python_test_params(${test} "${test_params}" test_namespace test_name test_suites)
             message("${test_name} is of unknown type (TEST_LIBRARY property is \"${test_type}\")")
-            list(APPEND unknown_tests "        { \"name\": \"${test}\", \"type\": \"${test_type}\" }")
+            list(APPEND unknown_tests "        { \"namespace\": \"${test_namespace}\", \"name\": \"${test}\", \"type\": \"${test_type}\" }")
         endif()
     endforeach()
 
@@ -312,6 +324,35 @@ function(ly_test_impact_write_gem_target_enumeration_file GEM_TARGET_TEMPLATE_FI
      configure_file(${GEM_TARGET_TEMPLATE_FILE} ${mapping_path})
 endfunction()
 
+#! ly_extract_target_dependencies: extracts the target dependencies for the specified target as a comma separated list.
+function(ly_extract_target_dependencies INPUT_DEPENDENCY_LIST OUTPUT_DEPENDENCY_LIST)
+    set(dependencies "")
+    # Walk the dependency list
+    foreach(target_name_components ${INPUT_DEPENDENCY_LIST})
+        # Extract just the target name, ignoring the namespace
+        string(REPLACE "::" ";" target_name_components ${target_name_components})
+        list(LENGTH target_name_components num_name_components)
+        if(num_name_components GREATER 1)
+            list(GET target_name_components 0 target_namespace)
+            list(GET target_name_components 1 target_name)
+            # Skipt third party dependencies
+            if(NOT target_namespace STREQUAL "3rdParty")
+                list(APPEND dependencies "\"${target_name}\"")
+            endif()
+        else()
+            set(target_name ${target_name_components})
+            list(APPEND dependencies "\"${target_name}\"")
+        endif()
+    endforeach()
+
+    # Remove the access modifiers and convert to a comma separated list
+    string (REPLACE "\"PUBLIC\";" "" dependencies "${dependencies}")
+    string (REPLACE "\"PRIVATE\";" "" dependencies "${dependencies}")
+    string (REPLACE "\"INTERFACE\";" "" dependencies "${dependencies}")
+    string (REPLACE ";" ",\n" dependencies "${dependencies}")
+    set(${OUTPUT_DEPENDENCY_LIST} ${dependencies} PARENT_SCOPE)
+endfunction()
+
 #! ly_test_impact_export_source_target_mappings: exports the static source to target mappings to file.
 #
 # \arg:MAPPING_TEMPLATE_FILE path to source to target template file
@@ -337,6 +378,12 @@ function(ly_test_impact_export_source_target_mappings MAPPING_TEMPLATE_FILE)
             # No custom output name was specified so use the target name
             set(target_output_name "${target}")
         endif()
+
+        # Dependencies
+        get_property(build_dependencies GLOBAL PROPERTY LY_ALL_TARGETS_${target}_BUILD_DEPENDENCIES)
+        get_property(runtime_dependencies GLOBAL PROPERTY LY_ALL_TARGETS_${target}_RUNTIME_DEPENDENCIES)
+        ly_extract_target_dependencies("${build_dependencies}" build_dependencies)
+        ly_extract_target_dependencies("${runtime_dependencies}" runtime_dependencies)
 
         # Autogen source file mappings
         get_target_property(autogen_input_files ${target} AUTOGEN_INPUT_FILES)
@@ -407,7 +454,10 @@ function(ly_test_impact_write_config_file CONFIG_TEMPLATE_FILE BIN_DIR)
     endif()
 
     # Testrunner binary
-    set(test_runner_bin $<TARGET_FILE:AzTestRunner>)
+    set(native_test_runner_bin $<TARGET_FILE:AzTestRunner>)
+
+    # Python command
+    set(python_cmd "${LY_ROOT_FOLDER}/python/python.cmd")
 
     # Repository root
     set(repo_dir ${LY_ROOT_FOLDER})
@@ -415,14 +465,23 @@ function(ly_test_impact_write_config_file CONFIG_TEMPLATE_FILE BIN_DIR)
     # Test impact framework output binary dir
     set(bin_dir ${BIN_DIR})
     
-    # Temp dir
-    set(temp_dir "${LY_TEST_IMPACT_RUNTIME_TEMP_DIR}")
+    # Native temp dir
+    set(native_temp_dir "${LY_TEST_IMPACT_RUNTIME_TEMP_DIR}/Native")
 
-    # Active persistent data dir
-    set(active_dir "${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR}/active")
+    # Native active persistent data dir
+    set(native_active_dir "${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR}/Native/active")
 
-    # Historic persistent data dir
-    set(historic_dir "${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR}/historic")
+    # Native historic persistent data dir
+    set(native_historic_dir "${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR}/Native/historic")
+
+    # Python temp dir
+    set(python_temp_dir "${LY_TEST_IMPACT_RUNTIME_TEMP_DIR}/Python")
+
+    # Python active persistent data dir
+    set(python_active_dir "${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR}/Python/active")
+
+    # Python historic persistent data dir
+    set(python_historic_dir "${LY_TEST_IMPACT_RUNTIME_PERSISTENT_DIR}/Python/historic")
 
     # Source to target mappings dir
     set(source_target_mapping_dir "${LY_TEST_IMPACT_SOURCE_TARGET_MAPPING_DIR}")
@@ -436,8 +495,11 @@ function(ly_test_impact_write_config_file CONFIG_TEMPLATE_FILE BIN_DIR)
     # Build dependency artifact dir
     set(target_dependency_dir "${LY_TEST_IMPACT_TARGET_DEPENDENCY_DIR}")
 
-    # Test impact analysis framework binary
-    set(tiaf_bin "$<TARGET_FILE:${LY_TEST_IMPACT_CONSOLE_TARGET}>")
+    # Test impact analysis framework native runtime binary
+    set(native_runtime_bin "$<TARGET_FILE:${LY_TEST_IMPACT_NATIVE_CONSOLE_TARGET}>")
+
+    # Test impact analysis framework python runtime binary
+    set(python_runtime_bin "$<TARGET_FILE:${LY_TEST_IMPACT_PYTHON_CONSOLE_TARGET}>")
     
     # Substitute config file template with above vars
     ly_file_read("${CONFIG_TEMPLATE_FILE}" config_file)

--- a/cmake/TestImpactFramework/SourceToTargetMapping.in
+++ b/cmake/TestImpactFramework/SourceToTargetMapping.in
@@ -13,6 +13,14 @@ ${static_sources}
     "target": {
         "name": "${target_name}",
         "output_name": "${target_output_name}",
-        "path": "${target_path}"
+        "path": "${target_path}",
+        "dependencies": {
+            "build": [
+                ${build_dependencies}
+            ],
+            "runtime": [
+                ${runtime_dependencies}
+            ]
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR contains the CMake and Console source changes for implementing Python TIAF seeding.

This PR adds the necessary infrastructure for the Python runtime to complete a seeded test run, producing the necessary run and coverage artifacts so that they can be consumed and transformed into the client test reports and TIAF coverage data.

As of this PR, the Python test runner is using the null test runner, a special variant of the standard Python test runner that consumes existing run and coverage artifacts produced by anther test runner processes (e.g. CTest). This allows it to run in AR in order to produce ongoing data about the efficiency of test selection as the TIAF team work to refine it.

A followup PR will connect the Python Jenkins job to the AR pipeline whereupon the Python TIAF runtime will perform test selection that will be transmitted to MARS for further analysis.