### PR TITLE
Potential/partial unit test fix

### DIFF
--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.cpp
@@ -555,16 +555,19 @@ namespace AzToolsFramework
         {
             delete elem.second;
         }
+        m_actions.clear();
 
         for (auto elem : m_actionContexts)
         {
             delete elem.second;
         }
+        m_actionContexts.clear();
 
         for (auto elem : m_actionContextWidgetWatchers)
         {
             delete elem.second;
         }
+        m_actionContextWidgetWatchers.clear();
     }
 
     ActionManagerOperationResult ActionManager::RegisterWidgetAction(

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManager.h
@@ -122,8 +122,7 @@ namespace AzToolsFramework
         ActionVisibility GetActionToolBarVisibility(const AZStd::string& actionIdentifier) const override;
         QWidget* GenerateWidgetFromWidgetAction(const AZStd::string& widgetActionIdentifier) override;
         void UpdateAllActionsInActionContext(const AZStd::string& actionContextIdentifier) override;
-
-        void Clear();
+        void Clear() override;
 
         AZStd::unordered_map<AZStd::string, EditorActionContext*> m_actionContexts;
         ApplicationWatcher m_applicationWatcher;

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h
@@ -74,6 +74,9 @@ namespace AzToolsFramework
         //! Update all actions that are parented to a specific action context.
         //! @param actionContextIdentifier The action context identifier for the context to update all actions for.
         virtual void UpdateAllActionsInActionContext(const AZStd::string& actionContextIdentifier) = 0;
+
+        // TODO: Give this a better name
+        virtual void Clear() = 0;
     };
 
 } // namespace AzToolsFramework

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.cpp
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/ActionManager/Action/EditorAction.cpp
@@ -63,8 +63,6 @@ namespace AzToolsFramework
 
     EditorAction::~EditorAction()
     {
-        m_action->disconnect();
-
         m_triggerBehavior = nullptr;
         m_checkStateCallback = nullptr;
         m_enabledStateCallbacks.clear();

--- a/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
+++ b/Code/Framework/AzToolsFramework/AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h
@@ -314,15 +314,22 @@ namespace UnitTest
                 auto actionManagerInterface = AZ::Interface<AzToolsFramework::ActionManagerInterface>::Get();
                 auto hotKeyManagerInterface = AZ::Interface<AzToolsFramework::HotKeyManagerInterface>::Get();
 
-                AzToolsFramework::ActionContextProperties contextProperties;
-                contextProperties.m_name = "O3DE Editor";
+                bool actionContextIsRegistered = actionManagerInterface->IsActionContextRegistered(EditorIdentifiers::MainWindowActionContextIdentifier);
+                if (!actionContextIsRegistered)
+                {
+                    AzToolsFramework::ActionContextProperties contextProperties;
+                    contextProperties.m_name = "O3DE Editor";
 
-                actionManagerInterface->RegisterActionContext(
-                    EditorIdentifiers::MainWindowActionContextIdentifier, contextProperties);
+                    actionManagerInterface->RegisterActionContext(
+                        EditorIdentifiers::MainWindowActionContextIdentifier, contextProperties);
+                }
 
                 hotKeyManagerInterface->AssignWidgetToActionContext(EditorIdentifiers::MainWindowActionContextIdentifier, m_defaultMainWindow);
 
-                AzToolsFramework::EditorEventsBus::Broadcast(&AzToolsFramework::EditorEvents::NotifyMainWindowInitialized, m_defaultMainWindow);
+                if (!actionContextIsRegistered)
+                {
+                    AzToolsFramework::EditorEventsBus::Broadcast(&AzToolsFramework::EditorEvents::NotifyMainWindowInitialized, m_defaultMainWindow);
+                }
             }
 
             SetUpEditorFixtureImpl();

--- a/Gems/PhysX/Code/Tests/PhysXEditorTest.cpp
+++ b/Gems/PhysX/Code/Tests/PhysXEditorTest.cpp
@@ -10,6 +10,7 @@
 #include <AzCore/Utils/Utils.h>
 #include <AzFramework/IO/LocalFileIO.h>
 #include <AzTest/GemTestEnvironment.h>
+#include <AzToolsFramework/ActionManager/Action/ActionManagerInternalInterface.h>
 #include <AzToolsFramework/Application/ToolsApplication.h>
 #include <AzToolsFramework/UnitTest/AzToolsFrameworkTestHelpers.h>
 #include <ComponentDescriptors.h>
@@ -99,6 +100,10 @@ namespace Physics
             AZ::Data::AssetManager::Instance().DispatchEvents();
             m_physXSystem->Shutdown();
             m_physXSystem.reset();
+
+            // Clear the action manager before destroying the application
+            auto actionManagerInternalInterface = AZ::Interface<AzToolsFramework::ActionManagerInternalInterface>::Get();
+            actionManagerInternalInterface->Clear();
         }
 
         /// Allows derived environments to override to perform additional steps after destroying the application.


### PR DESCRIPTION
## What does this PR do?

This seems to work, basically I changed the test environment to clear the action manager before destroying the application. We'd need to do this for AtomLyIntegration as well, and potentially a better spot would be to be in the base tools test environment that they both derive from.

## How was this PR tested?

Ran the PhysX.Editor tests and they all passed!
