### PR TITLE
Fixed Prismatic joint when not using motor.

### DIFF
--- a/Gems/PhysX/Code/Source/PrismaticJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/PrismaticJointComponent.cpp
@@ -87,56 +87,59 @@ namespace PhysX
             m_jointSceneOwner = leadFollowerInfo.m_followerBody->m_sceneOwner;
         }
 
-        CachePhysXD6Joint();
-
-        JointRequestBus::Handler::BusConnect(AZ::EntityComponentIdPair(GetEntityId(), GetId()));
+        // Only connect to the JointRequest bus when it's using a PhysX D6 joint,
+        // which only happens when the "Use Motor" option is enabled.
+        // Otherwise it will use internally a PhysX prismatic joint.
+        if (TryCachePhysXD6Joint())
+        {
+            JointRequestBus::Handler::BusConnect(AZ::EntityComponentIdPair(GetEntityId(), GetId()));
+        }
     }
 
     void PrismaticJointComponent::DeinitNativeJoint()
     {
         JointRequestBus::Handler::BusDisconnect();
-        m_native = nullptr;
+        m_nativeD6Joint = nullptr;
     }
 
-    void PrismaticJointComponent::CachePhysXD6Joint()
+    bool PrismaticJointComponent::TryCachePhysXD6Joint()
     {
-        if (m_native)
+        if (m_nativeD6Joint)
         {
-            return;
+            return true;
         }
         auto* sceneInterface = AZ::Interface<AzPhysics::SceneInterface>::Get();
         AZ_Assert(sceneInterface, "No sceneInterface");
         const auto* joint = sceneInterface->GetJointFromHandle(m_jointSceneOwner, m_jointHandle);
         AZ_Assert(joint->GetNativeType() == NativeTypeIdentifiers::PrismaticJoint, "It is not PhysXPrismaticJoint");
         physx::PxJoint* native = static_cast<physx::PxJoint*>(joint->GetNativePointer());
-        physx::PxD6Joint* nativeD6 = native->is<physx::PxD6Joint>();
-        AZ_Assert(nativeD6, "It is not PxD6Joint");
-        m_native = nativeD6;
+        m_nativeD6Joint = native->is<physx::PxD6Joint>();
+        return m_nativeD6Joint != nullptr;
     }
 
     float PrismaticJointComponent::GetPosition() const
     {
         // Underlying PhysX joint is D6, but it simulates PhysXPrismatic joint.
         // The D6 joint has only X-axis unlocked, so report only X travel.
-        return m_native->getRelativeTransform().p.x;
+        return m_nativeD6Joint->getRelativeTransform().p.x;
     };
 
     float PrismaticJointComponent::GetVelocity() const
     {
         // Undelying PhysX joint is D6, but it simulates PhysXPrismatic joint.
         // The D6 joint has only X-axis unlocked, so report only X velocity.
-        return m_native->getRelativeLinearVelocity().x;
+        return m_nativeD6Joint->getRelativeLinearVelocity().x;
     };
 
     AZStd::pair<float, float> PrismaticJointComponent::GetLimits() const
     {
-        auto limits = m_native->getLinearLimit(physx::PxD6Axis::eX);
+        auto limits = m_nativeD6Joint->getLinearLimit(physx::PxD6Axis::eX);
         return AZStd::pair<float, float>(limits.lower, limits.upper);
     }
 
     AZ::Transform PrismaticJointComponent::GetTransform() const
     {
-        const auto worldFromLocal = m_native->getRelativeTransform();
+        const auto worldFromLocal = m_nativeD6Joint->getRelativeTransform();
         return AZ::Transform(
             AZ::Vector3{ worldFromLocal.p.x, worldFromLocal.p.y, worldFromLocal.p.z },
             AZ::Quaternion{ worldFromLocal.q.x, worldFromLocal.q.y, worldFromLocal.q.z, worldFromLocal.q.w },
@@ -145,12 +148,12 @@ namespace PhysX
 
     void PrismaticJointComponent::SetVelocity(float velocity)
     {
-        m_native->setDriveVelocity({ velocity, 0.0f, 0.0f }, physx::PxVec3(0.0f), true);
+        m_nativeD6Joint->setDriveVelocity({ velocity, 0.0f, 0.0f }, physx::PxVec3(0.0f), true);
     };
 
     void PrismaticJointComponent::SetMaximumForce(float force)
     {
         const physx::PxD6JointDrive drive(0.f , PX_MAX_F32, force, true);
-        m_native->setDrive(physx::PxD6Drive::eX, drive);
+        m_nativeD6Joint->setDrive(physx::PxD6Drive::eX, drive);
     };
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/PrismaticJointComponent.h
+++ b/Gems/PhysX/Code/Source/PrismaticJointComponent.h
@@ -18,7 +18,7 @@ namespace PhysX
     //! joint frames.
     class PrismaticJointComponent
         : public JointComponent
-        , public JointRequestBus::Handler
+        , protected JointRequestBus::Handler
     {
     public:
         AZ_COMPONENT(PrismaticJointComponent, "{9B34CA1B-C063-4D42-A15B-CE6CD7C828DC}", JointComponent);
@@ -33,6 +33,11 @@ namespace PhysX
             const JointMotorProperties& motorProperties);
         ~PrismaticJointComponent() = default;
 
+    protected:
+        // JointComponent overrides ...
+        void InitNativeJoint() override;
+        void DeinitNativeJoint() override;
+
         // JointRequestBus::Handler overrides ...
         float GetPosition() const override;
         float GetVelocity() const override;
@@ -41,14 +46,10 @@ namespace PhysX
         void SetMaximumForce(float force) override;
         AZStd::pair<float, float> GetLimits() const override;
 
-    protected:
-        // JointComponent overrides ...
-        void InitNativeJoint() override;
-        void DeinitNativeJoint() override;
-
     private:
-        void CachePhysXD6Joint();
+        bool TryCachePhysXD6Joint();
 
-        physx::PxD6Joint* m_native{ nullptr };
+        // D6 joint will only be used when the "Use Motor" option is enabled.
+        physx::PxD6Joint* m_nativeD6Joint{ nullptr };
     };
 } // namespace PhysX


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

## What does this PR do?

Fixes #14389

Prismatic Joint only uses native D6 joint when the "Use Motor" option is enabled, so the component has to deal with the possibility that it cannot cache a D6 joint.

## How was this PR tested?

Run PhysX unit tests.
Tested Prismatic joint with "Use Motor" enabled and disabled, Editor doesn't assert anymore.
