### PR TITLE
Add Multi-Suite/Label Support to TIAF Specialized Runtimes

### DIFF
--- a/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/Source/TestImpactConsoleMain.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Native/Code/Source/TestImpactConsoleMain.cpp
@@ -48,13 +48,14 @@ namespace TestImpact::Console
             }
 
             std::cout << "Constructing in-memory model of source tree and test coverage for test suite ";
-            std::cout << SuiteTypeAsString(options.GetSuiteFilter()).c_str() << ", this may take a moment...\n";
+            std::cout << SuiteSetAsString(options.GetSuiteSet()).c_str() << ", this may take a moment...\n";
             NativeRuntime runtime(
                 NativeRuntimeConfigurationFactory(ReadFileContents<CommandLineOptionsException>(options.GetConfigurationFilePath())),
                 options.GetDataFilePath(),
                 options.GetPreviousRunDataFilePath(),
                 options.GetExcludedTests(),
-                options.GetSuiteFilter(),
+                options.GetSuiteSet(),
+                options.GetSuiteLabelExcludeSet(),
                 options.GetExecutionFailurePolicy(),
                 options.GetFailedTestCoveragePolicy(),
                 options.GetTestFailurePolicy(),

--- a/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/TestImpactConsoleMain.cpp
+++ b/Code/Tools/TestImpactFramework/Frontend/Console/Python/Code/Source/TestImpactConsoleMain.cpp
@@ -39,13 +39,14 @@ namespace TestImpact::Console
             }
 
             std::cout << "Constructing in-memory model of source tree and test coverage for test suite ";
-            std::cout << SuiteTypeAsString(options.GetSuiteFilter()).c_str() << ", this may take a moment...\n";
+            std::cout << SuiteSetAsString(options.GetSuiteSet()).c_str() << ", this may take a moment...\n";
             PythonRuntime runtime(
                 PythonRuntimeConfigurationFactory(ReadFileContents<CommandLineOptionsException>(options.GetConfigurationFilePath())),
                 options.GetDataFilePath(),
                 options.GetPreviousRunDataFilePath(),
                 options.GetExcludedTests(),
-                options.GetSuiteFilter(),
+                options.GetSuiteSet(),
+                options.GetSuiteLabelExcludeSet(),
                 options.GetExecutionFailurePolicy(),
                 options.GetFailedTestCoveragePolicy(),
                 options.GetTestFailurePolicy(),

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
@@ -30,7 +30,8 @@ namespace TestImpact
         //! @param dataFile The optional data file to be used instead of that specified in the config file.
         //! @param previousRunDataFile The optional previous run data file to be used instead of that specified in the config file.
         //! @param testsToExclude The tests to exclude from the run (will override any excluded tests in the config file).
-        //! @param suiteFilter The test suite for which the coverage data and test selection will draw from.
+        //! @param suiteSet The test suites for which the coverage data and test selection will draw from.
+        //! @param suiteLabelExcludeSet The suite labels that will exclude any tests with any matching suite labels.
         //! @param executionFailurePolicy Determines how to handle test targets that fail to execute.
         //! @param executionFailureDraftingPolicy Determines how test targets that previously failed to execute are drafted into subsequent test sequences.
         //! @param testFailurePolicy Determines how to handle test targets that report test failures.
@@ -41,7 +42,8 @@ namespace TestImpact
             const AZStd::optional<RepoPath>& dataFile,
             [[maybe_unused]]const AZStd::optional<RepoPath>& previousRunDataFile,
             const AZStd::vector<ExcludedTarget>& testsToExclude,
-            SuiteType suiteFilter,
+            const SuiteSet& suiteSet,
+            const SuiteLabelExcludeSet& suiteLabelExcludeSet,
             Policy::ExecutionFailure executionFailurePolicy,
             Policy::FailedTestCoverage failedTestCoveragePolicy,
             Policy::TestFailure testFailurePolicy,
@@ -159,7 +161,8 @@ namespace TestImpact
 
         RuntimeConfig m_config;
         RepoPath m_sparTiaFile;
-        SuiteType m_suiteFilter;
+        SuiteSet m_suiteSet;
+        SuiteLabelExcludeSet m_suiteLabelExcludeSet;
         Policy::ExecutionFailure m_executionFailurePolicy;
         Policy::FailedTestCoverage m_failedTestCoveragePolicy;
         Policy::TestFailure m_testFailurePolicy;

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
@@ -30,7 +30,7 @@ namespace TestImpact
         //! @param dataFile The optional data file to be used instead of that specified in the config file.
         //! @param previousRunDataFile The optional previous run data file to be used instead of that specified in the config file.
         //! @param testsToExclude The tests to exclude from the run (will override any excluded tests in the config file).
-        //! @param suiteSet The test suites for which the coverage data and test selection will draw from.
+        //! @param suiteSet The test suites from which the coverage data and test selection will draw from.
         //! @param suiteLabelExcludeSet Any tests with suites that match a label from this set will be excluded.
         //! @param executionFailurePolicy Determines how to handle test targets that fail to execute.
         //! @param executionFailureDraftingPolicy Determines how test targets that previously failed to execute are drafted into subsequent test sequences.

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
@@ -31,7 +31,7 @@ namespace TestImpact
         //! @param previousRunDataFile The optional previous run data file to be used instead of that specified in the config file.
         //! @param testsToExclude The tests to exclude from the run (will override any excluded tests in the config file).
         //! @param suiteSet The test suites for which the coverage data and test selection will draw from.
-        //! @param suiteLabelExcludeSet The suite labels that will exclude any tests with any matching suite labels.
+        //! @param suiteLabelExcludeSet Any tests with suites that match a label from this set will be excluded.
         //! @param executionFailurePolicy Determines how to handle test targets that fail to execute.
         //! @param executionFailureDraftingPolicy Determines how test targets that previously failed to execute are drafted into subsequent test sequences.
         //! @param testFailurePolicy Determines how to handle test targets that report test failures.

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.cpp
@@ -78,9 +78,11 @@ namespace TestImpact
                     const auto suiteLabels = suite[Keys[SuiteLabelsKey]].GetArray();
                     for (const auto& label : suiteLabels)
                     {
+                        // Check to see if this test suite has a label in our exclude list
                         const auto labelString = label.GetString();
                         if (suiteLabelExcludeSet.contains(labelString))
                         {
+                            // Set the flag so we can break out of the parent loop
                             skipTest = true;
                             break;
                         }

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.cpp
@@ -9,6 +9,7 @@
 #include <TestImpactFramework/TestImpactUtils.h>
 
 #include <Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h>
+#include <Artifact/Factory/TestImpactTestTargetMetaMapFactoryUtils.h>
 #include <Artifact/TestImpactArtifactException.h>
 
 #include <AzCore/JSON/document.h>
@@ -67,56 +68,43 @@ namespace TestImpact
         for (const auto& test : tests)
         {
             NativeTestTargetMeta testMeta;
+            AZStd::string name = test[Keys[NameKey]].GetString();
+            AZ_TestImpact_Eval(!name.empty(), ArtifactException, "Test name field cannot be empty");
+            testMeta.m_testTargetMeta.m_namespace = test[Keys[Namespacekey]].GetString();
+
+            if (const auto buildTypeString = test[Keys[LaunchMethodKey]].GetString(); strcmp(buildTypeString, Keys[TestRunnerKey]) == 0)
+            {
+                testMeta.m_launchMeta.m_launchMethod = LaunchMethod::TestRunner;
+            }
+            else if (strcmp(buildTypeString, Keys[StandAloneKey]) == 0)
+            {
+                testMeta.m_launchMeta.m_launchMethod = LaunchMethod::StandAlone;
+            }
+            else
+            {
+                throw(ArtifactException("Unexpected test build type"));
+            }
+
             const auto testSuites = test[Keys[TestSuitesKey]].GetArray();
-            bool skipTest = false;
             for (const auto& suite : testSuites)
             {
-                // Check to see if this test target has the suite we're looking for
+                // Check to see if this test target has a suite we're looking for (first suite to
+                // match will be "the" suite for this test)
                 if (const auto suiteName = suite[Keys[SuiteKey]].GetString();
                     suiteSet.contains(suiteName))
                 {
-                    const auto suiteLabels = suite[Keys[SuiteLabelsKey]].GetArray();
-                    for (const auto& label : suiteLabels)
+                    if (auto labelSet = ExtractTestSuiteLabelSet(suite[Keys[SuiteLabelsKey]].GetArray(), suiteLabelExcludeSet);
+                        labelSet.has_value())
                     {
-                        // Check to see if this test suite has a label in our exclude list
-                        const auto labelString = label.GetString();
-                        if (suiteLabelExcludeSet.contains(labelString))
-                        {
-                            // Set the flag so we can break out of the parent loop
-                            skipTest = true;
-                            break;
-                        }
-
-                        testMeta.m_testTargetMeta.m_suiteMeta.m_labelSet.insert(labelString);
+                        testMeta.m_testTargetMeta.m_suiteMeta.m_labelSet = AZStd::move(labelSet.value());
+                        testMeta.m_testTargetMeta.m_suiteMeta.m_name = suiteName;
+                        testMeta.m_testTargetMeta.m_suiteMeta.m_timeout = AZStd::chrono::seconds{ suite[Keys[TimeoutKey]].GetUint() };
+                        testMeta.m_launchMeta.m_customArgs = suite[Keys[CommandKey]].GetString();
+                        testMetas.emplace(AZStd::move(name), AZStd::move(testMeta));
                     }
 
-                    if (skipTest)
-                    {
-                        break;
-                    }
-
-                    testMeta.m_testTargetMeta.m_namespace = test[Keys[Namespacekey]].GetString();
-                    testMeta.m_testTargetMeta.m_suiteMeta.m_name = suiteName;
-                    testMeta.m_testTargetMeta.m_suiteMeta.m_timeout = AZStd::chrono::seconds{ suite[Keys[TimeoutKey]].GetUint() };
-                    testMeta.m_launchMeta.m_customArgs = suite[Keys[CommandKey]].GetString();
-
-                    if (const auto buildTypeString = test[Keys[LaunchMethodKey]].GetString();
-                        strcmp(buildTypeString, Keys[TestRunnerKey]) == 0)
-                    {
-                        testMeta.m_launchMeta.m_launchMethod = LaunchMethod::TestRunner;
-                    }
-                    else if (strcmp(buildTypeString, Keys[StandAloneKey]) == 0)
-                    {
-                        testMeta.m_launchMeta.m_launchMethod = LaunchMethod::StandAlone;
-                    }
-                    else
-                    {
-                        throw(ArtifactException("Unexpected test build type"));
-                    }
-
-                    AZStd::string name = test[Keys[NameKey]].GetString();
-                    AZ_TestImpact_Eval(!name.empty(), ArtifactException, "Test name field cannot be empty");
-                    testMetas.emplace(AZStd::move(name), AZStd::move(testMeta));
+                    // We either have one matching suite or the suite contians a label in the exclude set so we will break
+                    // out of the suite loop
                     break;
                 }
             }

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
@@ -15,7 +15,9 @@ namespace TestImpact
 {
     //! Constructs a list of test target meta-data artifacts of the specified suite type from the specified master test list data.
     //! @param masterTestListData The raw master test list data in JSON format.
-    //! @param suiteType The suite type to select the target meta-data artifacts from.
+    //! @param suiteSet The suites to select the target meta-data artifacts from.
+    //! @param suiteLabelExcludeSet The suite labels that will exclude any tests with any matching suite labels.
     //! @return The constructed list of test target meta-data artifacts.
-    NativeTestTargetMetaMap NativeTestTargetMetaMapFactory(const AZStd::string& masterTestListData, SuiteType suiteType);
+    NativeTestTargetMetaMap NativeTestTargetMetaMapFactory(
+        const AZStd::string& masterTestListData, const SuiteSet& suiteSet, const SuiteLabelExcludeSet& suiteLabelExcludeSet);
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <TestImpactFramework/TestImpactTestSequence.h>
+
 #include <Artifact/Static/TestImpactNativeTestTargetMeta.h>
 
 namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
@@ -16,7 +16,7 @@ namespace TestImpact
     //! Constructs a list of test target meta-data artifacts of the specified suite type from the specified master test list data.
     //! @param masterTestListData The raw master test list data in JSON format.
     //! @param suiteSet The suites to select the target meta-data artifacts from.
-    //! @param suiteLabelExcludeSet The suite labels that will exclude any tests with any matching suite labels.
+    //! @param suiteLabelExcludeSet Any tests with suites that match a label from this set will be excluded.
     //! @return The constructed list of test target meta-data artifacts.
     NativeTestTargetMetaMap NativeTestTargetMetaMapFactory(
         const AZStd::string& masterTestListData, const SuiteSet& suiteSet, const SuiteLabelExcludeSet& suiteLabelExcludeSet);

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.cpp
@@ -53,7 +53,7 @@ namespace TestImpact
         return AZStd::nullopt;
     }
 
-    //!
+    //! Determines the test run result of a native instrumented test run.
     AZStd::optional<Client::TestRunResult> NativeInstrumentedTestRunnerErrorCodeChecker(
         const typename NativeInstrumentedTestRunner::JobInfo& jobInfo, const JobMeta& meta)
     {
@@ -91,6 +91,28 @@ namespace TestImpact
         }
 
         return AZStd::nullopt;
+    }
+
+    //! Checks the successfully completed test runs for missing coverage whoch would compromise the integrity of the dynamic dependency map.
+    AZStd::string GenerateIntegrityErrorString(const TestEngineInstrumentedRunResult<NativeTestTarget, TestCoverage>& engineJobs)
+    {
+        // Now that we know the true result of successful jobs that return non-zero we can deduce if we have any integrity failures
+        // where a test target ran and completed its tests without incident yet failed to produce coverage data
+        AZStd::string integrityErrors;
+        const auto& [result, engineRuns] = engineJobs;
+        for (const auto& engineRun : engineRuns)
+        {
+            if (const auto testResult = engineRun.GetTestResult();
+                (testResult == Client::TestRunResult::AllTestsPass || testResult == Client::TestRunResult::TestFailures) &&
+                !engineRun.GetCoverge().has_value())
+            {
+                integrityErrors += AZStd::string::format(
+                    "Test target %s completed its test run but failed to produce coverage data\n",
+                    engineRun.GetTestTarget()->GetName().c_str());
+            }
+        }
+
+        return integrityErrors;
     }
 
     // Type trait for the test enumerator

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Include/TestImpactFramework/Python/TestImpactPythonRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Include/TestImpactFramework/Python/TestImpactPythonRuntime.h
@@ -32,7 +32,8 @@ namespace TestImpact
             const AZStd::optional<RepoPath>& dataFile,
             [[maybe_unused]] const AZStd::optional<RepoPath>& previousRunDataFile,
             const AZStd::vector<ExcludedTarget>& testsToExclude,
-            SuiteType suiteFilter,
+            const SuiteSet& suiteSet,
+            const SuiteLabelExcludeSet& suiteLabelExcludeSet,
             Policy::ExecutionFailure executionFailurePolicy,
             Policy::FailedTestCoverage failedTestCoveragePolicy,
             Policy::TestFailure testFailurePolicy,
@@ -151,7 +152,8 @@ namespace TestImpact
 
         PythonRuntimeConfig m_config;
         RepoPath m_sparTiaFile;
-        SuiteType m_suiteFilter;
+        SuiteSet m_suiteSet;
+        SuiteLabelExcludeSet m_suiteLabelExcludeSet;
         Policy::ExecutionFailure m_executionFailurePolicy;
         Policy::FailedTestCoverage m_failedTestCoveragePolicy;
         Policy::TestFailure m_testFailurePolicy;

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Include/TestImpactFramework/Python/TestImpactPythonRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Include/TestImpactFramework/Python/TestImpactPythonRuntime.h
@@ -27,6 +27,18 @@ namespace TestImpact
     class PythonRuntime
     {
     public:
+        //! Constructs a runtime with the specified configuration and policies.
+        //! @param config The configuration used for this runtime instance.
+        //! @param dataFile The optional data file to be used instead of that specified in the config file.
+        //! @param previousRunDataFile The optional previous run data file to be used instead of that specified in the config file.
+        //! @param testsToExclude The tests to exclude from the run (will override any excluded tests in the config file).
+        //! @param suiteSet The test suites from which the coverage data and test selection will draw from.
+        //! @param suiteLabelExcludeSet Any tests with suites that match a label from this set will be excluded.
+        //! @param executionFailurePolicy Determines how to handle test targets that fail to execute.
+        //! @param executionFailureDraftingPolicy Determines how test targets that previously failed to execute are drafted into subsequent test sequences.
+        //! @param testFailurePolicy Determines how to handle test targets that report test failures.
+        //! @param integrationFailurePolicy Determines how to handle instances where the build system model and/or test impact analysis data is compromised.
+        //! @param testRunnerPolicy Determines which test runner type to use.
         PythonRuntime(
             PythonRuntimeConfig&& config,
             const AZStd::optional<RepoPath>& dataFile,
@@ -43,6 +55,7 @@ namespace TestImpact
 
         ~PythonRuntime();
 
+        //! Returns true if the runtime has test impact analysis data (either preexisting or generated).
         bool HasImpactAnalysisData() const;
 
         //! Runs a test sequence where all tests with a matching suite in the suite filter and also not on the excluded list are selected.

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.cpp
@@ -74,9 +74,11 @@ namespace TestImpact
                     const auto suiteLabels = suite[Keys[SuiteLabelsKey]].GetArray();
                     for (const auto& label : suiteLabels)
                     {
+                        // Check to see if this test suite has a label in our exclude list
                         const auto labelString = label.GetString();
                         if (suiteLabelExcludeSet.contains(labelString))
                         {
+                            // Set the flag so we can break out of the parent loop
                             skipTest = true;
                             break;
                         }

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.cpp
@@ -9,6 +9,7 @@
 #include <TestImpactFramework/TestImpactUtils.h>
 
 #include <Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h>
+#include <Artifact/Factory/TestImpactTestTargetMetaMapFactoryUtils.h>
 #include <Artifact/TestImpactArtifactException.h>
 
 #include <AzCore/JSON/document.h>
@@ -63,43 +64,31 @@ namespace TestImpact
         for (const auto& test : tests)
         {
             PythonTestTargetMeta testMeta;
+            AZStd::string name = test[Keys[NameKey]].GetString();
+            AZ_TestImpact_Eval(!name.empty(), ArtifactException, "Test name field cannot be empty");
+            testMeta.m_testTargetMeta.m_namespace = test[Keys[NamespaceKey]].GetString();
+
             const auto testSuites = test[Keys[TestSuitesKey]].GetArray();
-            bool skipTest = false;
             for (const auto& suite : testSuites)
             {
-                // Check to see if this test target has the suite we're looking for
+                // Check to see if this test target has a suite we're looking for (first suite to
+                // match will be "the" suite for this test)
                 if (const auto suiteName = suite[Keys[SuiteKey]].GetString();
                     suiteSet.contains(suiteName))
                 {
-                    const auto suiteLabels = suite[Keys[SuiteLabelsKey]].GetArray();
-                    for (const auto& label : suiteLabels)
+                    if (auto labelSet = ExtractTestSuiteLabelSet(suite[Keys[SuiteLabelsKey]].GetArray(), suiteLabelExcludeSet);
+                        labelSet.has_value())
                     {
-                        // Check to see if this test suite has a label in our exclude list
-                        const auto labelString = label.GetString();
-                        if (suiteLabelExcludeSet.contains(labelString))
-                        {
-                            // Set the flag so we can break out of the parent loop
-                            skipTest = true;
-                            break;
-                        }
-
-                        testMeta.m_testTargetMeta.m_suiteMeta.m_labelSet.insert(labelString);
+                        testMeta.m_testTargetMeta.m_suiteMeta.m_labelSet = AZStd::move(labelSet.value());
+                        testMeta.m_testTargetMeta.m_suiteMeta.m_name = suiteName;
+                        testMeta.m_testTargetMeta.m_suiteMeta.m_timeout = AZStd::chrono::seconds{ suite[Keys[TimeoutKey]].GetUint() };
+                        testMeta.m_scriptMeta.m_scriptPath = suite[Keys[ScriptKey]].GetString();
+                        testMeta.m_scriptMeta.m_testCommand = suite[Keys[TestCommandKey]].GetString();
+                        testMetas.emplace(AZStd::move(name), AZStd::move(testMeta));
                     }
 
-                    if (skipTest)
-                    {
-                        break;
-                    }
-
-                    testMeta.m_testTargetMeta.m_namespace = test[Keys[NamespaceKey]].GetString();
-                    testMeta.m_testTargetMeta.m_suiteMeta.m_name = suiteName;
-                    testMeta.m_testTargetMeta.m_suiteMeta.m_timeout = AZStd::chrono::seconds{ suite[Keys[TimeoutKey]].GetUint() };
-                    testMeta.m_scriptMeta.m_scriptPath = suite[Keys[ScriptKey]].GetString();
-                    testMeta.m_scriptMeta.m_testCommand = suite[Keys[TestCommandKey]].GetString();
-
-                    AZStd::string name = test[Keys[NameKey]].GetString();
-                    AZ_TestImpact_Eval(!name.empty(), ArtifactException, "Test name field cannot be empty");
-                    testMetas.emplace(AZStd::move(name), AZStd::move(testMeta));
+                    // We either have one matching suite or the suite contians a label in the exclude set so we will break
+                    // out of the suite loop
                     break;
                 }
             }

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h
@@ -15,7 +15,9 @@ namespace TestImpact
 {
     //! Constructs a list of test target meta-data artifacts of the specified suite type from the specified master test list data.
     //! @param testListData The raw test list data in JSON format.
-    //! @param suiteType The suite type to select the target meta-data artifacts from.
+    //! @param suiteSet The suites to select the target meta-data artifacts from.
+    //! @param suiteLabelExcludeSet The suite labels that will exclude any tests with any matching suite labels.
     //! @return The constructed list of test target meta-data artifacts.
-    PythonTestTargetMetaMap PythonTestTargetMetaMapFactory(const AZStd::string& testListData, SuiteType suiteType);
+    PythonTestTargetMetaMap PythonTestTargetMetaMapFactory(
+        const AZStd::string& testListData, const SuiteSet& suiteSet, const SuiteLabelExcludeSet& suiteLabelExcludeSet);
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h
@@ -8,8 +8,9 @@
 
 #pragma once
 
-#include <Artifact/Static/TestImpactPythonTestTargetMeta.h>
 #include <TestImpactFramework/TestImpactTestSequence.h>
+
+#include <Artifact/Static/TestImpactPythonTestTargetMeta.h>
 
 namespace TestImpact
 {

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h
@@ -16,7 +16,7 @@ namespace TestImpact
     //! Constructs a list of test target meta-data artifacts of the specified suite type from the specified master test list data.
     //! @param testListData The raw test list data in JSON format.
     //! @param suiteSet The suites to select the target meta-data artifacts from.
-    //! @param suiteLabelExcludeSet The suite labels that will exclude any tests with any matching suite labels.
+    //! @param suiteLabelExcludeSet Any tests with suites that match a label from this set will be excluded.
     //! @return The constructed list of test target meta-data artifacts.
     PythonTestTargetMetaMap PythonTestTargetMetaMapFactory(
         const AZStd::string& testListData, const SuiteSet& suiteSet, const SuiteLabelExcludeSet& suiteLabelExcludeSet);

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.cpp
@@ -149,7 +149,6 @@ namespace TestImpact
         InstrumentedRun(
         const AZStd::vector<const PythonTestTarget*>& testTargets,
         Policy::ExecutionFailure executionFailurePolicy,
-        Policy::IntegrityFailure integrityFailurePolicy,
         Policy::TestFailure testFailurePolicy,
         Policy::TargetOutputCapture targetOutputCapture,
         AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,
@@ -161,7 +160,7 @@ namespace TestImpact
         if (m_testRunnerPolicy == Policy::TestRunner::UseNullTestRunner)
         {
             // We don't delete the artifacts as they have been left by another test runner (e.g. ctest)
-            const auto result = RunTests(
+            return RunTests(
                 m_instrumentedNullTestRunner.get(),
                 jobInfos,
                 testTargets,
@@ -173,23 +172,10 @@ namespace TestImpact
                 globalTimeout,
                 callback,
                 std::nullopt);
-
-            if(const auto integrityErrors = GenerateIntegrityErrorString(result);
-                !integrityErrors.empty())
-            {
-                AZ_TestImpact_Eval(
-                        integrityFailurePolicy != Policy::IntegrityFailure::Abort,
-                        TestEngineException,
-                        integrityErrors);
-
-                AZ_Error("InstrumentedRun", false, integrityErrors.c_str());
-            }
-
-            return result;
         }
         else
         {
-            const auto result = RunTests(
+            return RunTests(
                     m_instrumentedTestRunner.get(),
                     jobInfos,
                     testTargets,
@@ -201,19 +187,6 @@ namespace TestImpact
                     globalTimeout,
                     callback,
                     std::nullopt);
-
-            if(const auto integrityErrors = GenerateIntegrityErrorString(result);
-                !integrityErrors.empty())
-            {
-                AZ_TestImpact_Eval(
-                        integrityFailurePolicy != Policy::IntegrityFailure::Abort,
-                        TestEngineException,
-                        integrityErrors);
-
-                AZ_Error("InstrumentedRun", false, integrityErrors.c_str());
-            }
-
-            return result;
         }
     }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.h
@@ -78,7 +78,6 @@ namespace TestImpact
         //! about the run.
         //! @param testTargets The test targets to run.
         //! @param executionFailurePolicy Policy for how test execution failures should be handled.
-        //! @param integrityFailurePolicy Policy for how integrity failures of the test impact data and source tree model should be handled.
         //! @param testFailurePolicy Policy for how test targets with failing tests should be handled.
         //! @param targetOutputCapture Policy for how test target standard output should be captured and handled.
         //! @param testTargetTimeout The maximum duration a test target may be in-flight for before being forcefully terminated (infinite if
@@ -91,7 +90,6 @@ namespace TestImpact
         InstrumentedRun(
             const AZStd::vector<const PythonTestTarget*>& testTargets,
             Policy::ExecutionFailure executionFailurePolicy,
-            Policy::IntegrityFailure integrityFailurePolicy,
             Policy::TestFailure testFailurePolicy,
             Policy::TargetOutputCapture targetOutputCapture,
             AZStd::optional<AZStd::chrono::milliseconds> testTargetTimeout,

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntime.cpp
@@ -301,10 +301,10 @@ namespace TestImpact
         const AZStd::unordered_set<const PythonTestTarget*> selectedTestTargetSet(selectedTestTargets.begin(), selectedTestTargets.end());
 
         // Unlike native test impact analysis, python test impact analysis can have tests with no coverage so we cannot simply
-        // draft in tests without coverage (i.e. for native, new tests, or tests that have yet to successfully execute in previous
-        // runs). Instead, the python test selector will run all parent test target tests when a new python test is added. What we
-        // should do in future versions (for both native and python) is draft in any previous failing tests. For now, we will leave
-        // the drafted set empty.
+        // draft in tests without coverage (i.e. new tests, or tests that have yet to successfully execute in previous runs).
+        // Instead, the python test selector will run all parent test target tests when a new python test is added. What we
+        // should do in future versions (for both native and python) is draft in any previous failing tests. For now, we will
+        // leave the drafted set empty.
         AZStd::vector<const TestTarget*> draftedTestTargets;
 
         // The subset of selected test targets that are not on the configuration's exclude list and those that are

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntime.cpp
@@ -320,7 +320,6 @@ namespace TestImpact
             return m_testEngine->InstrumentedRun(
                 testsTargets,
                 m_executionFailurePolicy,
-                m_integrationFailurePolicy,
                 m_testFailurePolicy,
                 m_targetOutputCapture,
                 testTargetTimeout,
@@ -438,7 +437,6 @@ namespace TestImpact
             return m_testEngine->InstrumentedRun(
                 testsTargets,
                 m_executionFailurePolicy,
-                m_integrationFailurePolicy,
                 m_testFailurePolicy,
                 m_targetOutputCapture,
                 testTargetTimeout,
@@ -593,7 +591,6 @@ namespace TestImpact
         const auto [result, testJobs] = m_testEngine->InstrumentedRun(
             includedTestTargets,
             m_executionFailurePolicy,
-            m_integrationFailurePolicy,
             m_testFailurePolicy,
             m_targetOutputCapture,
             testTargetTimeout,

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntime.cpp
@@ -25,10 +25,14 @@
 
 namespace TestImpact
 {
-    PythonTestTargetMetaMap ReadPythonTestTargetMetaMapFile(SuiteType suiteFilter, const RepoPath& testTargetMetaConfigFile, const AZStd::string& buildType)
+    PythonTestTargetMetaMap ReadPythonTestTargetMetaMapFile(
+        const SuiteSet& suiteSet,
+        const SuiteLabelExcludeSet& suiteLabelExcludeSet,
+        const RepoPath& testTargetMetaConfigFile,
+        const AZStd::string& buildType)
     {
         const auto masterTestListData = ReadFileContents<RuntimeException>(testTargetMetaConfigFile);
-        auto testTargetMetaMap = PythonTestTargetMetaMapFactory(masterTestListData, suiteFilter);
+        auto testTargetMetaMap = PythonTestTargetMetaMapFactory(masterTestListData, suiteSet, suiteLabelExcludeSet);
         for (auto& [name, meta] : testTargetMetaMap)
         {
             meta.m_scriptMeta.m_testCommand = AZStd::regex_replace(meta.m_scriptMeta.m_testCommand, AZStd::regex("\\$\\<CONFIG\\>"), buildType);
@@ -42,7 +46,8 @@ namespace TestImpact
         const AZStd::optional<RepoPath>& dataFile,
         [[maybe_unused]] const AZStd::optional<RepoPath>& previousRunDataFile,
         const AZStd::vector<ExcludedTarget>& testsToExclude,
-        SuiteType suiteFilter,
+        const SuiteSet& suiteSet,
+        const SuiteLabelExcludeSet& suiteLabelExcludeSet,
         Policy::ExecutionFailure executionFailurePolicy,
         Policy::FailedTestCoverage failedTestCoveragePolicy,
         Policy::TestFailure testFailurePolicy,
@@ -50,7 +55,8 @@ namespace TestImpact
         Policy::TargetOutputCapture targetOutputCapture,
         Policy::TestRunner testRunnerPolicy)
         : m_config(AZStd::move(config))
-        , m_suiteFilter(suiteFilter)
+        , m_suiteSet(suiteSet)
+        , m_suiteLabelExcludeSet(suiteLabelExcludeSet)
         , m_executionFailurePolicy(executionFailurePolicy)
         , m_failedTestCoveragePolicy(failedTestCoveragePolicy)
         , m_testFailurePolicy(testFailurePolicy)
@@ -62,7 +68,8 @@ namespace TestImpact
         auto targetDescriptors = ReadTargetDescriptorFiles(m_config.m_commonConfig.m_buildTargetDescriptor);
         auto buildTargets = CompilePythonTargetLists(
             AZStd::move(targetDescriptors),
-            ReadPythonTestTargetMetaMapFile(suiteFilter, m_config.m_commonConfig.m_testTargetMeta.m_metaFile, m_config.m_commonConfig.m_meta.m_buildConfig));
+            ReadPythonTestTargetMetaMapFile(
+                m_suiteSet, m_suiteLabelExcludeSet, m_config.m_commonConfig.m_testTargetMeta.m_metaFile, m_config.m_commonConfig.m_meta.m_buildConfig));
         auto&& [productionTargets, testTargets] = buildTargets;
         m_buildTargets = AZStd::make_unique<BuildTargetList<ProductionTarget, TestTarget>>(
             AZStd::move(testTargets), AZStd::move(productionTargets));
@@ -102,7 +109,7 @@ namespace TestImpact
             }
             else
             {
-                m_sparTiaFile = m_config.m_workspace.m_active.m_root / RepoPath(SuiteTypeAsString(m_suiteFilter)) /
+                m_sparTiaFile = m_config.m_workspace.m_active.m_root / RepoPath(SuiteSetAsString(m_suiteSet)) /
                     m_config.m_workspace.m_active.m_sparTiaFile;
             }
 
@@ -140,8 +147,8 @@ namespace TestImpact
             AZ_Printf(
                 LogCallSite,
                 AZStd::string::format(
-                    "No test impact analysis data found for suite '%s' at %s\n",
-                    SuiteTypeAsString(m_suiteFilter).c_str(),
+                    "No test impact analysis data found for suites '%s' at %s\n",
+                    SuiteSetAsString(m_suiteSet).c_str(),
                     m_sparTiaFile.c_str())
                     .c_str());
         }
@@ -240,7 +247,7 @@ namespace TestImpact
         // Inform the client that the sequence is about to start
         if (testSequenceStartCallback.has_value())
         {
-            (*testSequenceStartCallback)(m_suiteFilter, selectedTests);
+            (*testSequenceStartCallback)(m_suiteSet, m_suiteLabelExcludeSet, selectedTests);
         }
 
         // Run the test targets and collect the test run results
@@ -261,7 +268,8 @@ namespace TestImpact
             testTargetTimeout,
             globalTimeout,
             GenerateSequencePolicyState(),
-            m_suiteFilter,
+            m_suiteSet,
+            m_suiteLabelExcludeSet,
             selectedTests,
             GenerateTestRunReport(result, testRunTimer.GetStartTimePointRelative(sequenceTimer), testRunDuration, testJobs));
 
@@ -286,21 +294,18 @@ namespace TestImpact
     {
         const Timer sequenceTimer;
 
-        AZStd::vector<const TestTarget*> draftedTestTargets;
-        if (!HasImpactAnalysisData())
-        {
-            const auto notCovered = m_dynamicDependencyMap->GetNotCoveringTests();
-            for (const auto& testTarget : notCovered)
-            {
-                if (!m_testTargetExcludeList->IsTestTargetFullyExcluded(testTarget))
-                {
-                    draftedTestTargets.push_back(testTarget);
-                }
-            }
-        }
-
         // The test targets that were selected for the change list by the dynamic dependency map and the test targets that were not
         const auto [selectedTestTargets, discardedTestTargets] = SelectCoveringTestTargets(changeList, testPrioritizationPolicy);
+
+        // Set of selected tests so we can prune from drafted tests to avoid duplicate runs
+        const AZStd::unordered_set<const PythonTestTarget*> selectedTestTargetSet(selectedTestTargets.begin(), selectedTestTargets.end());
+
+        // Unlike native test impact analysis, python test impact analysis can have tests with no coverage so we cannot simply
+        // draft in tests without coverage (i.e. for native, new tests, or tests that have yet to successfully execute in previous
+        // runs). Instead, the python test selector will run all parent test target tests when a new python test is added. What we
+        // should do in future versions (for both native and python) is draft in any previous failing tests. For now, we will leave
+        // the drafted set empty.
+        AZStd::vector<const TestTarget*> draftedTestTargets;
 
         // The subset of selected test targets that are not on the configuration's exclude list and those that are
         const auto [includedSelectedTestTargets, excludedSelectedTestTargets] =
@@ -341,7 +346,8 @@ namespace TestImpact
             return ImpactAnalysisTestSequenceWrapper(
                 1,
                 GenerateImpactAnalysisSequencePolicyState(testPrioritizationPolicy, dynamicDependencyMapPolicy),
-                m_suiteFilter,
+                m_suiteSet,
+                m_suiteLabelExcludeSet,
                 sequenceTimer,
                 instrumentedTestRun,
                 includedSelectedTestTargets,
@@ -360,7 +366,8 @@ namespace TestImpact
             return ImpactAnalysisTestSequenceWrapper(
                 1,
                 GenerateImpactAnalysisSequencePolicyState(testPrioritizationPolicy, dynamicDependencyMapPolicy),
-                m_suiteFilter,
+                m_suiteSet,
+                m_suiteLabelExcludeSet,
                 sequenceTimer,
                 instrumentedTestRun,
                 includedSelectedTestTargets,
@@ -415,7 +422,7 @@ namespace TestImpact
         // Inform the client that the sequence is about to start
         if (testSequenceStartCallback.has_value())
         {
-            (*testSequenceStartCallback)(m_suiteFilter, selectedTests, discardedTests, draftedTests);
+            (*testSequenceStartCallback)(m_suiteSet, m_suiteLabelExcludeSet, selectedTests, discardedTests, draftedTests);
         }
 
         // We share the test run complete handler between the selected, discarded and drafted test runs as to present them together as one
@@ -521,7 +528,8 @@ namespace TestImpact
             testTargetTimeout,
             globalTimeout,
             GenerateSafeImpactAnalysisSequencePolicyState(testPrioritizationPolicy),
-            m_suiteFilter,
+            m_suiteSet,
+            m_suiteLabelExcludeSet,
             selectedTests,
             discardedTests,
             draftedTests,
@@ -577,7 +585,7 @@ namespace TestImpact
         // Inform the client that the sequence is about to start
         if (testSequenceStartCallback.has_value())
         {
-            (*testSequenceStartCallback)(m_suiteFilter, selectedTests);
+            (*testSequenceStartCallback)(m_suiteSet, m_suiteLabelExcludeSet, selectedTests);
         }
 
         // Run the test targets and collect the test run results
@@ -599,7 +607,8 @@ namespace TestImpact
             testTargetTimeout,
             globalTimeout,
             GenerateSequencePolicyState(),
-            m_suiteFilter,
+            m_suiteSet,
+            m_suiteLabelExcludeSet,
             selectedTests,
             GenerateTestRunReport(result, testRunTimer.GetStartTimePointRelative(sequenceTimer), testRunDuration, testJobs));
 


### PR DESCRIPTION
Signed-off-by: John <jonawals@amazon.com>

## What does this PR do?

This PR implements the specializedTIAF runtime-side functionality to:
-  Support multiple suites for drawing tests from for TIAF test runs
-  Support excluding tests based on test labels for TIAF test runs

_Please describe any testing performed._

These changes have been tested with manual end-to-end testing.