### PR TITLE
Rename rigid body type Dynamic to Simulated.

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/RagdollPhysicsBus.h
+++ b/Code/Framework/AzFramework/AzFramework/Physics/RagdollPhysicsBus.h
@@ -17,7 +17,7 @@ namespace Physics
     enum class SimulationType
     {
         Kinematic, ///< For ragdoll nodes controlled directly by animation.
-        Dynamic ///< For ragdoll nodes driven by the physics simulation.
+        Simulated ///< For ragdoll nodes driven by the physics simulation.
     };
 
     /// Contains pose and velocity information, simulation type and joint strength properties for a node in the ragdoll

--- a/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeRagdollNode.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/BlendTreeRagdollNode.cpp
@@ -255,7 +255,7 @@ namespace EMotionFX
                     Physics::RagdollNodeState& targetRagdollRootNodeState = outputPoseData->GetRagdollNodeState(ragdollRootNodeIndex.GetValue());
 
                     // Only move along joints parented to the ragdoll root in case the ragdoll root is actually driven by physics (simulated).
-                    if (targetRagdollRootNodeState.m_simulationType == Physics::SimulationType::Dynamic)
+                    if (targetRagdollRootNodeState.m_simulationType == Physics::SimulationType::Simulated)
                     {
                         const Physics::RagdollNodeState& currentRagdollRootNodeState = currentRagdollState[ragdollRootNodeIndex.GetValue()];
 
@@ -284,7 +284,7 @@ namespace EMotionFX
                     Physics::RagdollNodeState& targetRagdollNodeState = outputPoseData->GetRagdollNodeState(ragdollNodeIndex.GetValue());
 
                     // The joint is part of the ragdoll as well as added and selected by this ragdoll node.
-                    targetRagdollNodeState.m_simulationType = Physics::SimulationType::Dynamic;
+                    targetRagdollNodeState.m_simulationType = Physics::SimulationType::Simulated;
 
                     // Go up the chain and find the next joint that is part of the ragdoll (Parent of the ragdoll node).
                     AZ::Outcome<size_t> ragdollParentJointIndex = AZ::Failure();

--- a/Gems/EMotionFX/Code/EMotionFX/Source/PoseDataRagdoll.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/PoseDataRagdoll.cpp
@@ -92,7 +92,7 @@ namespace EMotionFX
 
         // Blending from kinematic to dynamic joint
         if (nodeState.m_simulationType == Physics::SimulationType::Kinematic &&
-            destNodeState.m_simulationType == Physics::SimulationType::Dynamic)
+            destNodeState.m_simulationType == Physics::SimulationType::Simulated)
         {
             nodeState.m_position = jointTransform.m_position.Lerp(destNodeState.m_position, weight);
             nodeState.m_orientation = jointTransform.m_rotation.NLerp(destNodeState.m_orientation, weight);
@@ -107,11 +107,11 @@ namespace EMotionFX
             if (weight > strengthEpsilon)
             {
                 // TODO: Evaluate if we should calculate the initial velocities here when we switch to dynamic. Or will we need to calculate that information every frame anyway additionally to the motors!?
-                nodeState.m_simulationType = Physics::SimulationType::Dynamic;
+                nodeState.m_simulationType = Physics::SimulationType::Simulated;
             }
         }
         // Blending from dynamic to kinematic joint
-        else if (nodeState.m_simulationType == Physics::SimulationType::Dynamic &&
+        else if (nodeState.m_simulationType == Physics::SimulationType::Simulated &&
                  destNodeState.m_simulationType == Physics::SimulationType::Kinematic)
         {
             nodeState.m_position = nodeState.m_position.Lerp(destJointTransform.m_position, weight);
@@ -128,8 +128,8 @@ namespace EMotionFX
             }
         }
         // Blending between two dynamic joints
-        else if (nodeState.m_simulationType == Physics::SimulationType::Dynamic &&
-                 destNodeState.m_simulationType == Physics::SimulationType::Dynamic)
+        else if (nodeState.m_simulationType == Physics::SimulationType::Simulated &&
+                 destNodeState.m_simulationType == Physics::SimulationType::Simulated)
         {
             nodeState.m_position = nodeState.m_position.Lerp(destNodeState.m_position, weight);
             nodeState.m_orientation = nodeState.m_orientation.NLerp(destNodeState.m_orientation, weight);
@@ -192,7 +192,7 @@ namespace EMotionFX
             const Physics::RagdollNodeState& nodeState = m_nodeStates[i];
 
             AZ_Printf("EMotionFX", "     - Ragdoll Node State %d:", i);
-            AZ_Printf("EMotionFX", "         + Type %s:", nodeState.m_simulationType == Physics::SimulationType::Dynamic ? "Dynamic" : "Kinematic");
+            AZ_Printf("EMotionFX", "         + Type %s:", nodeState.m_simulationType == Physics::SimulationType::Simulated ? "Simulated" : "Kinematic");
             AZ_Printf("EMotionFX", "         + Position: (%f, %f, %f)", static_cast<float>(nodeState.m_position.GetX()), static_cast<float>(nodeState.m_position.GetY()), static_cast<float>(nodeState.m_position.GetZ()));
             AZ_Printf("EMotionFX", "         + Rotation: (%f, %f, %f, %f)", static_cast<float>(nodeState.m_orientation.GetX()), static_cast<float>(nodeState.m_orientation.GetY()), static_cast<float>(nodeState.m_orientation.GetZ()), static_cast<float>(nodeState.m_orientation.GetW()));
             AZ_Printf("EMotionFX", "         + Linear Velocity: (%f, %f, %f)", static_cast<float>(nodeState.m_linearVelocity.GetX()), static_cast<float>(nodeState.m_linearVelocity.GetY()), static_cast<float>(nodeState.m_linearVelocity.GetZ()));

--- a/Gems/EMotionFX/Code/EMotionFX/Source/RagdollInstance.cpp
+++ b/Gems/EMotionFX/Code/EMotionFX/Source/RagdollInstance.cpp
@@ -461,7 +461,7 @@ namespace EMotionFX
             const size_t jointIndex = ragdollInstance->GetJointIndex(i);
             const Physics::RagdollNodeState& targetJointPose = ragdollTargetPose[i];
 
-            if (targetJointPose.m_simulationType == Physics::SimulationType::Dynamic)
+            if (targetJointPose.m_simulationType == Physics::SimulationType::Simulated)
             {
                 targetPose.SetLocalSpaceTransform(jointIndex, EMotionFX::Transform(targetJointPose.m_position, targetJointPose.m_orientation));
             }
@@ -499,7 +499,7 @@ namespace EMotionFX
 
                     const Physics::RagdollNodeState& targetParentJointPose = ragdollTargetPose[ragdollParentJointIndex.GetValue()];
 
-                    if (targetParentJointPose.m_simulationType == Physics::SimulationType::Dynamic)
+                    if (targetParentJointPose.m_simulationType == Physics::SimulationType::Simulated)
                     {
                         AZ::Color simulatedColor = defaultSimulatedColor;
                         // TODO: We might want to bake the strength into the alpha channel once we know its range.

--- a/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.cpp
+++ b/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.cpp
@@ -12,7 +12,7 @@ AZ_PUSH_DISABLE_DLL_EXPORT_MEMBER_WARNING
 #include <Editor/ui_KinematicDescriptionDialog.h>
 AZ_POP_DISABLE_DLL_EXPORT_MEMBER_WARNING
 
-static constexpr const char* const DynamicDescription = "With <b>Dynamic</b> rigid bodies, you can use physics forces "
+static constexpr const char* const SimulatedDescription = "With <b>Simulated</b> rigid bodies, you can use physics forces "
                                                   "(gravity, collision, etc.) to control the movement and "
                                                   "position of the object.";
 
@@ -50,9 +50,9 @@ namespace PhysX
 
         void KinematicDescriptionDialog::InitializeButtons()
         {
-            connect(m_ui->dynamicRadioButton, &QPushButton::clicked, this, &KinematicDescriptionDialog::OnButtonClicked);
+            connect(m_ui->simulatedRadioButton, &QPushButton::clicked, this, &KinematicDescriptionDialog::OnButtonClicked);
             connect(m_ui->kinematicRadioButton, &QPushButton::clicked, this, &KinematicDescriptionDialog::OnButtonClicked);
-            connect(m_ui->dynamicBox, &QGroupBox::clicked, this, &KinematicDescriptionDialog::OnButtonClicked);
+            connect(m_ui->simulatedBox, &QGroupBox::clicked, this, &KinematicDescriptionDialog::OnButtonClicked);
             connect(m_ui->kinematicBox, &QGroupBox::clicked, this, &KinematicDescriptionDialog::OnButtonClicked);
 
             if (m_kinematicSetting)
@@ -61,7 +61,7 @@ namespace PhysX
             }
             else
             {
-                m_ui->dynamicRadioButton->setChecked(true);
+                m_ui->simulatedRadioButton->setChecked(true);
             }
 
             // running OnButtonClicked manually to get initial border highlight
@@ -73,16 +73,16 @@ namespace PhysX
             const QString boxStyleSheet = QString("background-color: rgb(51, 51, 51);");
             const QString boxBorderStyleSheet = QString(" border: 1px solid rgb(30, 112, 235);");
 
-            if (m_ui->dynamicRadioButton->isChecked())
+            if (m_ui->simulatedRadioButton->isChecked())
             {
-                m_ui->dynamicBox->setStyleSheet(boxStyleSheet + boxBorderStyleSheet);
+                m_ui->simulatedBox->setStyleSheet(boxStyleSheet + boxBorderStyleSheet);
                 m_ui->kinematicBox->setStyleSheet(boxStyleSheet + " border: none;");
                 m_kinematicSetting = false;
             }
             else
             {
                 m_ui->kinematicBox->setStyleSheet(boxStyleSheet + boxBorderStyleSheet);
-                m_ui->dynamicBox->setStyleSheet(boxStyleSheet + " border: none;");
+                m_ui->simulatedBox->setStyleSheet(boxStyleSheet + " border: none;");
                 m_kinematicSetting = true;
             }
 
@@ -110,9 +110,9 @@ namespace PhysX
             }
             else
             {
-                m_ui->dynamicRadioButton->setChecked(true);
+                m_ui->simulatedRadioButton->setChecked(true);
 
-                m_ui->selectedDescriptionLabel->setText(DynamicDescription);
+                m_ui->selectedDescriptionLabel->setText(SimulatedDescription);
 
                 m_ui->validLabel1->setText(CollisionsText);
                 m_ui->validLabel2->setText(GravityText);

--- a/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.h
+++ b/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.h
@@ -24,7 +24,7 @@ namespace PhysX
 {
     namespace Editor
     {
-        /// Dialog for explaining the difference between Dynamic and Kinematic bodies.
+        /// Dialog for explaining the difference between Simulated and Kinematic bodies.
         class KinematicDescriptionDialog : public QDialog
         {
             Q_OBJECT

--- a/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.ui
+++ b/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.ui
@@ -107,7 +107,7 @@
             <rect>
              <x>10</x>
              <y>10</y>
-             <width>61</width>
+             <width>71</width>
              <height>21</height>
             </rect>
            </property>

--- a/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.ui
+++ b/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.ui
@@ -131,7 +131,7 @@
             <string notr="true">border: none;</string>
            </property>
            <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Used when physics are applied and&lt;br/&gt; automated forces are needed to move assets.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Used when physics is applied and&lt;br/&gt; automated forces are needed to move assets.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="alignment">
             <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>

--- a/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.ui
+++ b/Gems/PhysX/Code/Editor/KinematicDescriptionDialog.ui
@@ -81,7 +81,7 @@
          <property name="title">
           <string/>
          </property>
-         <widget class="QGroupBox" name="dynamicBox">
+         <widget class="QGroupBox" name="simulatedBox">
           <property name="geometry">
            <rect>
             <x>0</x>
@@ -115,7 +115,7 @@
             <string notr="true">border: none;</string>
            </property>
            <property name="text">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Dynamic&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Simulated&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
           </widget>
           <widget class="QLabel" name="label_3">
@@ -218,7 +218,7 @@
           <property name="title">
            <string/>
           </property>
-          <widget class="QRadioButton" name="dynamicRadioButton">
+          <widget class="QRadioButton" name="simulatedRadioButton">
            <property name="geometry">
             <rect>
              <x>20</x>
@@ -252,7 +252,7 @@
           </widget>
          </widget>
          <zorder>kinematicBox</zorder>
-         <zorder>dynamicBox</zorder>
+         <zorder>simulatedBox</zorder>
          <zorder>groupBox_5</zorder>
         </widget>
        </item>

--- a/Gems/PhysX/Code/Editor/KinematicWidget.cpp
+++ b/Gems/PhysX/Code/Editor/KinematicWidget.cpp
@@ -38,7 +38,7 @@ namespace PhysX
                 });
 
             auto comboBox = picker->GetComboBox();
-            comboBox->addItem("Dynamic");
+            comboBox->addItem("Simulated");
             comboBox->addItem("Kinematic");
 
             picker->GetEditButton()->setToolTip("Open Type dialog for a detailed description on the motion types");

--- a/Gems/PhysX/Code/Tests/Benchmarks/PhysXCharactersRagdollBenchmarks.cpp
+++ b/Gems/PhysX/Code/Tests/Benchmarks/PhysXCharactersRagdollBenchmarks.cpp
@@ -118,7 +118,7 @@ namespace PhysX::Benchmarks
         PhysX::EntityPtr m_terrainEntity;
     };
 
-    Physics::RagdollState GetTPose(const AZ::Vector3& position, Physics::SimulationType simulationType = Physics::SimulationType::Dynamic)
+    Physics::RagdollState GetTPose(const AZ::Vector3& position, Physics::SimulationType simulationType = Physics::SimulationType::Simulated)
     {
         Physics::RagdollState ragdollState;
         for (int nodeIndex = 0; nodeIndex < RagdollTestData::NumNodes; nodeIndex++)
@@ -133,7 +133,7 @@ namespace PhysX::Benchmarks
         return ragdollState;
     }
 
-    Physics::RagdollState GetTPose(Physics::SimulationType simulationType = Physics::SimulationType::Dynamic)
+    Physics::RagdollState GetTPose(Physics::SimulationType simulationType = Physics::SimulationType::Simulated)
     {
         return GetTPose(AZ::Vector3::CreateZero(), simulationType);
     }
@@ -256,7 +256,7 @@ namespace PhysX::Benchmarks
             const float x = washingMachineCentre.GetX() + RagdollConstants::WashingMachine::CylinderRadius * u * std::sin(theta);
             const float y = washingMachineCentre.GetY() + RagdollConstants::WashingMachine::CylinderRadius * u * std::cos(theta);
             const float z = washingMachineCentre.GetZ() + 1.0f + (0.3f * idx);
-            auto kinematicTPose = GetTPose(AZ::Vector3(x, y, z), Physics::SimulationType::Dynamic);
+            auto kinematicTPose = GetTPose(AZ::Vector3(x, y, z), Physics::SimulationType::Simulated);
             ragdoll->EnableSimulation(kinematicTPose);
             ragdoll->SetState(kinematicTPose);
             idx++;
@@ -292,7 +292,7 @@ namespace PhysX::Benchmarks
         ->RangeMultiplier(RagdollConstants::BenchmarkSettings::RangeMultipler)
         ->Ranges({
             {RagdollConstants::BenchmarkSettings::StartRange, RagdollConstants::BenchmarkSettings::EndRange},
-            {static_cast<int>(Physics::SimulationType::Kinematic), static_cast<int>(Physics::SimulationType::Dynamic)}
+            {static_cast<int>(Physics::SimulationType::Kinematic), static_cast<int>(Physics::SimulationType::Simulated)}
             })
         ->Unit(benchmark::kMillisecond)
         ->Iterations(RagdollConstants::BenchmarkSettings::NumIterations)

--- a/Gems/PhysX/Code/Tests/RagdollTests.cpp
+++ b/Gems/PhysX/Code/Tests/RagdollTests.cpp
@@ -44,7 +44,7 @@ namespace PhysX
         EXPECT_EQ(errorHandler.GetErrorCount(), 0);
     }
 
-    Physics::RagdollState GetTPose(Physics::SimulationType simulationType = Physics::SimulationType::Dynamic)
+    Physics::RagdollState GetTPose(Physics::SimulationType simulationType = Physics::SimulationType::Simulated)
     {
         Physics::RagdollState ragdollState;
         for (int nodeIndex = 0; nodeIndex < RagdollTestData::NumNodes; nodeIndex++)


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

This is to avoid collision with the renaming of PhysX Rigid Body to PhysX Dynamic Rigid Body.

## How was this PR tested?

Run PhysX unit tests.
Tested having a previous dynamic type in a level will correctly stay as simulated after the code change.

![image](https://user-images.githubusercontent.com/27999040/216605060-6cf9ad7d-88a5-4a2e-b9c8-3ae3b9d97269.png)

![image](https://user-images.githubusercontent.com/27999040/216607015-ab0ffc10-1999-409f-aa3c-0931f0fc997d.png)


