### PR TITLE
TIAF Python Test Seeding: Native Runtime Changes.

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
@@ -8,18 +8,9 @@
 
 #pragma once
 
+#include <TestImpactFramework/TestImpactRuntime.h>
 #include <TestImpactFramework/Native/TestImpactNativeConfiguration.h>
-#include <TestImpactFramework/TestImpactChangeList.h>
-#include <TestImpactFramework/TestImpactClientTestSelection.h>
-#include <TestImpactFramework/TestImpactClientTestRun.h>
-#include <TestImpactFramework/TestImpactClientSequenceReport.h>
-#include <TestImpactFramework/TestImpactTestSequence.h>
 
-#include <AzCore/std/string/string.h>
-#include <AzCore/std/chrono/chrono.h>
-#include <AzCore/std/optional.h>
-#include <AzCore/std/functional.h>
-#include <AzCore/std/containers/vector.h>
 #include <AzCore/std/containers/unordered_set.h>
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
@@ -29,68 +20,6 @@ namespace TestImpact
     class NativeTestTarget;
     class NativeProductionTarget;
     class SourceCoveringTestsList;
-
-    template<typename TestTarget, typename ProdutionTarget>
-    class ChangeDependencyList;
-
-    template<typename TestTarget, typename ProdutionTarget>
-    class BuildTargetList;
-
-    template<typename TestTarget, typename ProdutionTarget>
-    class DynamicDependencyMap;
-
-    template<typename TestTarget, typename ProdutionTarget>
-    class TestSelectorAndPrioritizer;
-
-    template<typename TestTarget>
-    class TestTargetExclusionList;
-
-    //! Callback for a test sequence that isn't using test impact analysis to determine selected tests.
-    //! @parm suiteType The test suite to select tests from.
-    //! @param tests The tests that will be run for this sequence.
-    using TestSequenceStartCallback = AZStd::function<void(SuiteType suiteType, const Client::TestRunSelection& tests)>;
-
-    //! Callback for a test sequence using test impact analysis.
-    //! @parm suiteType The test suite to select tests from.
-    //! @param selectedTests The tests that have been selected for this run by test impact analysis.
-    //! @param discardedTests The tests that have been rejected for this run by test impact analysis. 
-    //! @param draftedTests The tests that have been drafted in for this run due to requirements outside of test impact analysis
-    //! (e.g. test targets that have been added to the repository since the last test impact analysis sequence or test that failed
-    //! to execute previously).
-    //! These tests will be run with coverage instrumentation.
-    //! @note discardedTests and draftedTests may contain overlapping tests.
-    using ImpactAnalysisTestSequenceStartCallback = AZStd::function<void(
-        SuiteType suiteType,
-        const Client::TestRunSelection& selectedTests,
-        const AZStd::vector<AZStd::string>& discardedTests,
-        const AZStd::vector<AZStd::string>& draftedTests)>;
-
-    //! Callback for a test sequence using test impact analysis.
-    //! @parm suiteType The test suite to select tests from.
-    //! @param selectedTests The tests that have been selected for this run by test impact analysis.
-    //! @param discardedTests The tests that have been rejected for this run by test impact analysis.
-    //! These tests will not be run without coverage instrumentation unless there is an entry in the draftedTests list.
-    //! @param draftedTests The tests that have been drafted in for this run due to requirements outside of test impact analysis
-    //! (e.g. test targets that have been added to the repository since the last test impact analysis sequence or test that failed
-    //! to execute previously).
-    //! @note discardedTests and draftedTests may contain overlapping tests.
-    using SafeImpactAnalysisTestSequenceStartCallback = AZStd::function<void(
-        SuiteType suiteType,
-        const Client::TestRunSelection& selectedTests,
-        const Client::TestRunSelection& discardedTests,
-        const AZStd::vector<AZStd::string>& draftedTests)>;
-
-    //! Callback for end of a test sequence.
-    //! @tparam SequenceReportType The report type to be used for the sequence.
-    //! @param sequenceReport The completed sequence report.
-    template<typename SequenceReportType>
-    using TestSequenceCompleteCallback = AZStd::function<void(const SequenceReportType& sequenceReport)>;
-
-    //! Callback for test runs that have completed for any reason.
-    //! @param testRunMeta The test that has completed.
-    //! @param numTestRunsCompleted The number of test runs that have completed.
-    //! @param totalNumTestRuns The total number of test runs in the sequence.
-    using TestRunCompleteCallback = AZStd::function<void(Client::TestRunBase& testRun, size_t numTestRunsCompleted, size_t totalNumTestRuns)>;
 
     //! The native API exposed to the client responsible for all test runs and persistent data management.
     class NativeRuntime
@@ -193,6 +122,11 @@ namespace TestImpact
         bool HasImpactAnalysisData() const;
 
     private:
+        using RuntimeConfig = NativeRuntimeConfig;
+        using TestEngine = NativeTestEngine;
+        using ProductionTarget = NativeProductionTarget;
+        using TestTarget = NativeTestTarget;
+
         //! Updates the test enumeration cache for test targets that had sources modified by a given change list.
         //! @param changeDependencyList The resolved change dependency list generated for the change list.
         //void EnumerateMutatedTestTargets(const ChangeDependencyList& changeDependencyList);
@@ -202,7 +136,7 @@ namespace TestImpact
         //! @param changeList The change list for which the covering tests and enumeration cache updates will be generated for.
         //! @param testPrioritizationPolicy The test prioritization strategy to use for the selected test targets.
         //! @returns The pair of selected test targets and discarded test targets.
-        AZStd::pair<AZStd::vector<const NativeTestTarget*>, AZStd::vector<const NativeTestTarget*>> SelectCoveringTestTargets(
+        AZStd::pair<AZStd::vector<const TestTarget*>, AZStd::vector<const TestTarget*>> SelectCoveringTestTargets(
             const ChangeList& changeList,
             Policy::TestPrioritization testPrioritizationPolicy);
 
@@ -223,7 +157,7 @@ namespace TestImpact
         ImpactAnalysisSequencePolicyState GenerateImpactAnalysisSequencePolicyState(
             Policy::TestPrioritization testPrioritizationPolicy, Policy::DynamicDependencyMap dynamicDependencyMapPolicy) const;
 
-        NativeRuntimeConfig m_config;
+        RuntimeConfig m_config;
         RepoPath m_sparTiaFile;
         SuiteType m_suiteFilter;
         Policy::ExecutionFailure m_executionFailurePolicy;
@@ -233,14 +167,14 @@ namespace TestImpact
         Policy::TestSharding m_testShardingPolicy;
         Policy::TargetOutputCapture m_targetOutputCapture;
         size_t m_maxConcurrency = 0;
-        AZStd::unique_ptr<BuildTargetList<NativeTestTarget, NativeProductionTarget>> m_buildTargets;
-        AZStd::unique_ptr<DynamicDependencyMap<NativeTestTarget, NativeProductionTarget>> m_dynamicDependencyMap;
-        AZStd::unique_ptr<TestSelectorAndPrioritizer<NativeTestTarget, NativeProductionTarget>> m_testSelectorAndPrioritizer;
-        AZStd::unique_ptr<NativeTestEngine> m_testEngine;
-        AZStd::unique_ptr<TestTargetExclusionList<NativeTestTarget>> m_regularTestTargetExcludeList;
-        AZStd::unique_ptr<TestTargetExclusionList<NativeTestTarget>> m_instrumentedTestTargetExcludeList;
-        AZStd::unordered_set<const NativeTestTarget*> m_testTargetShardList;
-        AZStd::unordered_set<const NativeTestTarget*> m_previouslyFailingTestTargets;
+        AZStd::unique_ptr<BuildTargetList<ProductionTarget, TestTarget>> m_buildTargets;
+        AZStd::unique_ptr<DynamicDependencyMap<ProductionTarget, TestTarget>> m_dynamicDependencyMap;
+        AZStd::unique_ptr<TestSelectorAndPrioritizer<ProductionTarget, TestTarget>> m_testSelectorAndPrioritizer;
+        AZStd::unique_ptr<TestEngine> m_testEngine;
+        AZStd::unique_ptr<TestTargetExclusionList<TestTarget>> m_regularTestTargetExcludeList;
+        AZStd::unique_ptr<TestTargetExclusionList<TestTarget>> m_instrumentedTestTargetExcludeList;
+        AZStd::unordered_set<const TestTarget*> m_testTargetShardList;
+        AZStd::unordered_set<const TestTarget*> m_previouslyFailingTestTargets;
         bool m_hasImpactAnalysisData = false;
     };
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Static/TestImpactNativeTestTargetMeta.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Static/TestImpactNativeTestTargetMeta.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
-#include <Artifact/Static/TestImpactTestSuiteMeta.h>
+#include <TestImpactFramework/TestImpactRepoPath.h>
+
+#include <Artifact/Static/TestImpactTestTargetMeta.h>
 
 #include <AzCore/std/containers/unordered_map.h>
 
@@ -21,12 +23,17 @@ namespace TestImpact
         StandAlone //!< Target is launched directly by itself.
     };
 
+    struct NativeTargetLaunchMeta
+    {
+        AZStd::string m_customArgs;
+        LaunchMethod m_launchMethod = LaunchMethod::TestRunner;
+    };
+
     //! Artifact produced by the build system for each test target containing the additional meta-data about the test.
     struct NativeTestTargetMeta
     {
-        TestSuiteMeta m_suiteMeta;
-        AZStd::string m_customArgs;
-        LaunchMethod m_launchMethod = LaunchMethod::TestRunner;
+        TestTargetMeta m_testTargetMeta;
+        NativeTargetLaunchMeta m_launchMeta;
     };
 
     //! Map between test target name and test target meta-data.

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.cpp
@@ -10,29 +10,20 @@
 
 namespace TestImpact
 {
-    NativeTestTarget::NativeTestTarget(AZStd::unique_ptr<Descriptor> descriptor)
-        : NativeTarget(descriptor.get())
-        , m_descriptor(AZStd::move(descriptor))
+    NativeTestTarget::NativeTestTarget(
+        TargetDescriptor&& descriptor, NativeTestTargetMeta&& testMetaData)
+        : TestTarget(AZStd::move(descriptor), AZStd::move(testMetaData.m_testTargetMeta))
+        , m_launchMeta(AZStd::move(testMetaData.m_launchMeta))
     {
-    }
-
-    const AZStd::string& NativeTestTarget::GetSuite() const
-    {
-        return m_descriptor->m_testMetaData.m_suiteMeta.m_name;
     }
 
     const AZStd::string& NativeTestTarget::GetCustomArgs() const
     {
-        return m_descriptor->m_testMetaData.m_customArgs;
-    }
-
-    AZStd::chrono::milliseconds NativeTestTarget::GetTimeout() const
-    {
-        return m_descriptor->m_testMetaData.m_suiteMeta.m_timeout;
+        return m_launchMeta.m_customArgs;
     }
 
     LaunchMethod NativeTestTarget::GetLaunchMethod() const
     {
-        return m_descriptor->m_testMetaData.m_launchMethod;
+        return m_launchMeta.m_launchMethod;
     }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.h
@@ -8,35 +8,27 @@
 
 #pragma once
 
-#include <Artifact/Static/TestImpactNativeTestTargetDescriptor.h>
-#include <Target/Native/TestImpactNativeTarget.h>
+#include <Artifact/Static/TestImpactNativeTestTargetMeta.h>
+#include <Target/Common/TestImpactTestTarget.h>
 
 #include <AzCore/std/smart_ptr/unique_ptr.h>
 
 namespace TestImpact
 {
     //! Build target specialization for native test targets (build targets containing test code and no production code).
-    class NativeTestTarget
-        : public NativeTarget
+    class NativeTestTarget 
+    : public TestTarget
     {
     public:
-        using Descriptor = NativeTestTargetDescriptor;
-
-        NativeTestTarget(AZStd::unique_ptr<Descriptor> descriptor);
-
-        //! Returns the test target suite.
-        const AZStd::string& GetSuite() const;
+        NativeTestTarget(TargetDescriptor&& descriptor, NativeTestTargetMeta&& testMetaData);
 
         //! Returns the launcher custom arguments.
         const AZStd::string& GetCustomArgs() const;
-
-        //! Returns the test run timeout.
-        AZStd::chrono::milliseconds GetTimeout() const;
-
+        
         //! Returns the test target launch method.
         LaunchMethod GetLaunchMethod() const;
 
     private:
-        AZStd::unique_ptr<Descriptor> m_descriptor;
+        NativeTargetLaunchMeta m_launchMeta;
     };
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <TestImpactFramework/TestImpactConfiguration.h>
 #include <TestImpactFramework/TestImpactTestSequence.h>
 #include <TestImpactFramework/TestImpactClientTestRun.h>
 
@@ -44,7 +45,7 @@ namespace TestImpact
             const RepoPath& sourceDir,
             const RepoPath& targetBinaryDir,
             const RepoPath& cacheDir,
-            const RepoPath& artifactDir,
+            const ArtifactDir& artifactDir,
             const RepoPath& testRunnerBinary,
             const RepoPath& instrumentBinary,
             size_t maxConcurrentRuns);
@@ -79,7 +80,7 @@ namespace TestImpact
         //! @param globalTimeout The maximum duration the enumeration sequence may run before being forcefully terminated (infinite if empty). 
         //! @param callback The client callback function to handle completed test target runs.
         //! @ returns The sequence result and the test run results for the test targets that were run.
-        [[nodiscard]] AZStd::pair<TestSequenceResult, AZStd::vector<TestEngineRegularRun<NativeTestTarget>>>
+        [[nodiscard]] TestEngineRegularRunResult<NativeTestTarget>
         RegularRun(
             const AZStd::vector<const NativeTestTarget*>& testTargets,
             Policy::ExecutionFailure executionFailurePolicy,
@@ -99,7 +100,7 @@ namespace TestImpact
         //! @param globalTimeout The maximum duration the enumeration sequence may run before being forcefully terminated (infinite if empty). 
         //! @param callback The client callback function to handle completed test target runs.
         //! @ returns The sequence result and the test run results and test coverages for the test targets that were run.
-        [[nodiscard]] AZStd::pair<TestSequenceResult, AZStd::vector<TestEngineInstrumentedRun<NativeTestTarget, TestCoverage>>>
+        [[nodiscard]] TestEngineInstrumentedRunResult<NativeTestTarget, TestCoverage>
         InstrumentedRun(
             const AZStd::vector<const NativeTestTarget*>& testTargets,
             Policy::ExecutionFailure executionFailurePolicy,
@@ -120,6 +121,6 @@ namespace TestImpact
         AZStd::unique_ptr<NativeTestEnumerator> m_testEnumerator;
         AZStd::unique_ptr<NativeInstrumentedTestRunner> m_instrumentedTestRunner;
         AZStd::unique_ptr<NativeRegularTestRunner> m_testRunner;
-        RepoPath m_artifactDir;
+        ArtifactDir m_artifactDir;
     };
 } // namespace TestImpact


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR contains the native runtime source changes for implementing Python TIAF seeding.

This PR adds the necessary infrastructure for the Python runtime to complete a seeded test run, producing the necessary run and coverage artifacts so that they can be consumed and transformed into the client test reports and TIAF coverage data.

As of this PR, the Python test runner is using the null test runner, a special variant of the standard Python test runner that consumes existing run and coverage artifacts produced by anther test runner processes (e.g. CTest). This allows it to run in AR in order to produce ongoing data about the efficiency of test selection as the TIAF team work to refine it.

A followup PR will connect the Python Jenkins job to the AR pipeline whereupon the Python TIAF runtime will perform test selection that will be transmitted to MARS for further analysis.