### PR TITLE
Fixed UI navigation for meta data based assets in the Asset Processor…

### DIFF
--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.cpp
@@ -4337,7 +4337,7 @@ namespace AssetProcessor
         m_jobEntries.push_back(entry);
 
         // Signals SourceAssetTreeModel so it can update the CreateJobs duration change
-        Q_EMIT CreateJobsDurationChanged(sourceAsset.RelativePath().c_str());
+        Q_EMIT CreateJobsDurationChanged(sourceAsset.RelativePath().c_str(), sourceAsset.ScanFolderId());
     }
 
     bool AssetProcessorManager::ResolveSourceFileDependencyPath(const AssetBuilderSDK::SourceFileDependency& sourceDependency, QString& resultDatabaseSourceName, QStringList& resolvedDependencyList)

--- a/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
+++ b/Code/Tools/AssetProcessor/native/AssetManager/assetProcessorManager.h
@@ -285,7 +285,7 @@ namespace AssetProcessor
 
         void JobComplete(JobEntry jobEntry, AzToolsFramework::AssetSystem::JobStatus status);
         void JobProcessDurationChanged(JobEntry jobEntry, int durationMs);
-        void CreateJobsDurationChanged(QString sourceName);
+        void CreateJobsDurationChanged(QString sourceName, AZ::s64 scanFolderID);
 
         void IntermediateAssetCreated(QString newFileAbsolutePath);
 

--- a/Code/Tools/AssetProcessor/native/assetprocessor.h
+++ b/Code/Tools/AssetProcessor/native/assetprocessor.h
@@ -58,6 +58,9 @@ namespace AssetProcessor
     //! This is intentionally a map (not unordered_map) in order to ensure order is stable, and to eliminate duplicates.
     typedef AZStd::map<AZStd::string, AZStd::string> SourceFilesForFingerprintingContainer;
 
+    //! A shared convenience typedef for tracking a source path and a scan folder ID together.
+    typedef AZStd::pair<AZStd::string, AZ::s64> SourceAndScanID;
+
     enum AssetScanningStatus
     {
         Unknown,

--- a/Code/Tools/AssetProcessor/native/ui/AssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/AssetDetailsPanel.cpp
@@ -97,7 +97,7 @@ namespace AssetProcessor
         SourceAssetTreeModel* treeModel = isIntermediate ? m_intermediateTreeModel : m_sourceTreeModel;
         AssetTreeFilterModel* filterModel = isIntermediate ? m_intermediateFilterModel : m_sourceFilterModel;
 
-        QModelIndex goToIndex = treeModel->GetIndexForSource(sourceAsset.RelativePath().c_str());
+        QModelIndex goToIndex = treeModel->GetIndexForSource(sourceAsset.RelativePath().c_str(), sourceAsset.ScanFolderId());
         // Make sure this index is visible, even if a search is active.
         filterModel->ForceModelIndexVisible(goToIndex);
         QModelIndex filterIndex = filterModel->mapFromSource(goToIndex);

--- a/Code/Tools/AssetProcessor/native/ui/AssetTreeItem.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/AssetTreeItem.cpp
@@ -17,11 +17,14 @@
 namespace AssetProcessor
 {
 
-    AssetTreeItemData::AssetTreeItemData(const AZStd::string& assetDbName, QString name, bool isFolder, const AZ::Uuid& uuid) :
+    AssetTreeItemData::AssetTreeItemData(
+        const AZStd::string& assetDbName, QString name, bool isFolder, const AZ::Uuid& uuid, const AZ::s64 scanFolderID)
+        :
         m_assetDbName(assetDbName),
         m_name(name),
         m_isFolder(isFolder),
-        m_uuid(uuid)
+        m_uuid(uuid),
+        m_scanFolderID(scanFolderID)
     {
         QFileInfo fileInfo(name);
         m_extension = fileInfo.completeSuffix();

--- a/Code/Tools/AssetProcessor/native/ui/AssetTreeItem.h
+++ b/Code/Tools/AssetProcessor/native/ui/AssetTreeItem.h
@@ -25,12 +25,13 @@ namespace AssetProcessor
     public:
         AZ_RTTI(AssetTreeItemData, "{5660BA97-C4B0-4E3B-A03B-9ACD9C67841B}");
 
-        AssetTreeItemData(const AZStd::string& assetDbName, QString name, bool isFolder, const AZ::Uuid& uuid);
+        AssetTreeItemData(const AZStd::string& assetDbName, QString name, bool isFolder, const AZ::Uuid& uuid, const AZ::s64 scanFolderID);
         virtual ~AssetTreeItemData() {}
         virtual int GetColumnCount() const;
         virtual QVariant GetDataForColumn(int column) const;
 
         AZStd::string m_assetDbName;
+        AZ::s64 m_scanFolderID;
         QString m_name;
         QString m_extension;
         AZ::Uuid m_uuid;

--- a/Code/Tools/AssetProcessor/native/ui/AssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/AssetTreeModel.cpp
@@ -43,7 +43,11 @@ namespace AssetProcessor
     void AssetTreeModel::Reset()
     {
         beginResetModel();
-        m_root.reset(new AssetTreeItem(AZStd::make_shared<AssetTreeItemData>("", "", true, AZ::Uuid::CreateNull()), m_errorIcon, m_folderIcon, m_fileIcon));
+        m_root.reset(new AssetTreeItem(
+            AZStd::make_shared<AssetTreeItemData>("", "", true, AZ::Uuid::CreateNull(), AzToolsFramework::AssetDatabase::InvalidEntryId),
+            m_errorIcon,
+            m_folderIcon,
+            m_fileIcon));
 
         ResetModel();
 

--- a/Code/Tools/AssetProcessor/native/ui/BuilderData.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderData.cpp
@@ -119,7 +119,7 @@ namespace AssetProcessor
             });
     }
 
-    void BuilderData::OnCreateJobsDurationChanged(QString sourceName)
+    void BuilderData::OnCreateJobsDurationChanged(QString sourceName, [[maybe_unused]] AZ::s64 scanFolderID)
     {
         QString statKey = QString("CreateJobs,").append(sourceName).append("%");
         m_dbConnection->QueryStatLikeStatName(

--- a/Code/Tools/AssetProcessor/native/ui/BuilderData.h
+++ b/Code/Tools/AssetProcessor/native/ui/BuilderData.h
@@ -70,6 +70,6 @@ namespace AssetProcessor
         void DurationChanged(BuilderDataItem* itemChanged);
     public Q_SLOTS:
         void OnProcessJobDurationChanged(JobEntry jobEntry, int value);
-        void OnCreateJobsDurationChanged(QString sourceName);
+        void OnCreateJobsDurationChanged(QString sourceName, AZ::s64 scanFolderID);
     };
 }

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.cpp
@@ -422,8 +422,6 @@ void MainWindow::Activate()
     ui->productAssetDetailsPanel->SetIntermediateAssetFolderId(intermediateAssetFolderId);
     ui->sourceAssetDetailsPanel->SetIntermediateAssetFolderId(intermediateAssetFolderId);
     ui->intermediateAssetDetailsPanel->SetIntermediateAssetFolderId(intermediateAssetFolderId);
-    m_intermediateModel->SetIntermediateAssetFolderId(intermediateAssetFolderId);
-    m_sourceModel->SetIntermediateAssetFolderId(intermediateAssetFolderId);
 
     AzQtComponents::StyleManager::setStyleSheet(ui->sourceAssetDetailsPanel, QStringLiteral("style:AssetProcessor.qss"));
     AzQtComponents::StyleManager::setStyleSheet(ui->intermediateAssetDetailsPanel, QStringLiteral("style:AssetProcessor.qss"));
@@ -1042,20 +1040,23 @@ void MainWindow::SetupAssetSelectionCaching()
         }
         QModelIndex sourceModelIndex = sourceSelection.indexes()[0];
         AssetProcessor::AssetTreeItem* childItem = static_cast<AssetProcessor::AssetTreeItem*>(sourceModelIndex.internalPointer());
-        m_cachedSourceAssetSelection = childItem->GetData()->m_assetDbName;
+            m_cachedSourceAssetSelection =
+                AssetProcessor::SourceAndScanID(childItem->GetData()->m_assetDbName, childItem->GetData()->m_scanFolderID);
     });
 
     connect(m_sourceModel, &QAbstractItemModel::modelReset, [&]()
     {
-        if (m_cachedSourceAssetSelection.empty())
+            if (m_cachedSourceAssetSelection.first.empty() ||
+                m_cachedSourceAssetSelection.second == AzToolsFramework::AssetDatabase::InvalidEntryId)
         {
             return;
         }
-        QModelIndex goToIndex = m_sourceModel->GetIndexForSource(m_cachedSourceAssetSelection);
+        QModelIndex goToIndex = m_sourceModel->GetIndexForSource(m_cachedSourceAssetSelection.first, m_cachedSourceAssetSelection.second);
         // If the cached selection was deleted or is no longer available, clear the selection.
         if (!goToIndex.isValid())
         {
-            m_cachedSourceAssetSelection.clear();
+            m_cachedSourceAssetSelection.first.clear();
+            m_cachedSourceAssetSelection.second = AzToolsFramework::AssetDatabase::InvalidEntryId;
             ui->ProductAssetsTreeView->selectionModel()->clearSelection();
             // ClearSelection says in the Qt docs that the selectionChange signal will be sent, but that wasn't happening,
             // so force the details panel to refresh.

--- a/Code/Tools/AssetProcessor/native/ui/MainWindow.h
+++ b/Code/Tools/AssetProcessor/native/ui/MainWindow.h
@@ -254,7 +254,7 @@ private:
 
     AZStd::shared_ptr<AzToolsFramework::AssetDatabase::AssetDatabaseConnection> m_sharedDbConnection;
 
-    AZStd::string m_cachedSourceAssetSelection;
+    AssetProcessor::SourceAndScanID m_cachedSourceAssetSelection;
     AZStd::string m_cachedProductAssetSelection;
     QMetaObject::Connection m_connectionForResettingAssetsView;
 };

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeItemData.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeItemData.cpp
@@ -16,9 +16,15 @@
 namespace AssetProcessor
 {
 
-    AZStd::shared_ptr<ProductAssetTreeItemData> ProductAssetTreeItemData::MakeShared(const AzToolsFramework::AssetDatabase::ProductDatabaseEntry* databaseInfo, const AZStd::string& assetDbName, QString name, bool isFolder, const AZ::Uuid& uuid)
+    AZStd::shared_ptr<ProductAssetTreeItemData> ProductAssetTreeItemData::MakeShared(
+        const AzToolsFramework::AssetDatabase::ProductDatabaseEntry* databaseInfo,
+        const AZStd::string& assetDbName,
+        QString name,
+        bool isFolder,
+        const AZ::Uuid& uuid,
+        const AZ::s64 scanFolderID)
     {
-        return AZStd::make_shared<ProductAssetTreeItemData>(databaseInfo, assetDbName, name, isFolder, uuid);
+        return AZStd::make_shared<ProductAssetTreeItemData>(databaseInfo, assetDbName, name, isFolder, uuid, scanFolderID);
     }
 
     ProductAssetTreeItemData::ProductAssetTreeItemData(
@@ -26,8 +32,10 @@ namespace AssetProcessor
         const AZStd::string& assetDbName,
         QString name,
         bool isFolder,
-        const AZ::Uuid& uuid) :
-        AssetTreeItemData(assetDbName, name, isFolder, uuid)
+        const AZ::Uuid& uuid,
+        const AZ::s64 scanFolderID)
+        :
+        AssetTreeItemData(assetDbName, name, isFolder, uuid, scanFolderID)
     {
         if (databaseInfo)
         {

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeItemData.h
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeItemData.h
@@ -23,9 +23,21 @@ namespace AssetProcessor
     public:
         AZ_RTTI(ProductAssetTreeItemData, "{6DEFC394-98A3-4EEA-9419-E8F51F447862}", AssetTreeItemData);
 
-        static AZStd::shared_ptr<ProductAssetTreeItemData> MakeShared(const AzToolsFramework::AssetDatabase::ProductDatabaseEntry* databaseInfo, const AZStd::string& assetDbName, QString name, bool isFolder, const AZ::Uuid& uuid);
+        static AZStd::shared_ptr<ProductAssetTreeItemData> MakeShared(
+            const AzToolsFramework::AssetDatabase::ProductDatabaseEntry* databaseInfo,
+            const AZStd::string& assetDbName,
+            QString name,
+            bool isFolder,
+            const AZ::Uuid& uuid,
+            const AZ::s64 scanFolderID);
 
-        ProductAssetTreeItemData(const AzToolsFramework::AssetDatabase::ProductDatabaseEntry* databaseInfo, const AZStd::string& assetDbName, QString name, bool isFolder, const AZ::Uuid& uuid);
+        ProductAssetTreeItemData(
+            const AzToolsFramework::AssetDatabase::ProductDatabaseEntry* databaseInfo,
+            const AZStd::string& assetDbName,
+            QString name,
+            bool isFolder,
+            const AZ::Uuid& uuid,
+            const AZ::s64 scanFolderID);
 
         ~ProductAssetTreeItemData() override {}
 

--- a/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/ProductAssetTreeModel.cpp
@@ -248,7 +248,13 @@ namespace AssetProcessor
                     Q_ASSERT(checkIndex(parentIndex));
                     beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
                 }
-                nextParent = parentItem->CreateChild(ProductAssetTreeItemData::MakeShared(nullptr, currentFullFolderPath.Native(), currentPath.c_str(), true, AZ::Uuid::CreateNull()));
+                nextParent = parentItem->CreateChild(ProductAssetTreeItemData::MakeShared(
+                    nullptr,
+                    currentFullFolderPath.Native(),
+                    currentPath.c_str(),
+                    true,
+                    AZ::Uuid::CreateNull(),
+                    AzToolsFramework::AssetDatabase::InvalidEntryId));
                 m_productToTreeItem[currentFullFolderPath.Native()] = nextParent;
                 // m_productIdToTreeItem is not used for folders, folders don't have product IDs.
 
@@ -261,11 +267,13 @@ namespace AssetProcessor
         }
 
         AZ::Uuid sourceId;
+        AZ::s64 scanFolderID;
         m_sharedDbConnection->QuerySourceByProductID(
             product.m_productID,
             [&](AzToolsFramework::AssetDatabase::SourceDatabaseEntry& sourceEntry)
         {
             sourceId = sourceEntry.m_sourceGuid;
+            scanFolderID = sourceEntry.m_scanFolderPK;
             return true;
         });
 
@@ -276,8 +284,8 @@ namespace AssetProcessor
             beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
         }
 
-        AZStd::shared_ptr<ProductAssetTreeItemData> productItemData =
-            ProductAssetTreeItemData::MakeShared(&product, product.m_productName, AZ::IO::FixedMaxPathString(filename.Native()).c_str(), false, sourceId);
+        AZStd::shared_ptr<ProductAssetTreeItemData> productItemData = ProductAssetTreeItemData::MakeShared(
+            &product, product.m_productName, AZ::IO::FixedMaxPathString(filename.Native()).c_str(), false, sourceId, scanFolderID);
         m_productToTreeItem[product.m_productName] =
             parentItem->CreateChild(productItemData);
         m_productIdToTreeItem[product.m_productID] = m_productToTreeItem[product.m_productName];

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetDetailsPanel.cpp
@@ -17,6 +17,7 @@
 #include <native/ui/ui_GoToButton.h>
 #include <native/ui/ui_SourceAssetDetailsPanel.h>
 #include <native/utilities/assetUtils.h>
+#include <native/utilities/IPathConversion.h>
 
 namespace AssetProcessor
 {
@@ -255,8 +256,12 @@ namespace AssetProcessor
                     }
                 }
 
-                SourceAssetTreeModel* treeModel = dependencyDetails.m_scanFolderPK == 1 ? m_intermediateTreeModel : m_sourceTreeModel;
-                QModelIndex goToIndex = treeModel->GetIndexForSource(dependencyDetails.m_sourceName);
+                IPathConversion* pathConversion = AZ::Interface<IPathConversion>::Get();
+                AZ_Assert(pathConversion, "IPathConversion interface is not available");
+
+                SourceAssetTreeModel* treeModel = dependencyDetails.m_scanFolderPK == pathConversion->GetIntermediateAssetScanFolderId()
+                    ? m_intermediateTreeModel : m_sourceTreeModel;
+                QModelIndex goToIndex = treeModel->GetIndexForSource(dependencyDetails.m_sourceName, dependencyDetails.m_scanFolderPK);
                 if (goToIndex.isValid())
                 {
                     // Qt handles cleanup automatically, setting this as the parent means

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeItemData.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeItemData.cpp
@@ -20,8 +20,9 @@ namespace AssetProcessor
         const AZStd::string& assetDbName,
         QString name,
         bool isFolder,
+        const AZ::s64 scanFolderID,
         AZ::s64 analysisJobDuration)
-        : AssetTreeItemData(assetDbName, name, isFolder, sourceInfo ? sourceInfo->m_sourceGuid : AZ::Uuid::CreateNull())
+        : AssetTreeItemData(assetDbName, name, isFolder, sourceInfo ? sourceInfo->m_sourceGuid : AZ::Uuid::CreateNull(), scanFolderID)
         , m_analysisDuration(analysisJobDuration)
     {
         if (sourceInfo && scanFolderInfo)

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeItemData.h
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeItemData.h
@@ -30,6 +30,7 @@ namespace AssetProcessor
             const AZStd::string& assetDbName,
             QString name,
             bool isFolder,
+            const AZ::s64 scanFolderID,
             AZ::s64 analysisJobDuration = -1);
 
         ~SourceAssetTreeItemData() override {}

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeModel.cpp
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeModel.cpp
@@ -12,11 +12,9 @@
 #include <AzCore/Component/TickBus.h>
 #include <AzCore/IO/Path/Path.h>
 #include <native/utilities/assetUtils.h>
+#include <native/utilities/IPathConversion.h>
 #include <AzCore/Console/IConsole.h>
 #include <AzCore/std/smart_ptr/make_shared.h>
-
-#include <QDebug>
-
 
 namespace AssetProcessor
 {
@@ -35,7 +33,10 @@ namespace AssetProcessor
     {
         // We need m_root to contain SourceAssetTreeItemData to show the stat column
         m_root.reset(new AssetTreeItem(
-            AZStd::make_shared<SourceAssetTreeItemData>(nullptr, nullptr, "", "", true), m_errorIcon, m_folderIcon, m_fileIcon));
+            AZStd::make_shared<SourceAssetTreeItemData>(nullptr, nullptr, "", "", true, AzToolsFramework::AssetDatabase::InvalidEntryId),
+            m_errorIcon,
+            m_folderIcon,
+            m_fileIcon));
 
         if (ap_disableAssetTreeView)
         {
@@ -95,14 +96,15 @@ namespace AssetProcessor
         {
             AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry scanFolderEntry;
 
-            if(!m_intermediateAssetFolderId.has_value())
+            IPathConversion* pathConversion = AZ::Interface<IPathConversion>::Get();
+
+            if (!pathConversion || pathConversion->GetIntermediateAssetScanFolderId() == AzToolsFramework::AssetDatabase::InvalidEntryId)
             {
-                // When building the intermediate asset source asset tree, search by the scan folder to save time
+                // If, for some reason, the path conversion interface is not available, then try to retrieve intermediate folder information a different way.
                 m_sharedDbConnection->QueryScanFolderByPortableKey(
                     AssetProcessor::IntermediateAssetsFolderName,
                     [&](AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry& scanFolder)
                     {
-                        m_intermediateAssetFolderId = scanFolder.m_scanFolderID;
                         scanFolderEntry = scanFolder;
                         return false;
                     });
@@ -110,7 +112,7 @@ namespace AssetProcessor
             else
             {
                 m_sharedDbConnection->QueryScanFolderByScanFolderID(
-                    m_intermediateAssetFolderId.value(),
+                    pathConversion->GetIntermediateAssetScanFolderId(),
                     [&](AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry& scanFolder)
                     {
                         scanFolderEntry = scanFolder;
@@ -140,7 +142,7 @@ namespace AssetProcessor
         const AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry& scanFolder,
         bool modelIsResetting, AZ::s64 createJobDuration)
     {
-        const auto& existingEntry = m_sourceToTreeItem.find(source.m_sourceName);
+        const auto& existingEntry = m_sourceToTreeItem.find(SourceAndScanID(source.m_sourceName, scanFolder.m_scanFolderID));
         if (existingEntry != m_sourceToTreeItem.end())
         {
             AZStd::shared_ptr<SourceAssetTreeItemData> sourceItemData = AZStd::rtti_pointer_cast<SourceAssetTreeItemData>(existingEntry->second->GetData());
@@ -159,12 +161,22 @@ namespace AssetProcessor
             dataChanged(existingIndexStart, existingIndexEnd);
             return;
         }
+        AzToolsFramework::AssetDatabase::ScanFolderDatabaseEntry scanFolderEntry;
 
-        if (m_intermediateAssetFolderId.has_value() &&
-            ((source.m_scanFolderPK == m_intermediateAssetFolderId.value() && !m_intermediateAssets) ||
-             (source.m_scanFolderPK != m_intermediateAssetFolderId.value() && m_intermediateAssets)))
+        IPathConversion* pathConversion = AZ::Interface<IPathConversion>::Get();
+        AZ::s64 intermediateAssetScanFolder = AzToolsFramework::AssetDatabase::InvalidEntryId;
+        if(pathConversion)
         {
-            return;
+            intermediateAssetScanFolder = pathConversion->GetIntermediateAssetScanFolderId();
+            
+            if (intermediateAssetScanFolder != AzToolsFramework::AssetDatabase::InvalidEntryId)
+            {
+                if (((source.m_scanFolderPK == intermediateAssetScanFolder && !m_intermediateAssets) ||
+                     (source.m_scanFolderPK != intermediateAssetScanFolder && m_intermediateAssets)))
+                {
+                    return;
+                }
+            }
         }
 
 
@@ -210,8 +222,13 @@ namespace AssetProcessor
                     beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
                 }
                 nextParent = parentItem->CreateChild(AZStd::make_shared<SourceAssetTreeItemData>(
-                    nullptr, nullptr, currentFullFolderPath.Native(), currentPath.c_str(), true));
-                m_sourceToTreeItem[currentFullFolderPath.Native()] = nextParent;
+                    nullptr,
+                    nullptr,
+                    currentFullFolderPath.Native(),
+                    currentPath.c_str(),
+                    true,
+                    scanFolder.m_scanFolderID));
+                m_sourceToTreeItem[SourceAndScanID(currentFullFolderPath.Native(), scanFolder.m_scanFolderID)] = nextParent;
                 // Folders don't have source IDs, don't add to m_sourceIdToTreeItem
                 if (!modelIsResetting)
                 {
@@ -228,9 +245,16 @@ namespace AssetProcessor
             beginInsertRows(parentIndex, parentItem->getChildCount(), parentItem->getChildCount());
         }
 
-        m_sourceToTreeItem[source.m_sourceName] = parentItem->CreateChild(AZStd::make_shared<SourceAssetTreeItemData>(
-            &source, &scanFolder, source.m_sourceName, AZ::IO::FixedMaxPathString(filename.Native()).c_str(), false, createJobDuration));
-        m_sourceIdToTreeItem[source.m_sourceID] = m_sourceToTreeItem[source.m_sourceName];
+        m_sourceToTreeItem[SourceAndScanID(source.m_sourceName, scanFolder.m_scanFolderID)] =
+            parentItem->CreateChild(AZStd::make_shared<SourceAssetTreeItemData>(
+                &source,
+                &scanFolder,
+                source.m_sourceName,
+                AZ::IO::FixedMaxPathString(filename.Native()).c_str(),
+                false,
+                scanFolder.m_scanFolderID,
+                createJobDuration));
+        m_sourceIdToTreeItem[source.m_sourceID] = m_sourceToTreeItem[SourceAndScanID(source.m_sourceName, scanFolder.m_scanFolderID)];
         if (!modelIsResetting)
         {
             endInsertRows();
@@ -290,7 +314,7 @@ namespace AssetProcessor
 
         beginRemoveRows(parentIndex, assetToRemove->GetRow(), assetToRemove->GetRow());
 
-        m_sourceToTreeItem.erase(assetToRemove->GetData()->m_assetDbName);
+        m_sourceToTreeItem.erase(SourceAndScanID(assetToRemove->GetData()->m_assetDbName, assetToRemove->GetData()->m_scanFolderID));
         const AZStd::shared_ptr<const SourceAssetTreeItemData> sourceItemData = AZStd::rtti_pointer_cast<const SourceAssetTreeItemData>(assetToRemove->GetData());
         if (sourceItemData && sourceItemData->m_hasDatabaseInfo)
         {
@@ -351,14 +375,14 @@ namespace AssetProcessor
 
     }
 
-    QModelIndex SourceAssetTreeModel::GetIndexForSource(const AZStd::string& source)
+    QModelIndex SourceAssetTreeModel::GetIndexForSource(const AZStd::string& source, AZ::s64 scanFolderID)
     {
         if (ap_disableAssetTreeView)
         {
             return QModelIndex();
         }
 
-        auto sourceItem = m_sourceToTreeItem.find(source);
+        auto sourceItem = m_sourceToTreeItem.find(SourceAndScanID(source, scanFolderID));
         if (sourceItem == m_sourceToTreeItem.end())
         {
             return QModelIndex();
@@ -366,10 +390,10 @@ namespace AssetProcessor
         return createIndex(sourceItem->second->GetRow(), 0, sourceItem->second);
     }
 
-    void SourceAssetTreeModel::OnCreateJobsDurationChanged(QString sourceName)
+    void SourceAssetTreeModel::OnCreateJobsDurationChanged(QString sourceName, AZ::s64 scanFolderID)
     {
         // update the source asset's CreateJob duration, if such asset exists in the tree
-        const auto& existingEntry = m_sourceToTreeItem.find(sourceName.toUtf8().constData());
+        const auto& existingEntry = m_sourceToTreeItem.find(SourceAndScanID(sourceName.toUtf8().constData(), scanFolderID));
         if (existingEntry != m_sourceToTreeItem.end())
         {
             AZStd::shared_ptr<SourceAssetTreeItemData> sourceItemData =

--- a/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeModel.h
+++ b/Code/Tools/AssetProcessor/native/ui/SourceAssetTreeModel.h
@@ -10,6 +10,7 @@
 #include "AssetTreeModel.h"
 #include <AzToolsFramework/API/AssetDatabaseBus.h>
 #include <AzCore/std/containers/unordered_map.h>
+#include <native/assetprocessor.h>
 #include <native/utilities/ApplicationManagerAPI.h>
 #include <QDir>
 
@@ -28,17 +29,12 @@ namespace AssetProcessor
         // Overriding AssetTreeModel for displaying analysis job duration header
         QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-        QModelIndex GetIndexForSource(const AZStd::string& source);
+        QModelIndex GetIndexForSource(const AZStd::string& source, AZ::s64 scanFolderID);
 
         void SetOnlyShowIntermediateAssets() { m_intermediateAssets = true; }
 
-        void SetIntermediateAssetFolderId(AZStd::optional<AZ::s64> intermediateAssetFolderId)
-        {
-            m_intermediateAssetFolderId = intermediateAssetFolderId;
-        }
-
     public Q_SLOTS:
-        void OnCreateJobsDurationChanged(QString sourceName);
+        void OnCreateJobsDurationChanged(QString sourceName, AZ::s64 scanFolderID);
 
     protected:
         void ResetModel() override;
@@ -51,11 +47,10 @@ namespace AssetProcessor
         void RemoveAssetTreeItem(AssetTreeItem* assetToRemove);
         void RemoveFoldersIfEmpty(AssetTreeItem* itemToCheck);
 
-        AZStd::unordered_map<AZStd::string, AssetTreeItem*> m_sourceToTreeItem;
+        AZStd::unordered_map<SourceAndScanID, AssetTreeItem*> m_sourceToTreeItem;
         AZStd::unordered_map<AZ::s64, AssetTreeItem*> m_sourceIdToTreeItem;
         QDir m_assetRoot;
         bool m_assetRootSet = false;
         bool m_intermediateAssets = false;
-        AZStd::optional<AZ::s64> m_intermediateAssetFolderId;
     };
 }

--- a/Code/Tools/AssetProcessor/native/utilities/IPathConversion.h
+++ b/Code/Tools/AssetProcessor/native/utilities/IPathConversion.h
@@ -29,5 +29,11 @@ namespace AssetProcessor
         virtual const AssetProcessor::ScanFolderInfo* GetScanFolderForFile(const QString& fullFileName) const = 0;
 
         virtual const AssetProcessor::ScanFolderInfo* GetScanFolderById(AZ::s64 id) const = 0;
+
+        // Get the scan folder ID for the intermediate asset path.
+        virtual const AZ::s64 GetIntermediateAssetScanFolderId() const
+        {
+            return -1;
+        }
     };
 }

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.cpp
@@ -1475,6 +1475,11 @@ namespace AssetProcessor
             });
     }
 
+    const AZ::s64 PlatformConfiguration::GetIntermediateAssetScanFolderId() const
+    {
+        return m_intermediateAssetScanFolderId;
+    }
+
     void PlatformConfiguration::AddScanFolder(const AssetProcessor::ScanFolderInfo& source, bool isUnitTesting)
     {
         if (isUnitTesting)

--- a/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
+++ b/Code/Tools/AssetProcessor/native/utilities/PlatformConfiguration.h
@@ -199,6 +199,7 @@ namespace AssetProcessor
         //! Retrieve the scan folder found by a boolean predicate function, when the predicate returns true, the current scan folder info is returned.
         const AssetProcessor::ScanFolderInfo* FindScanFolder(AZStd::function<bool(const AssetProcessor::ScanFolderInfo&)> predicate) const;
         const AssetProcessor::ScanFolderInfo* GetScanFolderById(AZ::s64 id) const override;
+        const AZ::s64 GetIntermediateAssetScanFolderId() const;
 
         //!  Manually add a scan folder.  Also used for testing.
         void AddScanFolder(const AssetProcessor::ScanFolderInfo& source, bool isUnitTesting = false);


### PR DESCRIPTION
…. The scan folder ID is kept with the relative path to the source asset, so it can be looked up later.

## What does this PR do?

Without this change, if you enable meta data files, and then create two source assets at the same relative paths as each other to their relevant scan folders, one of those assets won't show up in the source tab of the Asset Processor. There were other bugs, with the system tracking asset links via relative source path, it meant the "go to" UI elements would sometimes send you to the incorrect asset.

With this change, the source path is now paired with the scan folder ID, which means that both assets now show up in the source assets tab, and the go to functionality brings you to the correct entry.

## How was this PR tested?

Tested locally, manually.

1. Enabled the test asset format "intersource" for meta data generation
2. Created two intersource files with the same relative path in two different scan folders (O3DERoot\Assets\Engine\TestAssets\test.intersource, O3DERoot\AutomatedTesting\TestAssets\test.intersource)
3. Verified both files processed, and each one got a unique sidecar meta file.
4. Without this change, verified that only one showed up in the Source Assets tab of Asset Processor, and that the logic to navigate between product/source/intermediate assets, and jobs, was not working as expected due to the fact that these linked via just the relative path.
5. With this change, verified those all worked, because the scan folder ID was used to assist in finding the correct asset.
