### PR TITLE
Implementing Minimum loveable product for Project Export CLI, with 2 helper APIs

### DIFF
--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -159,8 +159,7 @@ def execute_python_script(target_script_path: pathlib.Path or str, o3de_context:
     #load the target script as a module, set the context, and then execute
     logger.info(f"Begin loading script '{target_script_path}'...")
 
-    utils.load_and_execute_script(target_script_path, context_attribute_name="o3de_context", context = o3de_context)
-    return 0
+    return utils.load_and_execute_script(target_script_path, context_attribute_name="o3de_context", context = o3de_context)
 
 
 #Export Script entry point

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -55,7 +55,8 @@ def process_command(args: list,
     """
     Wrapper for subprocess.Popen, which handles polling the process for logs, reacting to failure, and cleaning up the process.
     :param args: A list of space separated strings which build up the entire command to run. Similar to the command list of subprocess.Popen
-    :param cwd: The desired current working directory of the command. Useful for commands which require a differing starting environment.
+    :param cwd: (Optional) The desired current working directory of the command. Useful for commands which require a differing starting environment.
+    :param env: (Optional) Environment to use when processing this command.
     """
     if len(args) == 0:
         logging.error("function `process_command` must be supplied a non-empty list of arguments")

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -133,6 +133,7 @@ def process_command(args: list,
 
     try:
         with Popen(args, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE) as process:
+            logger.info(f"Running command: {args}")
             poll_process(process)
             
             stderr = cleanup_process(process)

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -116,9 +116,9 @@ def add_parser_args(parser) -> None:
     parser.add_argument('-pp', '--project-path', type=pathlib.Path, required=False,
                         help="Project to export. If not supplied, it will be inferred by the export script.")
     
-    parser.add_argument('-v', '--verbosity', dest='log_level', default='ERROR',
+    parser.add_argument('-ll', '--log-level', default='ERROR',
                         choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-                        help="Set the log verbosity level")
+                        help="Set the log level")
     
     parser.set_defaults(func=_run_export_script, accepts_partial_args=True)
     

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -72,8 +72,8 @@ def execute_python_script(target_script_path: pathlib.Path or str, o3de_context:
     """
     #Prepare import paths for script ease of use
     #Allow for imports from calling script and the target script's local directory
-    utils.add_to_system_path(pathlib.Path(__file__))
-    utils.add_to_system_path(target_script_path)
+    utils.prepend_to_system_path(pathlib.Path(__file__))
+    utils.prepend_to_system_path(target_script_path)
 
     logging.info(f"Begin loading script '{target_script_path}'...")
     

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -106,7 +106,7 @@ def process_command(args: list,
     :param args: A list of space separated strings which build up the entire command to run. Similar to the command list of subprocess.Popen
     :param cwd: The desired current working directory of the command. Useful for commands which require a differing starting environment.
     """
-    return utils.CLICommand(args, cwd, env, logger).run()
+    return utils.CLICommand(args, cwd, logger, env=env).run()
 
 
 def execute_python_script(target_script_path: pathlib.Path or str, o3de_context: O3DEScriptExportContext = None) -> int:
@@ -134,7 +134,7 @@ def _run_export_script(args: argparse, passthru_args: list) -> int:
     export_script_path = args.export_script
     try:
         validate_export_script(export_script_path)
-        project_path = utils.infer_project_path(export_script_path, args.project_path)
+        project_path = utils.get_project_path_from_file (export_script_path, args.project_path)
         
         #prepare O3DE arguments for script
         o3de_context = O3DEScriptExportContext(export_script_path= export_script_path,

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -37,7 +37,6 @@ class O3DEScriptExportContext(object):
         self._logger = logger
         self._args = args
         object.__setattr__(self, "_read_only_names", set(["_export_script_path", "export_script_path",
-                                                          "_read_only_attribute_names",
                                                           "_project_path", "project_path",
                                                           "_engine_path", "engine_path",
                                                           "_logger", "logger",

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -12,10 +12,6 @@ import pathlib
 import sys
 
 from o3de import manifest, utils
-from o3de.validation import validate_export_script
-
-logger = logging.getLogger(__name__)
-logging.basicConfig(format=utils.LOG_FORMAT)
 
 class O3DEScriptExportContext(object):
     """
@@ -26,20 +22,12 @@ class O3DEScriptExportContext(object):
     def __init__(self, export_script_path: pathlib.Path,
                        project_path: pathlib.Path,
                        engine_path: pathlib.Path,
-                       logger: logging.Logger,
                        args: list = []) -> None:
-        object.__setattr__(self,"_read_only_names", set())
         self._export_script_path = export_script_path
         self._project_path = project_path
         self._engine_path = engine_path
-        self._logger = logger
         self._args = args
-        object.__setattr__(self, "_read_only_names", set(["_export_script_path", "export_script_path",
-                                                          "_project_path", "project_path",
-                                                          "_engine_path", "engine_path",
-                                                          "_logger", "logger",
-                                                          "_args", "args"]))
-
+        
     @property
     def export_script_path(self) -> pathlib.Path:
         """The absolute path to the export script being run."""
@@ -56,46 +44,9 @@ class O3DEScriptExportContext(object):
         return self._engine_path
     
     @property
-    def logger(self) -> logging.Logger:
-        """Instance of the logger for export_project.py that export scripts can use for consistent logging."""
-        return self._logger
-    
-    @property
     def args(self) -> list:
         """A list of the CLI arguments that were unparsed, and passed through for further processing, if necessary."""
         return self._args
-    
-
-    def __setattr__(self, attr, value) -> None:
-        if attr in self._read_only_names:
-            logger.error(f"Cannot set '{attr}' to '{value}', it is a read-only parameter!")
-        else:
-            self.__dict__[attr] = value
-    def __getattr__(self, attr) -> None:
-        if attr in self.__dict__: 
-            return self.__dict__[attr]
-        else:
-            logger.error(f"Attribute '{attr}' does not exist in export parameters!")
-            return None
-
-    def mark_readonly(self, *params:str) -> None:
-        """Provide the string names of context parameters/variables that should be read only. """
-        for p in params:
-            self._read_only_names.add(p)
-
-    def mark_writeable(self, *params:str) -> None:
-        """Provide the string names of context parameters/variables that should be writeable. """
-        for p in params:
-            if p in self._read_only_names:
-                self._read_only_names.remove(p)
-    
-    def set_params(self, **kwargs) -> None:
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-
-    def as_dict(self) -> dict:
-        return self.__dict__
-
 
 #Helper API
 def process_command(args: list,
@@ -106,7 +57,7 @@ def process_command(args: list,
     :param args: A list of space separated strings which build up the entire command to run. Similar to the command list of subprocess.Popen
     :param cwd: The desired current working directory of the command. Useful for commands which require a differing starting environment.
     """
-    return utils.CLICommand(args, cwd, logger, env=env).run()
+    return utils.CLICommand(args, cwd, logging.getLogger(__name__), env=env).run()
 
 
 def execute_python_script(target_script_path: pathlib.Path or str, o3de_context: O3DEScriptExportContext = None) -> int:
@@ -122,32 +73,37 @@ def execute_python_script(target_script_path: pathlib.Path or str, o3de_context:
     utils.add_to_system_path(pathlib.Path(__file__))
     utils.add_to_system_path(target_script_path)
     
-    logger.info(f"Begin loading script '{target_script_path}'...")
+    logging.info(f"Begin loading script '{target_script_path}'...")
 
-    return utils.load_and_execute_script(target_script_path, o3de_context = o3de_context)
+    return utils.load_and_execute_script(target_script_path, o3de_context = o3de_context, o3de_logger=logging.getLogger(__name__))
 
 
 #Export Script entry point
 def _run_export_script(args: argparse, passthru_args: list) -> int:
-    logger.setLevel(args.log_level)
-
+    logging.basicConfig(level = args.log_level, format=utils.LOG_FORMAT)
+    logging.getLogger(__name__).setLevel(args.log_level)
+    
     export_script_path = args.export_script
-    try:
-        validate_export_script(export_script_path)
-        project_path = utils.get_project_path_from_file(export_script_path, args.project_path)
-        
-        #prepare O3DE arguments for script
-        o3de_context = O3DEScriptExportContext(export_script_path= export_script_path,
-                                            project_path = project_path,
-                                            engine_path = manifest.get_project_engine_path(project_path),
-                                            logger= logger,
-                                            args = passthru_args)
-
-        return execute_python_script(export_script_path, o3de_context)
-
-    except Exception as err:
-        logger.error(str(err))
+    
+    if not export_script_path.is_file() or export_script_path.suffix != '.py':
+        logging.error(f"Export script path unrecognized: '{export_script_path}'. Please provide a file path to an existing python script with '.py' extension.")
         return 1
+
+    project_path = utils.get_project_path_from_file(export_script_path, args.project_path)
+
+    if not project_path:
+        if args.project_path:
+            logging.error(f"Project path '{project_path}' is invalid: does not contain a project.json file.")
+        else:
+            logging.error(f"Unable to find project folder associated with file '{target_file_path}'. Please specify using --project-path, or ensure the file is inside a project folder.")
+        return 1
+    
+    #prepare O3DE arguments for script
+    o3de_context = O3DEScriptExportContext(export_script_path= export_script_path,
+                                        project_path = project_path,
+                                        engine_path = manifest.get_project_engine_path(project_path),
+                                        args = passthru_args)
+    return execute_python_script(export_script_path, o3de_context)
 
 
 #Argument handling
@@ -166,17 +122,3 @@ def add_parser_args(parser) -> None:
 def add_args(subparsers) -> None:
     export_subparser = subparsers.add_parser('export-project')
     add_parser_args(export_subparser)
-
-
-def main() -> None:
-    """
-    Runs export_project.py as a standalone script
-    """
-    parser = argparse.ArgumentParser()
-    add_parser_args(parser)
-    args = parser.parse_known_args()
-    ret = args.func(args) if hasattr(args, 'func') else 1
-    sys.exit(ret)
-
-if __name__ == "__main__":
-    main()

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -164,7 +164,6 @@ def execute_python_script(target_script_path: pathlib.Path or str, o3de_context:
     utils.add_to_system_path(pathlib.Path(__file__))
     utils.add_to_system_path(target_script_path)
     
-    #load the target script as a module, set the context, and then execute
     logger.info(f"Begin loading script '{target_script_path}'...")
 
     return utils.load_and_execute_script(target_script_path, o3de_context = o3de_context)

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -15,117 +15,181 @@ from subprocess import Popen, PIPE
 import sys
 
 from o3de import manifest, utils
-logger = logging.getLogger('o3de.export_project')
+from o3de.validation import *
+
+#grab process utilities from Tools/LyTestTools
+sys.path.insert(0, os.path.join(os.path.dirname(__file__),"..", "..","..","Tools","LyTestTools","ly_test_tools","environment"))
+import process_utils as putil
+
+logger = logging.getLogger(__name__)
 logging.basicConfig(format=utils.LOG_FORMAT)
 
+READ_ONLY_PARAMS = ["export_script", "project_path", "engine_path", "logger", "args"]
+LOGGER_PARAM = "logger"
 
-class o3de_export_parameters(object):
-    pass
+# a singleton which manages all parameters for the duration of the export process
+# the export script and any script it calls via execute_python_script have access to these params 
+class O3DEScriptExportParameters(utils.BaseSingleton):
+    _attributes = {}
+    _read_only_attribute_names = set()
+
+    def __setattr__(self, attr, value):
+        if attr in O3DEScriptExportParameters._read_only_attribute_names:
+            logger.error(f"Cannot set '{attr}' to '{value}', it is a read-only parameter!")
+        else:
+            O3DEScriptExportParameters._attributes[attr] = value
+    def __getattr__(self, attr):
+        if attr in O3DEScriptExportParameters._attributes: 
+            return O3DEScriptExportParameters._attributes[attr]
+        else:
+            logger.error(f"Attribute '{attr}' does not exist in export parameters!")
+            return None
+    def as_dict(self):
+        return O3DEScriptExportParameters._attributes
+
 
 #Helper API
+def mark_readonly_params(*params:str):
+    for p in params:
+        O3DEScriptExportParameters._read_only_attribute_names.add(p)
+
+def mark_writeable_params(*params:str):
+    for p in params:
+        if p in O3DEScriptExportParameters._read_only_attribute_names:
+            O3DEScriptExportParameters._read_only_attribute_names.remove(p)
+
 def process_command(args: list,
                     cwd: pathlib.Path = None,
                     env: os._Environ = None,
-                    show_logging: bool = True):
-    process = Popen(args, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE)
+                    show_logging: bool = True) -> int:
+    
+    logger = O3DEScriptExportParameters().logger
+    
+    def poll_process(process):
+        #read any log lines coming from subprocess
+        while process.poll() is None:
+            line = process.stdout.readline()
+            if not line: break
+            log_line = line.decode('utf-8')
+            logger.info(log_line)
+    
+    def cleanup_process(process) -> str:
+        #flush remaining log lines
+        log_lines = process.stdout.read().decode('utf-8')
+        logger.info(log_lines)
+        stderr = process.stderr.read()
 
-    #read any log lines coming from subprocess
-    while process.poll() is None:
-        line = process.stdout.readline()
-        if not line: break
-
-        log_line = line.decode('utf-8')
-        if show_logging:
-            print(log_line)
+        logger.info("Finishing current command...")
+        putil._safe_kill_processes([process])
         
-        logger.info(log_line)
-    
-    #flush out any remaining text from stdout
-    log_lines = process.stdout.read().decode('utf-8')
-    if show_logging:
-        print(log_lines)
-    
-    stderr = process.stderr.read()
+        return stderr
 
-    #update this to safely kill a process
-    process.kill()
+    try:
+        with Popen(args, cwd=cwd, env=env, stdout=PIPE, stderr=PIPE) as process:
+            poll_process(process)
+            
+            stderr = cleanup_process(process)
 
-    ret = process.returncode
-
-    #if the process returns a FAILURE code (>0)
-    if bool(ret):
-        logger.error(stderr.decode('utf-8'))
+            ret = process.returncode            
+            if stderr:
+                # bool(ret) --> if the process returns a FAILURE code (>0)
+                logger_func = logger.error if bool(ret) else logger.warning
+                logger_func(stderr.decode('utf-8'))
+    except RuntimeError as re:
+        logger.error(re)
+        raise re
+        
 
     return ret
 
 
+def execute_python_script(target_script_path: pathlib.Path or str, override_logger=False, **kwargs) -> int:
+    if type(target_script_path) == str:
+        target_script_path = pathlib.Path(target_script_path)
 
-#Export Script entry  point
-def _run_export_script(args: argparse, passthru_args: list) -> int:
-    def validate_export_script(script_path):
-        if not os.path.isfile(script_path):
-            logger.error(f"The export script '{script_path}' does not exist!")
-            return False
-
-        if script_path.suffix != '.py':
-            logger.error("A Python script with .py extension must be supplied for --export-script parameter!")
-            return False
-        return True
-    
-    def validate_project_path(project_path):
-        if not os.path.isdir(project_path):
-            logger.error(f"Project path is not a directory!")
-            return False
-
-        if not os.path.isfile(os.path.join(project_path, 'project.json')):
-            logger.error("Project path is invalid: does not contain a project.json file!")
-            return False
-        return True
-
-
-    export_script_path = args.export_script
-    if not validate_export_script(export_script_path):
-        print("Failed to process export script.")
-        return 1
-    
- 
-    project_path = args.project_path
-    if project_path is not None:
-        if not validate_project_path(project_path):
-            print(f"Specified Project Path '{project_path}' is not valid.")
-            return 1
-    else:
-        project_path = utils.find_ancestor_dir_containing_file(pathlib.PurePath('project.json'), export_script_path)
-        if project_path is None:
-            logger.error("Unable to find project folder associated with export script. Please specify using --project-path, or select an export script inside a project folder.")
-            return 1
-
-    script_name = os.path.basename(export_script_path)
-    print(f"Begin loading export script '{script_name}'...")
-    
+    script_name = os.path.basename(target_script_path)
+    logger.info(f"Begin loading script '{script_name}'...")
 
     #Prepare import paths for export script ease of use
-    #Allow for imports from O3DE CLI and the script's local directory 
-    sys.path.insert(0, os.path.dirname(__file__))
-    sys.path.insert(0, os.path.split(export_script_path)[0])
+    #Allow for imports from calling script and the target script's local directory
 
-    #prepare O3DE arguments for script
-    o3de_export = o3de_export_parameters()
-    o3de_export.project_path = project_path
-    o3de_export.engine_path = manifest.get_project_engine_path(project_path)
-    o3de_export.args = passthru_args 
+    current_folder_path = os.path.dirname(__file__)
+    if current_folder_path not in sys.path: 
+        sys.path.insert(0, current_folder_path)
+
+    target_folder_path = os.path.split(target_script_path)[0]    
+    if target_folder_path not in sys.path:
+        sys.path.insert(0, target_folder_path)
 
 
-    #execute the script
-    spec = importlib.util.spec_from_file_location(script_name, export_script_path)
+    spec = importlib.util.spec_from_file_location(script_name, target_script_path)
     script_module = importlib.util.module_from_spec(spec)
     sys.modules[script_name] = script_module
-    script_module.o3de_export = o3de_export
-    spec.loader.exec_module(script_module)
+
+    o3de_export = O3DEScriptExportParameters()
+    for key,value in kwargs.items():
+        setattr(o3de_export, key, value)
+
+    if override_logger:
+        parent_logger = o3de_export.logger
+        mark_writeable_params(LOGGER_PARAM)
+        o3de_export.logger = parent_logger.getChild(script_name.replace(".py", ""))
+        mark_readonly_params(LOGGER_PARAM)
+
+    try:
+        spec.loader.exec_module(script_module)
+    except RuntimeError as re:
+        logger.error(f"Failed to run script '{target_script_path}': \nException: "+ str(re))
+        return 1
+    finally:
+        if override_logger:
+            mark_writeable_params(LOGGER_PARAM)
+            o3de_export.logger = parent_logger
+            mark_readonly_params(LOGGER_PARAM)
 
     return 0
 
+#Export Script entry  point
+def _run_export_script(args: argparse, passthru_args: list) -> int:
+    def get_project_path(args):
+        project_path = args.project_path
+        if not project_path:
+            project_path = utils.find_ancestor_dir_containing_file(pathlib.PurePath('project.json'), export_script_path)
+            if not project_path:
+                logger.error("Unable to find project folder associated with export script. Please specify using --project-path, or select an export script inside a project folder.")
+                return None   
+        
+        if not valid_o3de_project_path(project_path):
+            logger.error(f"Specified Project Path '{project_path}' is not valid.")
+            return None
+        return project_path
+        
+   
+    logger.setLevel(args.log_level)
 
+    export_script_path = args.export_script
+    if not valid_export_script(export_script_path):
+        logger.error("Failed to process export script.")
+        return 1
+ 
+    project_path = get_project_path(args)
+    if not project_path:
+        return 1
+    
+    #prepare O3DE arguments for script
+    o3de_export = O3DEScriptExportParameters()
+    
+    o3de_export.project_path = project_path
+    o3de_export.engine_path = manifest.get_project_engine_path(project_path)
+    o3de_export.logger = logger
+    o3de_export.args = passthru_args 
+
+    mark_readonly_params(*READ_ONLY_PARAMS)
+
+    ret = execute_python_script(export_script_path)
+
+    logger.info("Finished exporting")
+    return ret
 
 
 #Argument handling
@@ -133,14 +197,16 @@ def add_parser_args(parser):
     parser.add_argument('-es', '--export-script', type=pathlib.Path, required=True, help="An external Python script to run")
     parser.add_argument('-pp', '--project-path', type=pathlib.Path, required=False,
                         help="Project to export. If not supplied, it will be inferred by the export script.")
-    parser.set_defaults(func=_run_export_script)
-
+    
+    parser.add_argument('-v', '--verbosity', dest='log_level', default='ERROR',
+                        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+                        help="Set the log verbosity level")
+    
+    parser.set_defaults(func=_run_export_script, accepts_partial_args=True)
+    
 
 def add_args(subparsers):
-    """
-    <TODO: INFO HERE>
-    """
-    export_subparser = subparsers.add_parser('export_project')
+    export_subparser = subparsers.add_parser('export-project')
     add_parser_args(export_subparser)
 
 

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -36,12 +36,12 @@ class O3DEScriptExportContext(object):
         self._engine_path = engine_path
         self._logger = logger
         self._args = args
-        object.__setattr__(self, "_read_only_names", set(["_export_script_path",
+        object.__setattr__(self, "_read_only_names", set(["_export_script_path", "export_script_path",
                                                           "_read_only_attribute_names",
-                                                          "_project_path",
-                                                          "_engine_path",
-                                                          "_logger",
-                                                          "_args"]))
+                                                          "_project_path", "project_path",
+                                                          "_engine_path", "engine_path",
+                                                          "_logger", "logger",
+                                                          "_args", "args"]))
 
     @property
     def export_script_path(self):
@@ -159,7 +159,7 @@ def execute_python_script(target_script_path: pathlib.Path or str, o3de_context:
     #load the target script as a module, set the context, and then execute
     logger.info(f"Begin loading script '{target_script_path}'...")
 
-    return utils.load_and_execute_script(target_script_path, context_attribute_name="o3de_context", context = o3de_context)
+    return utils.load_and_execute_script(target_script_path, o3de_context = o3de_context)
 
 
 #Export Script entry point

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -105,6 +105,7 @@ def process_command(args: list,
                     cwd: pathlib.Path = None,
                     env: os._Environ = None) -> int:
     """
+    Wrapper for subprocess.Popen, which handles polling the process for logs, reacting to failure, and cleaning up the process.
     :param args: A list of space separated strings which build up the entire command to run. Similar to the command list of subprocess.Popen
     :param cwd: The desired current working directory of the command. Useful for commands which require a differing starting environment.
     """
@@ -148,6 +149,12 @@ def process_command(args: list,
 
 
 def execute_python_script(target_script_path: pathlib.Path or str, o3de_context: O3DEScriptExportContext = None) -> int:
+    """
+    Execute a new python script, using new or existing O3DEScriptExportContexts to streamline communication between multiple scripts
+    :param target_script_path: The path to the python script to run.
+    :param o3de_context: An O3DEScriptExportContext object that contains necessary data to run the target script. The target script can also write to this context to pass back to its caller.
+    :return: return code upon success or failure
+    """
     if isinstance(target_script_path, str):
         target_script_path = pathlib.Path(target_script_path)
 
@@ -183,9 +190,7 @@ def _run_export_script(args: argparse, passthru_args: list) -> int:
                                           logger= logger,
                                           args = passthru_args)
 
-    ret = execute_python_script(export_script_path, o3de_context)
-
-    return ret
+    return execute_python_script(export_script_path, o3de_context)
 
 
 #Argument handling

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -134,7 +134,7 @@ def _run_export_script(args: argparse, passthru_args: list) -> int:
     export_script_path = args.export_script
     try:
         validate_export_script(export_script_path)
-        project_path = utils.get_project_path_from_file (export_script_path, args.project_path)
+        project_path = utils.get_project_path_from_file(export_script_path, args.project_path)
         
         #prepare O3DE arguments for script
         o3de_context = O3DEScriptExportContext(export_script_path= export_script_path,

--- a/scripts/o3de/o3de/export_project.py
+++ b/scripts/o3de/o3de/export_project.py
@@ -178,8 +178,9 @@ def _run_export_script(args: argparse, passthru_args: list) -> int:
         logger.error(reason)
         return 1
  
-    project_path = utils.infer_project_path(export_script_path, args.project_path)
+    project_path, reason = utils.infer_project_path(export_script_path, args.project_path)
     if not project_path:
+        logger.error(reason)
         return 1
     
     #prepare O3DE arguments for script

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -60,6 +60,16 @@ class VerbosityAction(argparse.Action):
         elif count == 1:
             log.setLevel(logging.INFO)
 
+class MetaSingleton(type):
+    _instances = {}
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(MetaSingleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]
+
+class BaseSingleton(metaclass=MetaSingleton):
+    pass
+
 
 def add_verbosity_arg(parser: argparse.ArgumentParser) -> None:
     """

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -163,7 +163,7 @@ def load_and_execute_script(script_path: pathlib.Path or str, **context_variable
 
     try:
         spec.loader.exec_module(script_module)
-    except RuntimeError as re:
+    except Exception as err:
         logger.error(f"Failed to run script '{script_path}'. Here is the stacktrace: ", exc_info=True)
         return 1
 
@@ -456,7 +456,7 @@ def find_ancestor_dir_containing_file(target_file_name: pathlib.PurePath, start_
     ancestor_file = find_ancestor_file(target_file_name, start_path, max_scan_up_range)
     return ancestor_file.parent if ancestor_file else None
 
-def get_project_path_from_file(target_file_path: pathlib.Path, supplied_project_path: pathlib.Path = None) -> pathlib.Path:
+def get_project_path_from_file(target_file_path: pathlib.Path, supplied_project_path: pathlib.Path = None) -> pathlib.Path or None:
     """
     Based on a file supplied by the user, and optionally a differing project path, determine and validate a proper project path, if any.
     :param target_file_path: A user supplied file path
@@ -466,11 +466,10 @@ def get_project_path_from_file(target_file_path: pathlib.Path, supplied_project_
     project_path = supplied_project_path
     if not project_path:
         project_path = find_ancestor_dir_containing_file(pathlib.PurePath('project.json'), target_file_path)
-        if not project_path:
-            raise valid.InvalidProjectPathException(f"Unable to find project folder associated with file '{target_file_path}'. Please specify using --project-path, or ensure the file is inside a project folder.")
     
-    valid.validate_o3de_project_path(project_path)
-    
+    if not valid.valid_o3de_project_json(project_path / 'project.json'):
+        return None
+
     return project_path
 
 def get_gem_names_set(gems: list) -> set:

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -69,20 +69,22 @@ def add_to_system_path(path: pathlib.Path):
     if folder_path not in sys.path:
         sys.path.insert(0, folder_path)
 
-def load_and_execute_script(script_path: pathlib.Path, context_attribute_name: str, context: object) -> int:
+def load_and_execute_script(script_path: pathlib.Path, **context_variables) -> int:
     """
     For a given python script, use importlib to load the script spec and module to execute it later
 
     :param script_name: The string name of the script without the .py extension
-    :param context_attribute_name: This is the name by which the context of the script is accessed. It is setup as a module attribute, so it's accessible using '.' syntax.
-    :param context: The context object which stores all relevant values for the execution of the script
+    :param context_variables: A series of keyword arguments which specify the context for the script before it is run.
     :return: return code indicating succes or failure of script
     """
     script_name = script_path.name
     spec = importlib.util.spec_from_file_location(script_name, script_path)
     script_module = importlib.util.module_from_spec(spec)
     sys.modules[script_name] = script_module
-    setattr(script_module, context_attribute_name, context)
+
+    #inject the script module with relevant context variables
+    for key, value in context_variables.items():
+        setattr(script_module, key, value)
 
     try:
         spec.loader.exec_module(script_module)

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -110,7 +110,7 @@ class CLICommand(object):
         ret = 1
         try:
             with Popen(self.args, cwd=self.cwd, env=self.env, stdout=PIPE, stderr=PIPE) as process:
-                self.logger.info(f"Running command: {self.args}")
+                self.logger.info(f"Running process '{self.args[0]}' with PID({process.pid}): {self.args}")
                 
                 self._poll_process(process)
                 stderr = self._cleanup_process(process)
@@ -650,7 +650,7 @@ def safe_kill_processes(*processes: List[Popen], process_logger: logging.Logger 
     """
     def on_terminate(proc) -> None:
         try:
-            process_logger.info(f"process '{proc.args[0]}' with id '{proc.pid}' terminated with exit code {proc.returncode}")
+            process_logger.info(f"process '{proc.args[0]}' with PID({proc.pid}) terminated with exit code {proc.returncode}")
         except psutil.AccessDenied:
             process_logger.warning("Termination failed, Access Denied with stacktrace:", exc_info=True)
         except psutil.NoSuchProcess:
@@ -661,7 +661,7 @@ def safe_kill_processes(*processes: List[Popen], process_logger: logging.Logger 
     
     for proc in processes:
         try:
-            process_logger.info(f"Terminating process '{proc.args[0]}' with id '{proc.pid}'")
+            process_logger.info(f"Terminating process '{proc.args[0]}' with PID({proc.pid})")
             proc.kill()
         except psutil.AccessDenied:
             process_logger.warning("Termination failed, Access Denied with stacktrace:", exc_info=True)

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -66,11 +66,18 @@ class VerbosityAction(argparse.Action):
             log.setLevel(logging.INFO)
 
 class CLICommand(object):
+    """
+    CLICommand is an interface for storing CLI commands as list of string arguments to run later in a script.
+    A current working directory, pre-existing OS environment, and desired logger can also be specified.
+    To execute a command, use the run() function.
+
+    This class is responsible for starting a new process, polling it for updates and logging, and safely terminating it.
+    """
     def __init__(self, 
                 args: list,
                 cwd: pathlib.Path,
-                env: os._Environ,
-                logger: logging.Logger) -> None:
+                logger: logging.Logger,
+                env: os._Environ=None) -> None:
         self.args = args
         self.cwd = cwd
         self.env = env
@@ -449,7 +456,7 @@ def find_ancestor_dir_containing_file(target_file_name: pathlib.PurePath, start_
     ancestor_file = find_ancestor_file(target_file_name, start_path, max_scan_up_range)
     return ancestor_file.parent if ancestor_file else None
 
-def infer_project_path(target_file_path: pathlib.Path, supplied_project_path: pathlib.Path = None) -> pathlib.Path:
+def get_project_path_from_file(target_file_path: pathlib.Path, supplied_project_path: pathlib.Path = None) -> pathlib.Path:
     """
     Based on a file supplied by the user, and optionally a differing project path, determine and validate a proper project path, if any.
     :param target_file_path: A user supplied file path

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -126,9 +126,9 @@ class CLICommand(object):
             raise err
         return ret
 
-def add_to_system_path(file_path: pathlib.Path or str) -> None:
+def prepend_to_system_path(file_path: pathlib.Path or str) -> None:
     """
-    Adjust the running script's imported system module paths. Useful for loading scripts in a foreign directory
+    Prepend the running script's imported system module paths. Useful for loading scripts in a foreign directory
     :param path: The file path of the desired script to load
     :return: None
     """

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -73,7 +73,7 @@ def load_and_execute_script(script_path: pathlib.Path, **context_variables) -> i
     """
     For a given python script, use importlib to load the script spec and module to execute it later
 
-    :param script_name: The string name of the script without the .py extension
+    :param script_path: The path to the python script to run
     :param context_variables: A series of keyword arguments which specify the context for the script before it is run.
     :return: return code indicating succes or failure of script
     """

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -26,7 +26,7 @@ from packaging.specifiers import SpecifierSet
 
 from o3de import gitproviderinterface, github_utils, validation as valid
 from subprocess import Popen, PIPE
-from typing import Tuple, List
+from typing import List
 
 LOG_FORMAT = '[%(levelname)s] %(name)s: %(message)s'
 

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -77,6 +77,9 @@ def load_and_execute_script(script_path: pathlib.Path, **context_variables) -> i
     :param context_variables: A series of keyword arguments which specify the context for the script before it is run.
     :return: return code indicating succes or failure of script
     """
+
+    
+    #load the target script as a module, set the context, and then execute
     script_name = script_path.name
     spec = importlib.util.spec_from_file_location(script_name, script_path)
     script_module = importlib.util.module_from_spec(spec)

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -123,6 +123,7 @@ class CLICommand(object):
                     logger_func = self.logger.error if bool(ret) else self.logger.warning
                     logger_func(stderr.decode('utf-8', 'ignore'))
         except Exception as err:
+            self.logger.error(err)
             raise err
         return ret
 
@@ -646,6 +647,7 @@ def safe_kill_processes(*processes: List[Popen], process_logger: logging.Logger 
     Kills a given process without raising an error
 
     :param processes: An iterable of processes to kill
+    :param process_logger: (Optional) logger to use
     """
     def on_terminate(proc) -> None:
         try:

--- a/scripts/o3de/o3de/utils.py
+++ b/scripts/o3de/o3de/utils.py
@@ -385,7 +385,7 @@ def find_ancestor_dir_containing_file(target_file_name: pathlib.PurePath, start_
     return ancestor_file.parent if ancestor_file else None
 
 
-def infer_project_path(target_file_path: pathlib.Path, supplied_project_path: pathlib.Path = None) -> pathlib.Path or None:
+def infer_project_path(target_file_path: pathlib.Path, supplied_project_path: pathlib.Path = None) -> Tuple[pathlib.Path or None, str]:
     """
     Based on a file supplied by the user, and optionally a differing project path, determine and validate a proper project path, if any.
     :param target_file_path: A user supplied file path
@@ -396,14 +396,12 @@ def infer_project_path(target_file_path: pathlib.Path, supplied_project_path: pa
     if not project_path:
         project_path = find_ancestor_dir_containing_file(pathlib.PurePath('project.json'), target_file_path)
         if not project_path:
-            logger.error(f"Unable to find project folder associated with file '{target_file_path}'. Please specify using --project-path, or ensure the file is inside a project folder.")
-            return None   
+            return None, f"Unable to find project folder associated with file '{target_file_path}'. Please specify using --project-path, or ensure the file is inside a project folder." 
     
     isValid, reason = valid.valid_o3de_project_path(project_path)
     if not isValid:
-        logger.error(reason)
-        return None
-    return project_path
+        return None, reason
+    return project_path, ""
 
 def get_gem_names_set(gems: list) -> set:
     """
@@ -587,9 +585,9 @@ def safe_kill_processes(*processes):
         except psutil.AccessDenied:
             logger.warning("Termination failed, Access Denied with stacktrace:", exc_info=True)
         except psutil.NoSuchProcess:
-            logger.debug("Termination request ignored, process was already terminated during iteration with stacktrace:", exc_info=True)
+            logger.warning("Termination request ignored, process was already terminated during iteration with stacktrace:", exc_info=True)
         except Exception:  # purposefully broad
-            logger.debug("Unexpected exception ignored while terminating process, with stacktrace:", exc_info=True)
+            logger.error("Unexpected exception ignored while terminating process, with stacktrace:", exc_info=True)
 
     def on_terminate(proc):
         try:
@@ -597,13 +595,13 @@ def safe_kill_processes(*processes):
         except psutil.AccessDenied:
             logger.warning("Termination failed, Access Denied with stacktrace:", exc_info=True)
         except psutil.NoSuchProcess:
-            logger.debug("Termination request ignored, process was already terminated during iteration with stacktrace:", exc_info=True)
+            logger.warning("Termination request ignored, process was already terminated during iteration with stacktrace:", exc_info=True)
 
     try:
         psutil.wait_procs(processes, timeout=30, callback=on_terminate)
     except psutil.AccessDenied:
         logger.warning("Termination failed, Access Denied with stacktrace:", exc_info=True)
     except psutil.NoSuchProcess:
-        logger.debug("Termination request ignored, process was already terminated during iteration with stacktrace:", exc_info=True)
+        logger.warning("Termination request ignored, process was already terminated during iteration with stacktrace:", exc_info=True)
     except Exception:  # purposefully broad
-        logger.debug("Unexpected exception while waiting for processes to terminate, with stacktrace:", exc_info=True)
+        logger.error("Unexpected exception while waiting for processes to terminate, with stacktrace:", exc_info=True)

--- a/scripts/o3de/o3de/validation.py
+++ b/scripts/o3de/o3de/validation.py
@@ -126,19 +126,25 @@ def valid_o3de_restricted_json(file_name: str or pathlib.Path) -> bool:
             return False
     return True
 
-def validate_export_script(script_path: pathlib.Path) -> Tuple[bool, str]:
+class InvalidExportScriptException(Exception):
+    pass
+
+def validate_export_script(script_path: pathlib.Path) -> bool:
     if not pathlib.Path.is_file(script_path):
-        return False, f"The export script '{script_path}' does not exist."
+        raise InvalidExportScriptException(f"The export script '{script_path}' does not exist.")
 
     if script_path.suffix != '.py':
-        return False, f"The provided export script path '{script_path}' does not have a '.py' extension. A Python script with .py extension must be supplied."
-    return True, ""
+        raise InvalidExportScriptException(f"The provided export script path '{script_path}' does not have a '.py' extension. A Python script with .py extension must be supplied.")
+    return True
 
 
-def valid_o3de_project_path(project_path: pathlib.Path) -> Tuple[bool, str]:
+class InvalidProjectPathException(Exception):
+    pass
+
+def validate_o3de_project_path(project_path: pathlib.Path) -> bool:
     if not pathlib.Path.is_dir(project_path):
-        return False, f"Project path '{project_path}' is not a directory! This should be the directory containing the project you wish to export."
+        raise InvalidProjectPathException(f"Project path '{project_path}' is not a directory! This should be the directory containing the project you wish to export.")
 
     if not pathlib.Path.is_file(pathlib.Path.joinpath(project_path, 'project.json')):
-        return False, f"Project path '{project_path}' is invalid: does not contain a project.json file."
-    return True, ""
+        raise InvalidProjectPathException(f"Project path '{project_path}' is invalid: does not contain a project.json file.")
+    return True

--- a/scripts/o3de/o3de/validation.py
+++ b/scripts/o3de/o3de/validation.py
@@ -14,6 +14,7 @@ import pathlib
 import uuid
 from o3de import utils
 
+from typing import Tuple
 
 def valid_o3de_json_dict(json_data: dict, key: str) -> bool:
     return key in json_data
@@ -126,23 +127,19 @@ def valid_o3de_restricted_json(file_name: str or pathlib.Path) -> bool:
             return False
     return True
 
-def valid_export_script(script_path: str or pathlib.Path) -> bool:
-    if not os.path.isfile(script_path):
-        logger.error(f"The export script '{script_path}' does not exist!")
-        return False
+def validate_export_script(script_path: pathlib.Path) -> Tuple[bool, str]:
+    if not pathlib.Path.is_file(script_path):
+        return False, f"The export script '{script_path}' does not exist."
 
     if script_path.suffix != '.py':
-        logger.error("A Python script with .py extension must be supplied for --export-script parameter!")
-        return False
-    return True
+        return False, f"The provided export script path '{script_path}' does not have a '.py' extension. A Python script with .py extension must be supplied."
+    return True, ""
 
 
-def valid_o3de_project_path(project_path: str or pathlib.Path) -> bool:
-    if not os.path.isdir(project_path):
-        logger.error(f"Project path '{project_path}' is not a directory! This should be the directory containing the project you wish to export.")
-        return False
+def valid_o3de_project_path(project_path: pathlib.Path) -> Tuple[bool, str]:
+    if not pathlib.Path.is_dir(project_path):
+        return False, f"Project path '{project_path}' is not a directory! This should be the directory containing the project you wish to export."
 
-    if not os.path.isfile(os.path.join(project_path, 'project.json')):
-        logger.error(f"Project path '{project_path}' is invalid: does not contain a project.json file!")
-        return False
-    return True
+    if not pathlib.Path.is_file(pathlib.Path.joinpath(project_path, 'project.json')):
+        return False, f"Project path '{project_path}' is invalid: does not contain a project.json file."
+    return True, ""

--- a/scripts/o3de/o3de/validation.py
+++ b/scripts/o3de/o3de/validation.py
@@ -9,7 +9,6 @@
 This file validating o3de object json files
 """
 import json
-import os
 import pathlib
 import uuid
 from o3de import utils

--- a/scripts/o3de/o3de/validation.py
+++ b/scripts/o3de/o3de/validation.py
@@ -9,11 +9,11 @@
 This file validating o3de object json files
 """
 import json
+import os
 import pathlib
 import uuid
 from o3de import utils
 
-from typing import Tuple
 
 def valid_o3de_json_dict(json_data: dict, key: str) -> bool:
     return key in json_data
@@ -124,27 +124,4 @@ def valid_o3de_restricted_json(file_name: str or pathlib.Path) -> bool:
             _ = json_data['restricted_name']
         except (json.JSONDecodeError, KeyError):
             return False
-    return True
-
-class InvalidExportScriptException(Exception):
-    pass
-
-def validate_export_script(script_path: pathlib.Path) -> bool:
-    if not pathlib.Path.is_file(script_path):
-        raise InvalidExportScriptException(f"The export script '{script_path}' does not exist.")
-
-    if script_path.suffix != '.py':
-        raise InvalidExportScriptException(f"The provided export script path '{script_path}' does not have a '.py' extension. A Python script with .py extension must be supplied.")
-    return True
-
-
-class InvalidProjectPathException(Exception):
-    pass
-
-def validate_o3de_project_path(project_path: pathlib.Path) -> bool:
-    if not pathlib.Path.is_dir(project_path):
-        raise InvalidProjectPathException(f"Project path '{project_path}' is not a directory! This should be the directory containing the project you wish to export.")
-
-    if not pathlib.Path.is_file(pathlib.Path.joinpath(project_path, 'project.json')):
-        raise InvalidProjectPathException(f"Project path '{project_path}' is invalid: does not contain a project.json file.")
     return True

--- a/scripts/o3de/o3de/validation.py
+++ b/scripts/o3de/o3de/validation.py
@@ -9,6 +9,7 @@
 This file validating o3de object json files
 """
 import json
+import os
 import pathlib
 import uuid
 from o3de import utils
@@ -123,4 +124,25 @@ def valid_o3de_restricted_json(file_name: str or pathlib.Path) -> bool:
             _ = json_data['restricted_name']
         except (json.JSONDecodeError, KeyError):
             return False
+    return True
+
+def valid_export_script(script_path: str or pathlib.Path) -> bool:
+    if not os.path.isfile(script_path):
+        logger.error(f"The export script '{script_path}' does not exist!")
+        return False
+
+    if script_path.suffix != '.py':
+        logger.error("A Python script with .py extension must be supplied for --export-script parameter!")
+        return False
+    return True
+
+
+def valid_o3de_project_path(project_path: str or pathlib.Path) -> bool:
+    if not os.path.isdir(project_path):
+        logger.error(f"Project path '{project_path}' is not a directory! This should be the directory containing the project you wish to export.")
+        return False
+
+    if not os.path.isfile(os.path.join(project_path, 'project.json')):
+        logger.error(f"Project path '{project_path}' is invalid: does not contain a project.json file!")
+        return False
     return True


### PR DESCRIPTION
This is a PR for the Project Export CLI with its first commit located here: https://github.com/aws-lumberyard-dev/o3de/commit/e4823ad04010972807f74812b1bc9849714e8ce1

Most of the code changes here are a second pass at the feedback provided at that commit link.

Unit testing is not yet implemented, but will likely come in the next commit, depending on feedback for the current PR.

Most notable change is the introduction of a second helper API: `execute_python_script`, which allows any user script to run a python script using the O3DE parameters defined in the CLI. Those parameters are now implemented as a singleton class `O3DEScriptExportParameters`, and attributes can be arbitrarily assigned to it. This allows for immense flexibility. The function also accepts arbitrary `**kwargs` and adds them as attributes to the export params singleton.

To help protect against overwriting important attributes, such as CLI parameters like`project-path`, and derailing the export process, such attributes are marked as read only. If the user needs to adjust this for other params in their script, they can use `mark_readonly_params` and `mark_writeable_params`.

Such introductions make the following python scripts possible:
```py
#test_export.py
import os
import o3de.export_project as exp

from o3de.export_project import process_command, execute_python_script, O3DEScriptExportParameters

#we require users to instantiate the singleton class to make clear the origin point for export parameters
o3de_export = O3DEScriptExportParameters()

logger = o3de_export.logger

#one way of setting the export parameter is by attribute assignment. This will transfer to other scripts
# o3de_export.hi_there = "hi there!"

process_command(["cmake", "--version"])

#you can also set export parameters as kwargs in execute_python_script(). When this script is called, it can directly access the export parameters, and set new parameters as well, which can feed back in this script
execute_python_script("C:\\Users\\tkothadev\\Desktop\\hello.py", hi_there="hi there!")

logger.info(f"Now running the export code {o3de_export.project_path}")

logger.info(f"Engine path: {o3de_export.engine_path}")

#this is not defined in test_export.py. It comes from hello.py
logger.info(o3de_export.hello_back)

```

```py
#hello.py
import o3de.export_project as exp
from o3de.export_project import O3DEScriptExportParameters
o3de_export = O3DEScriptExportParameters()

logger = o3de_export.logger

i = 0

while i < 10:
    print(f"hi {i}")
    i+=1

#this was defined by test_export.py
logger.info(o3de_export.hi_there)

print(o3de_export.project_path)
print(o3de_export.as_dict())

# this causes an error, since engine_path is read only
# o3de_export.engine_path = "whoops"

#we can set a variable that can be sent back to the script that executed us
o3de_export.hello_back = "Hello to you too!"

# we can leverage O3DE loggers from user scripts
logger.info("hi there!")

```
This is the resulting execution
```
λ .\scripts\o3de.bat export-project -es C:\workspace\projects\NewspaperDeliveryGame\export_rules\test_export.py --verbosity INFO hi there --gary
[INFO] o3de.export_project: Begin loading script 'test_export.py'...
[INFO] o3de.export_project: cmake version 3.24.1

[INFO] o3de.export_project:

[INFO] o3de.export_project: CMake suite maintained and supported by Kitware (kitware.com/cmake).

[INFO] o3de.export_project:
[INFO] o3de.export_project: Finishing current command...
[INFO] o3de.export_project: Begin loading script 'hello.py'...
hi 0
hi 1
hi 2
hi 3
hi 4
hi 5
hi 6
hi 7
hi 8
hi 9
[INFO] o3de.export_project: hi there!
C:\workspace\projects\NewspaperDeliveryGame
{'project_path': WindowsPath('C:/workspace/projects/NewspaperDeliveryGame'), 'engine_path': WindowsPath('C:/workspace/o3de'), 'logger': <Logger o3de.export_project (INFO)>, 'args': ['hi', 'there', '--gary'], 'hi_there': 'hi there!'}
[INFO] o3de.export_project: Now running the export code C:\workspace\projects\NewspaperDeliveryGame
[INFO] o3de.export_project: Engine path: C:\workspace\o3de
[INFO] o3de.export_project: Hello to you too!
[INFO] o3de.export_project: Finished exporting
```