### PR TITLE
Initial prototype for prefabs-dpe integration

### DIFF
--- a/Code/Framework/AzCore/AzCore/Component/Component.h
+++ b/Code/Framework/AzCore/AzCore/Component/Component.h
@@ -118,6 +118,13 @@ namespace AZ
          */
         void SetId(const ComponentId& id)   { m_id = id; }
 
+        virtual void SetAlias(const AZStd::string&){};
+
+        virtual AZStd::string GetAlias()
+        {
+            return AZStd::string();
+        }
+
         /**
         * Override to conduct per-component or per-slice validation logic during slice asset processing.
         * @param sliceEntities All entities that belong to the slice that the entity with this component is on.

--- a/Code/Framework/AzCore/AzCore/Component/EntitySerializer.cpp
+++ b/Code/Framework/AzCore/AzCore/Component/EntitySerializer.cpp
@@ -89,6 +89,7 @@ namespace AZ
                 if (component && (component->GetUnderlyingComponentType() != genericComponentWrapperTypeId))
                 {
                     entityInstance->m_components.emplace_back(component);
+                    component->SetAlias(componentKey);
                 }
             }
 

--- a/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
+++ b/Code/Framework/AzFramework/AzFramework/DocumentPropertyEditor/Reflection/LegacyReflectionBridge.cpp
@@ -254,7 +254,7 @@ namespace AZ::Reflection
                 else if (classElement)
                 {
                     AZStd::string_view elementName = classElement->m_name;
-                    if (!elementName.empty())
+                    if (!elementName.empty() && classElement->m_editData)
                     {
                         path.append("/");
                         path.append(elementName);

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ToolsComponents/EditorComponentBase.h
@@ -117,6 +117,16 @@ namespace AzToolsFramework
             virtual void Deactivate() override;
             //////////////////////////////////////////////////////////////////////////
 
+            void SetAlias(const AZStd::string& alias) override
+            {
+                m_alias = alias;
+            }
+
+            AZStd::string GetAlias() override
+            {
+                return m_alias;
+            }
+
             /**
              * Gets the transform interface of the entity that the component
              * belongs to, if the entity has a transform component.
@@ -191,6 +201,7 @@ namespace AzToolsFramework
             static void Reflect(AZ::ReflectContext* context);
 
         private:
+            AZStd::string m_alias;
             AZ::TransformInterface* m_transform;
         };
 

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UI/DocumentPropertyEditor/DPEComponentAdapter.h
@@ -47,6 +47,13 @@ namespace AZ::DocumentPropertyEditor
         Dom::Value HandleMessage(const AdapterMessage& message) override;
 
     protected:
+
+        void GeneratePropertyEditPatch(const ReflectionAdapter::PropertyChangeInfo& propertyChangeInfo);
+
+        AZStd::string m_entityAlias;
+        AZStd::string m_componentAlias;
+
+        ReflectionAdapter::PropertyChangeEvent::Handler m_propertyChangeHandler;
         AZ::Component* m_componentInstance = nullptr;
 
         AzToolsFramework::UndoSystem::URSequencePoint* m_currentUndoNode = nullptr;

--- a/editor.cfg
+++ b/editor.cfg
@@ -10,3 +10,5 @@ sys_PakWarnOnPakAccessFailures=0
 -- Enable warnings when asset loads take longer than the given millisecond threshold
 cl_assetLoadWarningEnable=true
 cl_assetLoadWarningMsThreshold=100
+
+ed_enableDPE=true


### PR DESCRIPTION
Idea is simple:
1. If non-opaque value, simply convert AZ::Dom::Value to PrefabDomValue
2. If opaque value, get its void* and serialize the value
3. In either of the above cases, modify dpe-dompath to prefab-dompath by reading in the 'SerializedPath' information stored in property editor nodes

Signed-off-by: srikappa-amzn <82230713+srikappa-amzn@users.noreply.github.com>

