### PR TITLE
Add prefab override handler to display edit-entity override outliner visualization

### DIFF
--- a/Code/Framework/AzQtComponents/AzQtComponents/Images/Entity/entity_overridden.svg
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Images/Entity/entity_overridden.svg
@@ -1,0 +1,3 @@
+<svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="4.41956" cy="4.45947" r="3.5" fill="#FF8F00" stroke="#1E252F"/>
+</svg>

--- a/Code/Framework/AzQtComponents/AzQtComponents/Images/resources.qrc
+++ b/Code/Framework/AzQtComponents/AzQtComponents/Images/resources.qrc
@@ -15,6 +15,7 @@
         <file alias="entity.svg">Entity/entity.svg</file>
         <file alias="entity_editoronly.svg">Entity/entity_editoronly.svg</file>
         <file alias="entity_notactive.svg">Entity/entity_notactive.svg</file>
+        <file alias="entity_overridden.svg">Entity/entity_overridden.svg</file>
         <file alias="layer.svg">Entity/layer.svg</file>
         <file alias="prefab.svg">Entity/prefab.svg</file>
         <file alias="prefab_edit.svg">Entity/prefab_edit.svg</file>

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Entity/PrefabEditorEntityOwnershipService.h
@@ -15,6 +15,7 @@
 #include <AzToolsFramework/Entity/EntityTypes.h>
 #include <AzToolsFramework/Entity/PrefabEditorEntityOwnershipInterface.h>
 #include <AzToolsFramework/Entity/SliceEditorEntityOwnershipServiceBus.h>
+#include <AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.h>
 #include <AzToolsFramework/Prefab/Spawnable/PrefabInMemorySpawnableConverter.h>
 
 namespace AzToolsFramework
@@ -219,6 +220,7 @@ namespace AzToolsFramework
 
         AZStd::string m_rootPath;
         AZStd::unique_ptr<Prefab::Instance> m_rootInstance;
+        Prefab::PrefabOverridePublicHandler m_prefabOverridePublicHandler;
 
         Prefab::PrefabFocusInterface* m_prefabFocusInterface = nullptr;
         Prefab::PrefabSystemComponentInterface* m_prefabSystemComponent = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h
@@ -46,6 +46,11 @@ namespace AzToolsFramework
             //! @return The string matching the path to the entity alias
             virtual AZStd::string GenerateEntityAliasPath(AZ::EntityId entityId) = 0;
 
+            //! Generates a path to the entity matching the id from the focused prefab.
+            //! @param entityId The entity id to fetch the path for.
+            //! @return The path to the entity with the given id.
+            virtual AZ::Dom::Path GenerateEntityPathFromFocusedPrefab(AZ::EntityId entityId) = 0;
+
             virtual void AppendEntityAliasToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId, AZStd::string prefix = "") = 0;
 
             //! Updates the template links (updating instances) for the given template and triggers propagation on its instances.

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Instance/InstanceToTemplatePropagator.h
@@ -37,6 +37,8 @@ namespace AzToolsFramework
 
             AZStd::string GenerateEntityAliasPath(AZ::EntityId entityId) override;
 
+            AZ::Dom::Path GenerateEntityPathFromFocusedPrefab(AZ::EntityId entityId) override;
+
             void AppendEntityAliasToPatchPaths(PrefabDom& providedPatch, AZ::EntityId entityId, AZStd::string prefix = "") override;
 
             InstanceOptionalReference GetTopMostInstanceInHierarchy(AZ::EntityId entityId) override;
@@ -49,6 +51,7 @@ namespace AzToolsFramework
             InstanceEntityMapperInterface* m_instanceEntityMapperInterface = nullptr;
             PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
             InstanceDomGenerator m_instanceDomGenerator;
+            static AzFramework::EntityContextId s_editorEntityContextId;
         };
     }
 }

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
@@ -120,6 +120,19 @@ namespace AzToolsFramework
             return ConstructLinkDomFromPatches(linkDom, allocator);
         }
 
+        bool Link::IsOverridePresent(AZ::Dom::Path path, AZ::Dom::PrefixTreeTraversalFlags prefixTreeTraversalFlags)
+        {
+            AZStd::vector<AZStd::pair<const AZ::Dom::Path&, const PrefabOverrideMetadata&>> results;
+            auto visitorFn = [&results](const AZ::Dom::Path& path, const PrefabOverrideMetadata& patch)
+            {
+                results.emplace_back(path, patch);
+                return true;
+            };
+
+            m_linkPatchesTree.VisitPath(path, visitorFn, prefixTreeTraversalFlags);
+            return (results.size() > 0);
+        }
+
         PrefabDomPath Link::GetInstancePath() const
         {
             return PrefabDomUtils::GetPrefabDomInstancePath(m_instanceName.c_str());

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.cpp
@@ -120,17 +120,19 @@ namespace AzToolsFramework
             return ConstructLinkDomFromPatches(linkDom, allocator);
         }
 
-        bool Link::IsOverridePresent(AZ::Dom::Path path, AZ::Dom::PrefixTreeTraversalFlags prefixTreeTraversalFlags)
+        bool Link::AreOverridesPresent(AZ::Dom::Path path, AZ::Dom::PrefixTreeTraversalFlags prefixTreeTraversalFlags)
         {
-            AZStd::vector<AZStd::pair<const AZ::Dom::Path&, const PrefabOverrideMetadata&>> results;
-            auto visitorFn = [&results](const AZ::Dom::Path& path, const PrefabOverrideMetadata& patch)
+            bool areOverridesPresent = false;
+            auto visitorFn = [&areOverridesPresent](AZ::Dom::Path, const PrefabOverrideMetadata&)
             {
-                results.emplace_back(path, patch);
-                return true;
+                areOverridesPresent = true;
+                // We just need to check if at least one override is present at the path.
+                // Return false here so that we don't keep looking for all patches at the path.
+                return false;
             };
 
             m_linkPatchesTree.VisitPath(path, visitorFn, prefixTreeTraversalFlags);
-            return (results.size() > 0);
+            return areOverridesPresent;
         }
 
         PrefabDomPath Link::GetInstancePath() const

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.h
@@ -106,12 +106,12 @@ namespace AzToolsFramework
             //! @param allocator The allocator to use for memory allocations of patches.
             void GetLinkDom(PrefabDomValue& linkDom, PrefabDomAllocator& allocator) const;
 
-            //! Checks whether an override is present by querying the patches tree with the provided path
-            //! @param path The path to query the patches tree with.
+            //! Checks whether overrides are present by querying the patches tree with the provided path
+            //! @param path The path to query the overrides tree with.
             //! @param prefixTreeTraversalFlags The traversal flags for the prefix tree. The default is to exclude parent paths because
             //!                                 we usually check for overrides on one or more components/properties within an entity.
-            //! @return true if patches are present at the provided path.
-            bool IsOverridePresent(
+            //! @return true if overrides are present at the provided path.
+            bool AreOverridesPresent(
                 AZ::Dom::Path path,
                 AZ::Dom::PrefixTreeTraversalFlags prefixTreeTraversalFlags = AZ::Dom::PrefixTreeTraversalFlags::ExcludeParentPaths);
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Link/Link.h
@@ -106,6 +106,15 @@ namespace AzToolsFramework
             //! @param allocator The allocator to use for memory allocations of patches.
             void GetLinkDom(PrefabDomValue& linkDom, PrefabDomAllocator& allocator) const;
 
+            //! Checks whether an override is present by querying the patches tree with the provided path
+            //! @param path The path to query the patches tree with.
+            //! @param prefixTreeTraversalFlags The traversal flags for the prefix tree. The default is to exclude parent paths because
+            //!                                 we usually check for overrides on one or more components/properties within an entity.
+            //! @return true if patches are present at the provided path.
+            bool IsOverridePresent(
+                AZ::Dom::Path path,
+                AZ::Dom::PrefixTreeTraversalFlags prefixTreeTraversalFlags = AZ::Dom::PrefixTreeTraversalFlags::ExcludeParentPaths);
+
             PrefabDomPath GetInstancePath() const;
             const AZStd::string& GetInstanceName() const;
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.h>
+#include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
+
+ namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        bool PrefabOverrideHandler::IsOverridePresent(AZ::Dom::Path path, LinkId linkId)
+        {
+            PrefabSystemComponentInterface* prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
+            if (prefabSystemComponentInterface != nullptr)
+            {
+                LinkReference link = prefabSystemComponentInterface->FindLink(linkId);
+                if (link.has_value())
+                {
+                    return link->get().IsOverridePresent(path);
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.cpp
@@ -13,7 +13,7 @@
 {
     namespace Prefab
     {
-        bool PrefabOverrideHandler::IsOverridePresent(AZ::Dom::Path path, LinkId linkId)
+        bool PrefabOverrideHandler::AreOverridesPresent(AZ::Dom::Path path, LinkId linkId)
         {
             PrefabSystemComponentInterface* prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
             if (prefabSystemComponentInterface != nullptr)
@@ -21,7 +21,7 @@
                 LinkReference link = prefabSystemComponentInterface->FindLink(linkId);
                 if (link.has_value())
                 {
-                    return link->get().IsOverridePresent(path);
+                    return link->get().AreOverridesPresent(path);
                 }
             }
             return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        class PrefabOverrideHandler
+        {
+        public:
+            //! Checks whether overrides are present on the link object matching the linkId at the provided path.
+            //! @param path The path to check for overrides on the link object.
+            //! @param linkId The id of the link object to check for overrides
+            //! @return true if overrides are present at the given path on the link object matching the link id.
+            bool IsOverridePresent(AZ::Dom::Path path, LinkId linkId);
+        };
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.h
@@ -8,6 +8,9 @@
 
 #pragma once
 
+#include <AzCore/DOM/DomPath.h>
+#include <AzToolsFramework/Prefab/PrefabIdTypes.h>
+
 namespace AzToolsFramework
 {
     namespace Prefab
@@ -19,7 +22,7 @@ namespace AzToolsFramework
             //! @param path The path to check for overrides on the link object.
             //! @param linkId The id of the link object to check for overrides
             //! @return true if overrides are present at the given path on the link object matching the link id.
-            bool IsOverridePresent(AZ::Dom::Path path, LinkId linkId);
+            bool AreOverridesPresent(AZ::Dom::Path path, LinkId linkId);
         };
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <AzToolsFramework/Entity/EditorEntityContextBus.h>
+#include <AzToolsFramework/Prefab/Instance/InstanceToTemplateInterface.h>
+#include <AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.h>
+#include <AzToolsFramework/Prefab/PrefabFocusInterface.h>
+#include <AzToolsFramework/Prefab/PrefabPublicInterface.h>
+#include <AzToolsFramework/Prefab/PrefabSystemComponentInterface.h>
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        PrefabOverridePublicHandler::PrefabOverridePublicHandler()
+        {
+            AZ::Interface<PrefabOverridePublicInterface>::Register(this);
+
+            m_instanceToTemplateInterface = AZ::Interface<InstanceToTemplateInterface>::Get();
+            AZ_Assert(m_instanceToTemplateInterface, "PrefabOverridePublicHandler - InstanceToTemplateInterface could not be found.");
+
+            m_prefabFocusInterface = AZ::Interface<PrefabFocusInterface>::Get();
+            AZ_Assert(m_prefabFocusInterface, "PrefabOverridePublicHandler - PrefabFocusInterface could not be found.");
+
+            m_prefabSystemComponentInterface = AZ::Interface<PrefabSystemComponentInterface>::Get();
+            AZ_Assert(m_prefabSystemComponentInterface, "PrefabOverridePublicHandler - PrefabSystemComponentInterface could not be found.");
+        }
+
+        PrefabOverridePublicHandler::~PrefabOverridePublicHandler()
+        {
+            AZ::Interface<PrefabOverridePublicInterface>::Unregister(this);
+        }
+
+        bool PrefabOverridePublicHandler::IsOverridePresent(AZ::EntityId entityId)
+        {
+            AzFramework::EntityContextId editorEntityContextId;
+            AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
+                editorEntityContextId, &AzToolsFramework::EditorEntityContextRequests::GetEditorEntityContextId);
+            Prefab::InstanceOptionalReference focusedInstance = m_prefabFocusInterface->GetFocusedPrefabInstance(editorEntityContextId);
+
+            AZ::Dom::Path absoluteEntityAliasPath = m_instanceToTemplateInterface->GenerateEntityPathFromFocusedPrefab(entityId);
+
+            // The first 2 tokens of the path will represent the path of the instance below the focused prefab.
+            // Eg: "Instances/InstanceA/Instances/InstanceB/....'. The override tree doesn't store the topmost instance to avoid
+            // redundant checks Eg: "Instances/InstanceB/....' . So we skip the first 2 tokens here.
+            if (focusedInstance.has_value() && absoluteEntityAliasPath.size() > 2)
+            {
+                AZStd::string_view overriddenInstanceKey = absoluteEntityAliasPath[1].GetKey().GetStringView();
+                Prefab::InstanceOptionalReference overriddenInstance = focusedInstance->get().FindNestedInstance(overriddenInstanceKey);
+                if (overriddenInstance.has_value())
+                {
+                    auto pathIterator = absoluteEntityAliasPath.begin() + 2;
+                    AZ::Dom::Path modifiedPath(pathIterator, absoluteEntityAliasPath.end());
+                    return m_prefabOverrideHandler.IsOverridePresent(modifiedPath, overriddenInstance->get().GetLinkId());
+                }
+            }
+            return false;
+        }
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.cpp
@@ -36,12 +36,12 @@ namespace AzToolsFramework
             AZ::Interface<PrefabOverridePublicInterface>::Unregister(this);
         }
 
-        bool PrefabOverridePublicHandler::IsOverridePresent(AZ::EntityId entityId)
+        bool PrefabOverridePublicHandler::AreOverridesPresent(AZ::EntityId entityId)
         {
             AzFramework::EntityContextId editorEntityContextId;
             AzToolsFramework::EditorEntityContextRequestBus::BroadcastResult(
                 editorEntityContextId, &AzToolsFramework::EditorEntityContextRequests::GetEditorEntityContextId);
-            Prefab::InstanceOptionalReference focusedInstance = m_prefabFocusInterface->GetFocusedPrefabInstance(editorEntityContextId);
+            InstanceOptionalReference focusedInstance = m_prefabFocusInterface->GetFocusedPrefabInstance(editorEntityContextId);
 
             AZ::Dom::Path absoluteEntityAliasPath = m_instanceToTemplateInterface->GenerateEntityPathFromFocusedPrefab(entityId);
 
@@ -51,12 +51,12 @@ namespace AzToolsFramework
             if (focusedInstance.has_value() && absoluteEntityAliasPath.size() > 2)
             {
                 AZStd::string_view overriddenInstanceKey = absoluteEntityAliasPath[1].GetKey().GetStringView();
-                Prefab::InstanceOptionalReference overriddenInstance = focusedInstance->get().FindNestedInstance(overriddenInstanceKey);
+                InstanceOptionalReference overriddenInstance = focusedInstance->get().FindNestedInstance(overriddenInstanceKey);
                 if (overriddenInstance.has_value())
                 {
                     auto pathIterator = absoluteEntityAliasPath.begin() + 2;
                     AZ::Dom::Path modifiedPath(pathIterator, absoluteEntityAliasPath.end());
-                    return m_prefabOverrideHandler.IsOverridePresent(modifiedPath, overriddenInstance->get().GetLinkId());
+                    return m_prefabOverrideHandler.AreOverridesPresent(modifiedPath, overriddenInstance->get().GetLinkId());
                 }
             }
             return false;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzToolsFramework/Prefab/Overrides/PrefabOverrideHandler.h>
+#include <AzToolsFramework/Prefab/Overrides/PrefabOverridePublicInterface.h>
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        class InstanceToTemplateInterface;
+        class PrefabFocusInterface;
+        class PrefabSystemComponentInterface;
+
+        class PrefabOverridePublicHandler : private PrefabOverridePublicInterface
+        {
+        public:
+            PrefabOverridePublicHandler();
+            virtual ~PrefabOverridePublicHandler();
+
+            //! Checks whether overrides are present on the given entity id. Overrides can come from any ancestor prefab but
+            //! this function specifically checks for overrides from the focused prefab.
+            //! @param entityId The id of the entity to check for overrides.
+            //! @return true if overrides are present on the given entity id from the focused prefab.
+            bool IsOverridePresent(AZ::EntityId entityId) override;
+        private:
+            PrefabOverrideHandler m_prefabOverrideHandler;
+
+            InstanceToTemplateInterface* m_instanceToTemplateInterface = nullptr;
+            PrefabFocusInterface* m_prefabFocusInterface = nullptr;
+            PrefabSystemComponentInterface* m_prefabSystemComponentInterface = nullptr;
+        };
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicHandler.h
@@ -25,12 +25,13 @@ namespace AzToolsFramework
             PrefabOverridePublicHandler();
             virtual ~PrefabOverridePublicHandler();
 
+        private:
             //! Checks whether overrides are present on the given entity id. Overrides can come from any ancestor prefab but
             //! this function specifically checks for overrides from the focused prefab.
             //! @param entityId The id of the entity to check for overrides.
             //! @return true if overrides are present on the given entity id from the focused prefab.
-            bool IsOverridePresent(AZ::EntityId entityId) override;
-        private:
+            bool AreOverridesPresent(AZ::EntityId entityId) override;
+
             PrefabOverrideHandler m_prefabOverrideHandler;
 
             InstanceToTemplateInterface* m_instanceToTemplateInterface = nullptr;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicInterface.h
@@ -24,7 +24,7 @@ namespace AzToolsFramework
             //! by the class implmenting this interface based on certain selections in the editor. eg: the prefab currently being edited.
             //! @param entityId The id of the entity to check for overrides.
             //! @return true if overrides are present on the given entity id.
-            virtual bool IsOverridePresent(AZ::EntityId entityId) = 0;
+            virtual bool AreOverridesPresent(AZ::EntityId entityId) = 0;
         };
     } // namespace Prefab
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/Overrides/PrefabOverridePublicInterface.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/EntityId.h>
+#include <AzCore/RTTI/RTTI.h>
+
+namespace AzToolsFramework
+{
+    namespace Prefab
+    {
+        class PrefabOverridePublicInterface
+        {
+        public:
+            AZ_RTTI(PrefabOverridePublicInterface, "{19F080A2-BDD7-476F-AA50-C1581401FC81}");
+
+            //! Checks whether overrides are present on the given entity id. The prefab that creates the overrides is identified
+            //! by the class implmenting this interface based on certain selections in the editor. eg: the prefab currently being edited.
+            //! @param entityId The id of the entity to check for overrides.
+            //! @return true if overrides are present on the given entity id.
+            virtual bool IsOverridePresent(AZ::EntityId entityId) = 0;
+        };
+    } // namespace Prefab
+} // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabInstanceUtils.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/Prefab/PrefabInstanceUtils.cpp
@@ -77,7 +77,7 @@ namespace AzToolsFramework
                     relativePath.append((*instanceIter)->GetInstanceAlias());
                 }
 
-                return relativePath;
+                return AZStd::move(relativePath);
             }
 
             bool IsDescendantInstance(const Instance& childInstance, const Instance& parentInstance)

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -19,6 +19,7 @@ namespace AzToolsFramework
     namespace Prefab
     {
         class PrefabFocusPublicInterface;
+        class PrefabOverridePublicInterface;
         class PrefabPublicInterface;
     }; // namespace Prefab
 
@@ -56,6 +57,7 @@ namespace AzToolsFramework
         ContainerEntityInterface* m_containerEntityInterface = nullptr;
         Prefab::PrefabFocusPublicInterface* m_prefabFocusPublicInterface = nullptr;
         Prefab::PrefabPublicInterface* m_prefabPublicInterface = nullptr;
+        Prefab::PrefabOverridePublicInterface* m_prefabOverridePublicInterface = nullptr;
 
         static bool IsLastVisibleChild(const QModelIndex& parent, const QModelIndex& child);
         static QModelIndex GetLastVisibleChild(const QModelIndex& parent);
@@ -88,7 +90,7 @@ namespace AzToolsFramework
 
         inline static const QColor s_overrideIconBackgroundColor = QColor("#444444");
         inline static const QPoint s_overrideIconOffset = QPoint(10, 10);
-        inline static const int s_overrideIconRadius = 6;
+        inline static const int s_overrideIconSize = 6;
         QIcon s_overrideIcon = QIcon(QString(":/Entity/entity_overridden.svg"));
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/Prefab/PrefabUiHandler.h
@@ -85,5 +85,10 @@ namespace AzToolsFramework
         QString m_prefabEditIconPath = QString(":/Entity/prefab_edit.svg");
         QString m_prefabEditOpenIconPath = QString(":/Entity/prefab_edit_open.svg");
         QString m_prefabEditCloseIconPath = QString(":/Entity/prefab_edit_close.svg");
+
+        inline static const QColor s_overrideIconBackgroundColor = QColor("#444444");
+        inline static const QPoint s_overrideIconOffset = QPoint(10, 10);
+        inline static const int s_overrideIconRadius = 6;
+        QIcon s_overrideIcon = QIcon(QString(":/Entity/entity_overridden.svg"));
     };
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/aztoolsframework_files.cmake
@@ -791,6 +791,11 @@ set(FILES
     Prefab/Instance/TemplateInstanceMapperInterface.h
     Prefab/Link/Link.h
     Prefab/Link/Link.cpp
+    Prefab/Overrides/PrefabOverrideHandler.h
+    Prefab/Overrides/PrefabOverrideHandler.cpp
+    Prefab/Overrides/PrefabOverridePublicInterface.h
+    Prefab/Overrides/PrefabOverridePublicHandler.h
+    Prefab/Overrides/PrefabOverridePublicHandler.cpp
     Prefab/Procedural/ProceduralPrefabAsset.h
     Prefab/Procedural/ProceduralPrefabAsset.cpp
     Prefab/PrefabPublicHandler.h


### PR DESCRIPTION
Signed-off-by: srikappa-amzn <82230713+srikappa-amzn@users.noreply.github.com>

## What does this PR do?

This PR adds the prefab override handlers and interface to query the prefab system whether overrides exist on entities or not.

https://user-images.githubusercontent.com/82230713/194442293-c702582d-1770-48bf-842e-19fa02bda37f.mp4

RFC: https://github.com/o3de/sig-content/issues/75


## How was this PR tested?

Manually. Unit tests and Automated tests will be added before launching the feature from behind the flag.
