### PR TITLE
[INTERNAL] Linux ARM64 compilation fixes for O3DE

### DIFF
--- a/Code/Framework/AzCore/Platform/Linux/AzCore/AzCore_Traits_Linux.h
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/AzCore_Traits_Linux.h
@@ -10,9 +10,21 @@
 #define AZ_PLATFORM_LINUX
 
 // Hardware traits ...
-#define AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR 0
-#define AZ_TRAIT_USE_PLATFORM_SIMD_NEON 0
-#define AZ_TRAIT_USE_PLATFORM_SIMD_SSE 1
+#if __ARM_ARCH
+    #if __ARM_NEON
+        #define AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR 0
+        #define AZ_TRAIT_USE_PLATFORM_SIMD_NEON 1
+        #define AZ_TRAIT_USE_PLATFORM_SIMD_SSE 0
+    #else
+        #define AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR 1
+        #define AZ_TRAIT_USE_PLATFORM_SIMD_NEON 0
+        #define AZ_TRAIT_USE_PLATFORM_SIMD_SSE 0
+    #endif // __ARM_NEON
+#else
+    #define AZ_TRAIT_USE_PLATFORM_SIMD_SCALAR 0
+    #define AZ_TRAIT_USE_PLATFORM_SIMD_NEON 0
+    #define AZ_TRAIT_USE_PLATFORM_SIMD_SSE 1
+#endif // __ARM_ARCH
 
 // OS traits ...
 #define AZ_TRAIT_OS_ALLOW_MULTICAST 1

--- a/Code/Framework/AzCore/Platform/Linux/AzCore/Math/Internal/MathTypes_Linux.h
+++ b/Code/Framework/AzCore/Platform/Linux/AzCore/Math/Internal/MathTypes_Linux.h
@@ -9,8 +9,10 @@
 #pragma once
 
 #if AZ_TRAIT_USE_PLATFORM_SIMD_SSE
-#   include <xmmintrin.h>
-#   include <pmmintrin.h>
-#   include <emmintrin.h>
-#   include <smmintrin.h>
+    #include <xmmintrin.h>
+    #include <pmmintrin.h>
+    #include <emmintrin.h>
+    #include <smmintrin.h>
+#elif AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+    #include <arm_neon.h>
 #endif

--- a/Code/Legacy/CryCommon/AndroidSpecific.h
+++ b/Code/Legacy/CryCommon/AndroidSpecific.h
@@ -22,7 +22,7 @@
 #define PLATFORM_64BIT
 #endif
 
-#if defined(__ARM_NEON__)
+if defined(__ARM_NEON__) || defined(__ARM_NEON)
 #define _CPU_NEON
 #endif
 

--- a/Code/Legacy/CryCommon/AndroidSpecific.h
+++ b/Code/Legacy/CryCommon/AndroidSpecific.h
@@ -22,7 +22,7 @@
 #define PLATFORM_64BIT
 #endif
 
-if defined(__ARM_NEON__) || defined(__ARM_NEON)
+#if defined(__ARM_NEON__) || defined(__ARM_NEON)
 #define _CPU_NEON
 #endif
 

--- a/Code/Legacy/CryCommon/Cry_Math.h
+++ b/Code/Legacy/CryCommon/Cry_Math.h
@@ -260,7 +260,7 @@ ILINE f64 isqrt_safe_tpl(f64 value)
 {
     return isqrt_tpl(value + (std::numeric_limits<f64>::min)());
 }
-#elif defined (__ARM_NEON__)
+#elif defined(__ARM_NEON__) || defined(__ARM_NEON)
 #include "arm_neon.h"
 
 template <int n>

--- a/Code/Legacy/CryCommon/Cry_Math.h
+++ b/Code/Legacy/CryCommon/Cry_Math.h
@@ -150,7 +150,7 @@ ILINE T Lerp(const T& a, const T& b, float s) { return T(a + (b - a) * s); }
 //-- the portability functions for CPU_X86
 //-------------------------------------------
 
-#if defined(_CPU_SSE)
+#if defined(_CPU_SSE) && !defined(__ARM_ARCH)
 #include <xmmintrin.h>
 #endif
 

--- a/Code/Legacy/CryCommon/Linux64Specific.h
+++ b/Code/Legacy/CryCommon/Linux64Specific.h
@@ -29,7 +29,10 @@
 #include <malloc.h>
 #include <stdint.h>
 #include <sys/dir.h>
+#if !defined(__ARM_ARCH)
 #include <sys/io.h>
+#endif // __ARM_ARCH
+
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/Code/Legacy/CryCommon/Linux64Specific.h
+++ b/Code/Legacy/CryCommon/Linux64Specific.h
@@ -106,7 +106,7 @@ typedef uint8               byte;
 
 #define PLATFORM_64BIT
 
-#ifdef _RELEASE || defined(__ARM_ARCH)
+#if defined(_RELEASE) || defined(__ARM_ARCH)
     #define __debugbreak()
 #else
     #define __debugbreak() asm("int3")

--- a/Code/Legacy/CryCommon/Linux64Specific.h
+++ b/Code/Legacy/CryCommon/Linux64Specific.h
@@ -15,11 +15,14 @@
 #pragma once
 
 
-
-//#define _CPU_X86
-#define _CPU_AMD64
-#define _CPU_SSE
-
+#if defined(__ARM_ARCH)
+    #if __ARM_NEON
+        #define __ARM_NEON__
+    #endif // __ARM_NEON
+#else
+    #define _CPU_AMD64
+    #define _CPU_SSE
+#endif // __ARM_NEON
 //////////////////////////////////////////////////////////////////////////
 // Standard includes.
 //////////////////////////////////////////////////////////////////////////
@@ -103,7 +106,7 @@ typedef uint8               byte;
 
 #define PLATFORM_64BIT
 
-#ifdef _RELEASE
+#ifdef _RELEASE || defined(__ARM_ARCH)
     #define __debugbreak()
 #else
     #define __debugbreak() asm("int3")

--- a/Code/Legacy/CryCommon/Linux64Specific.h
+++ b/Code/Legacy/CryCommon/Linux64Specific.h
@@ -15,11 +15,7 @@
 #pragma once
 
 
-#if defined(__ARM_ARCH)
-    #if __ARM_NEON
-        #define __ARM_NEON__
-    #endif // __ARM_NEON
-#else
+#if !defined(__ARM_ARCH)
     #define _CPU_AMD64
     #define _CPU_SSE
 #endif // __ARM_NEON

--- a/Code/Legacy/CrySystem/CrySystem_precompiled.h
+++ b/Code/Legacy/CrySystem/CrySystem_precompiled.h
@@ -49,7 +49,9 @@
 #elif defined(APPLE) // Scrubber friendly negated define pattern
 #elif defined(ANDROID) // Scrubber friendly negated define pattern
 #elif defined(LINUX)
+#if !defined(__ARM_ARCH)
     #   include <sys/io.h>
+#endif // __ARM_ARCH
 #else
     #   include <io.h>
 #endif

--- a/cmake/Platform/Android/Configurations_android.cmake
+++ b/cmake/Platform/Android/Configurations_android.cmake
@@ -20,7 +20,6 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     ly_append_configurations_options(
         DEFINES
             LINUX64
-            __ARM_NEON__
             _LINUX
             LINUX
             ANDROID


### PR DESCRIPTION
## What does this PR do?

Fixes the O3DE related compilation errors building with clang + arm64 & neon.
* Check for ARM predefined macros `__ARM_ARCH` and `__ARM_NEON`
* Prevent inclusion of sse intrinics files if building on arm, and include <arm_neon.h> instead
* Prevent inclusion of `sys/io.h` on ARM

## How was this PR tested?
Built locally 
