### PR TITLE
Fix Joints when the leader is a static rigid body.

### DIFF
--- a/Gems/PhysX/Code/Source/HingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/HingeJointComponent.cpp
@@ -87,13 +87,11 @@ namespace PhysX
                 leadFollowerInfo.m_followerBody->m_bodyHandle);
             m_jointSceneOwner = leadFollowerInfo.m_followerBody->m_sceneOwner;
         }
-        m_nativeJoint = GetPhysXNativeRevoluteJoint();
 
-        if (m_nativeJoint)
-        {
-            const AZ::EntityComponentIdPair id(GetEntityId(), GetId());
-            PhysX::JointRequestBus::Handler::BusConnect(id);
-        }
+        ObtainPhysXNativeRevoluteJoint();
+
+        const AZ::EntityComponentIdPair id(GetEntityId(), GetId());
+        PhysX::JointRequestBus::Handler::BusConnect(id);
     }
 
     void HingeJointComponent::DeinitNativeJoint()
@@ -102,11 +100,11 @@ namespace PhysX
         m_nativeJoint = nullptr;
     }
 
-    physx::PxRevoluteJoint* HingeJointComponent::GetPhysXNativeRevoluteJoint()
+    void HingeJointComponent::ObtainPhysXNativeRevoluteJoint()
     {
         if (m_nativeJoint)
         {
-            return m_nativeJoint;
+            return;
         }
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No sceneInterface");
@@ -116,7 +114,6 @@ namespace PhysX
         physx::PxRevoluteJoint* native = nativeJoint->is<physx::PxRevoluteJoint>();
         AZ_Assert(native, "It is not PxRevoluteJoint");
         m_nativeJoint = native;
-        return native;
     }
 
     float HingeJointComponent::GetPosition() const

--- a/Gems/PhysX/Code/Source/HingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/HingeJointComponent.cpp
@@ -88,10 +88,9 @@ namespace PhysX
             m_jointSceneOwner = leadFollowerInfo.m_followerBody->m_sceneOwner;
         }
 
-        ObtainPhysXNativeRevoluteJoint();
+        CachePhysXNativeRevoluteJoint();
 
-        const AZ::EntityComponentIdPair id(GetEntityId(), GetId());
-        PhysX::JointRequestBus::Handler::BusConnect(id);
+        JointRequestBus::Handler::BusConnect(AZ::EntityComponentIdPair(GetEntityId(), GetId()));
     }
 
     void HingeJointComponent::DeinitNativeJoint()
@@ -100,7 +99,7 @@ namespace PhysX
         m_nativeJoint = nullptr;
     }
 
-    void HingeJointComponent::ObtainPhysXNativeRevoluteJoint()
+    void HingeJointComponent::CachePhysXNativeRevoluteJoint()
     {
         if (m_nativeJoint)
         {
@@ -109,7 +108,7 @@ namespace PhysX
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No sceneInterface");
         const auto joint = sceneInterface->GetJointFromHandle(m_jointSceneOwner, m_jointHandle);
-        AZ_Assert(joint->GetNativeType() == PhysX::NativeTypeIdentifiers::HingeJoint, "It is not PhysXHingeJoint");
+        AZ_Assert(joint->GetNativeType() == NativeTypeIdentifiers::HingeJoint, "It is not PhysXHingeJoint");
         physx::PxJoint* nativeJoint = static_cast<physx::PxJoint*>(joint->GetNativePointer());
         physx::PxRevoluteJoint* native = nativeJoint->is<physx::PxRevoluteJoint>();
         AZ_Assert(native, "It is not PxRevoluteJoint");

--- a/Gems/PhysX/Code/Source/HingeJointComponent.h
+++ b/Gems/PhysX/Code/Source/HingeJointComponent.h
@@ -44,7 +44,7 @@ namespace PhysX
         void DeinitNativeJoint() override;
 
     private:
-        void ObtainPhysXNativeRevoluteJoint();
+        void CachePhysXNativeRevoluteJoint();
 
         physx::PxRevoluteJoint* m_nativeJoint{ nullptr };
     };

--- a/Gems/PhysX/Code/Source/HingeJointComponent.h
+++ b/Gems/PhysX/Code/Source/HingeJointComponent.h
@@ -44,7 +44,8 @@ namespace PhysX
         void DeinitNativeJoint() override;
 
     private:
-       physx::PxRevoluteJoint* GetPhysXNativeRevoluteJoint();
-       physx::PxRevoluteJoint* m_nativeJoint{ nullptr };
+        void ObtainPhysXNativeRevoluteJoint();
+
+        physx::PxRevoluteJoint* m_nativeJoint{ nullptr };
     };
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/JointComponent.cpp
+++ b/Gems/PhysX/Code/Source/JointComponent.cpp
@@ -212,17 +212,7 @@ namespace PhysX
         // If the lead exists but it doesn't have a rigid body then this joint will never get
         // created and therefore we need to warn about the invalid joint setup.
 
-        bool leadEntityHasRigidBody = false;
-        Physics::RigidBodyRequestBus::EnumerateHandlersId(
-            m_configuration.m_leadEntity,
-            [&leadEntityHasRigidBody](const Physics::RigidBodyRequests*)
-            {
-                leadEntityHasRigidBody = true;
-                return true;
-            });
-
-        // If lead entity has no rigid body then the joint won't be created.
-        if (!leadEntityHasRigidBody)
+        if (!Physics::RigidBodyRequestBus::FindFirstHandler(m_configuration.m_leadEntity))
         {
             const AZStd::string entityWithoutBodyWarningMsg("Rigid body not found in lead entity associated with joint. "
                                                             "Joint will not be created.");

--- a/Gems/PhysX/Code/Source/JointComponent.h
+++ b/Gems/PhysX/Code/Source/JointComponent.h
@@ -12,6 +12,7 @@
 #include <AzCore/Component/Component.h>
 #include <AzCore/Component/EntityId.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/Component/TickBus.h>
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/Common/PhysicsTypes.h>
 
@@ -46,6 +47,7 @@ namespace PhysX
     class JointComponent
         : public AZ::Component
         , protected Physics::RigidBodyNotificationBus::MultiHandler
+        , protected AZ::TickBus::Handler
     {
     public:
         AZ_COMPONENT(JointComponent, "{B01FD1D2-1D91-438D-874A-BF5EB7E919A8}");
@@ -78,11 +80,11 @@ namespace PhysX
             AzPhysics::SimulatedBody* m_followerBody = nullptr;
         };
 
-        // AZ::Component
+        // AZ::Component overrides ...
         void Activate() override;
         void Deactivate() override;
 
-        // Physics::RigidBodyNotifications overrides...
+        // Physics::RigidBodyNotifications overrides ...
         void OnPhysicsEnabled(const AZ::EntityId& entityId) override;
         void OnPhysicsDisabled(const AZ::EntityId& entityId) override;
 
@@ -95,6 +97,9 @@ namespace PhysX
         // Specific joint types will instantiate native joint pointer.
         virtual void InitNativeJoint(){};
         virtual void DeinitNativeJoint(){};
+
+        // AZ::TickEvents overrides ...
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
 
         AZ::Transform GetJointLocalPose(const physx::PxRigidActor* actor, const AZ::Transform& jointPose);
 

--- a/Gems/PhysX/Code/Source/PrismaticJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/PrismaticJointComponent.cpp
@@ -87,10 +87,9 @@ namespace PhysX
             m_jointSceneOwner = leadFollowerInfo.m_followerBody->m_sceneOwner;
         }
 
-        ObtainPhysXD6Joint();
+        CachePhysXD6Joint();
 
-        const AZ::EntityComponentIdPair id(GetEntityId(), GetId());
-        JointRequestBus::Handler::BusConnect(id);
+        JointRequestBus::Handler::BusConnect(AZ::EntityComponentIdPair(GetEntityId(), GetId()));
     }
 
     void PrismaticJointComponent::DeinitNativeJoint()
@@ -99,7 +98,7 @@ namespace PhysX
         m_native = nullptr;
     }
 
-    void PrismaticJointComponent::ObtainPhysXD6Joint()
+    void PrismaticJointComponent::CachePhysXD6Joint()
     {
         if (m_native)
         {
@@ -108,7 +107,7 @@ namespace PhysX
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No sceneInterface");
         const auto* joint = sceneInterface->GetJointFromHandle(m_jointSceneOwner, m_jointHandle);
-        AZ_Assert(joint->GetNativeType() == PhysX::NativeTypeIdentifiers::PrismaticJoint, "It is not PhysXPrismaticJoint");
+        AZ_Assert(joint->GetNativeType() == NativeTypeIdentifiers::PrismaticJoint, "It is not PhysXPrismaticJoint");
         physx::PxJoint* native = static_cast<physx::PxJoint*>(joint->GetNativePointer());
         physx::PxD6Joint* nativeD6 = native->is<physx::PxD6Joint>();
         AZ_Assert(nativeD6, "It is not PxD6Joint");

--- a/Gems/PhysX/Code/Source/PrismaticJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/PrismaticJointComponent.cpp
@@ -16,6 +16,7 @@
 #include <AzFramework/Physics/PhysicsScene.h>
 
 #include <PxPhysicsAPI.h>
+#include <PhysX/NativeTypeIdentifiers.h>
 
 namespace PhysX
 {
@@ -85,13 +86,11 @@ namespace PhysX
                 leadFollowerInfo.m_followerBody->m_bodyHandle);
             m_jointSceneOwner = leadFollowerInfo.m_followerBody->m_sceneOwner;
         }
-        m_native = GetPhysXD6Joint();
 
-        if (m_native)
-        {
-            const AZ::EntityComponentIdPair id(GetEntityId(), GetId());
-            JointRequestBus::Handler::BusConnect(id);
-        }
+        ObtainPhysXD6Joint();
+
+        const AZ::EntityComponentIdPair id(GetEntityId(), GetId());
+        JointRequestBus::Handler::BusConnect(id);
     }
 
     void PrismaticJointComponent::DeinitNativeJoint()
@@ -100,23 +99,20 @@ namespace PhysX
         m_native = nullptr;
     }
 
-    physx::PxD6Joint* PrismaticJointComponent::GetPhysXD6Joint()
+    void PrismaticJointComponent::ObtainPhysXD6Joint()
     {
         if (m_native)
         {
-            return m_native;
+            return;
         }
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No sceneInterface");
         const auto* joint = sceneInterface->GetJointFromHandle(m_jointSceneOwner, m_jointHandle);
+        AZ_Assert(joint->GetNativeType() == PhysX::NativeTypeIdentifiers::PrismaticJoint, "It is not PhysXPrismaticJoint");
         physx::PxJoint* native = static_cast<physx::PxJoint*>(joint->GetNativePointer());
-        if (native && native->is<physx::PxD6Joint>())
-        {
-            physx::PxD6Joint* nativeD6 = static_cast<physx::PxD6Joint*>(joint->GetNativePointer());
-            m_native = nativeD6;
-            return nativeD6;
-        }
-        return nullptr;
+        physx::PxD6Joint* nativeD6 = native->is<physx::PxD6Joint>();
+        AZ_Assert(nativeD6, "It is not PxD6Joint");
+        m_native = nativeD6;
     }
 
     float PrismaticJointComponent::GetPosition() const

--- a/Gems/PhysX/Code/Source/PrismaticJointComponent.h
+++ b/Gems/PhysX/Code/Source/PrismaticJointComponent.h
@@ -47,8 +47,8 @@ namespace PhysX
         void DeinitNativeJoint() override;
 
     private:
-        void ObtainPhysXD6Joint();
+        void CachePhysXD6Joint();
 
-        mutable physx::PxD6Joint* m_native{ nullptr };
+        physx::PxD6Joint* m_native{ nullptr };
     };
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/PrismaticJointComponent.h
+++ b/Gems/PhysX/Code/Source/PrismaticJointComponent.h
@@ -47,7 +47,8 @@ namespace PhysX
         void DeinitNativeJoint() override;
 
     private:
-        physx::PxD6Joint* GetPhysXD6Joint();
+        void ObtainPhysXD6Joint();
+
         mutable physx::PxD6Joint* m_native{ nullptr };
     };
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/StaticRigidBodyComponent.cpp
+++ b/Gems/PhysX/Code/Source/StaticRigidBodyComponent.cpp
@@ -89,6 +89,9 @@ namespace PhysX
             configuration.m_startSimulationEnabled = false; // enable physics will enable this when called.
             m_staticRigidBodyHandle = sceneInterface->AddSimulatedBody(m_attachedSceneHandle, &configuration);
         }
+
+        Physics::RigidBodyRequestBus::Handler::BusConnect(GetEntityId());
+        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusConnect(GetEntityId());
     }
 
     void StaticRigidBodyComponent::Activate()
@@ -120,8 +123,6 @@ namespace PhysX
         InitStaticRigidBody();
 
         EnablePhysics();
-
-        AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusConnect(entityId);
     }
 
     void StaticRigidBodyComponent::Deactivate()
@@ -138,6 +139,7 @@ namespace PhysX
         }
 
         AZ::EntityBus::Handler::BusDisconnect();
+        Physics::RigidBodyRequestBus::Handler::BusDisconnect();
         AzPhysics::SimulatedBodyComponentRequestsBus::Handler::BusDisconnect();
         AZ::TransformNotificationBus::Handler::BusDisconnect();
     }


### PR DESCRIPTION
**Note:** The issue happens in staging branch `PhysX_StaticRigidBody_Staging`.

Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?
 
- Fix bug for joints when the leader was using a static rigid body. The static rigid body wasn't connecting to the `RigidBodyRequests` bus and it was also connecting to the `SimulatedBodyComponentRequests` bus too late.
- Joints will now send a warning message that the joint setup is incorrect when the leader entity doesn't have any rigid body.
- Cleaned up Hinge and Prismatic joints private function to get the native joint.

## How was this PR tested?
Run PhysX unit tests.
Tested a ball joint where:
- it has no leader, it correctly used the global position.
- it has a leader with no rigid body, it correctly warned about the incorrect setup.
- it has a leader with a static rigid body, it worked as expected.
- it has a leader with a kinematic rigid body, it worked as expected. Also tested moving the kinematic body and the joint moved accordingly.
- it has a leader with a dynamic rigid body, it worked as expected.
