### PR TITLE
Turn on EMVF by default.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Application/Application.cpp
@@ -749,7 +749,7 @@ namespace AzFramework
 
     bool Application::IsEditorModeFeedbackEnabled() const
     {
-        bool value = false;
+        bool value = true;
         if (auto* registry = AZ::SettingsRegistry::Get())
         {
             registry->Get(value, ApplicationInternal::s_editorModeFeedbackKey);


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR turns on the Editor Mode Feedback System by default. Previously, it was turned off by default unless explicitly turned on by the customer.