### PR TITLE
Improve joints authoring by adding option to fix joint location

### DIFF
--- a/Gems/PhysX/Code/Editor/EditorJointConfiguration.h
+++ b/Gems/PhysX/Code/Editor/EditorJointConfiguration.h
@@ -145,12 +145,14 @@ namespace PhysX
         float m_torqueMax = 1.0f;
 
         AZ::Vector3 m_localPosition = AZ::Vector3::CreateZero();
-        AZ::Vector3 m_localRotation = AZ::Vector3::CreateZero(); ///< Local rotation angles about X, Y, Z axes in degrees, relative to lead body.
+        AZ::Vector3 m_localRotation = AZ::Vector3::CreateZero(); //!< Local rotation angles about X, Y, Z axes in degrees, relative to follower body.
+
+        bool m_fixJointLocation = false; //!< When moving entity the joint location and rotation will be recalculated to stay the same.
 
     private:
-        bool IsInComponentMode() const; ///< This function is necessary for usage of m_inComponentMode as an attribute in the edit context. Using the variable directly instead of this function will result in the variable being saved.
+        bool IsInComponentMode() const; //!< This function is necessary for usage of m_inComponentMode as an attribute in the edit context. Using the variable directly instead of this function will result in the variable being saved.
 
-        void ValidateLeadEntityId(); ///< Issues warning if lead entity does not contain required components for a joint to function correctly.
+        AZ::Crc32 OnLeadEntityChanged() const; //!< Issues warning if lead entity does not contain required components for a joint to function correctly.
     };
 
 } // namespace PhysX

--- a/Gems/PhysX/Code/Editor/EditorJointConfiguration.h
+++ b/Gems/PhysX/Code/Editor/EditorJointConfiguration.h
@@ -147,7 +147,7 @@ namespace PhysX
         AZ::Vector3 m_localPosition = AZ::Vector3::CreateZero();
         AZ::Vector3 m_localRotation = AZ::Vector3::CreateZero(); //!< Local rotation angles about X, Y, Z axes in degrees, relative to follower body.
 
-        bool m_fixJointLocation = false; //!< When moving entity the joint location and rotation will be recalculated to stay the same.
+        bool m_fixJointLocation = false; //!< When moving entity, the joint location and rotation will be recalculated to stay the same.
 
     private:
         bool IsInComponentMode() const; //!< This function is necessary for usage of m_inComponentMode as an attribute in the edit context. Using the variable directly instead of this function will result in the variable being saved.

--- a/Gems/PhysX/Code/Source/EditorBallJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorBallJointComponent.cpp
@@ -222,22 +222,16 @@ namespace PhysX
         }
 
         const AZ::EntityId entityId = GetEntityId();
-        AZ::Transform worldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId);
+        AZ::Transform jointWorldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId) *
+            GetTransformValue(PhysX::JointsComponentModeCommon::ParameterNames::Transform);
         const AzFramework::CameraState cameraState = AzToolsFramework::GetCameraState(viewportInfo.m_viewportId);
         // scaleMultiply will represent a scale for the debug draw that makes it remain the same size on screen
-        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(worldTransform.GetTranslation(), cameraState);
-
-        AZ::Transform localTransform;
-        EditorJointRequestBus::EventResult(localTransform,
-            AZ::EntityComponentIdPair(entityId, GetId()),
-            &EditorJointRequests::GetTransformValue, 
-            PhysX::JointsComponentModeCommon::ParameterNames::Transform);
+        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(jointWorldTransform.GetTranslation(), cameraState);
 
         AZ::u32 stateBefore = debugDisplay.GetState();
         debugDisplay.CullOff();
 
-        debugDisplay.PushMatrix(worldTransform);
-        debugDisplay.PushMatrix(localTransform);
+        debugDisplay.PushMatrix(jointWorldTransform);
 
         const float xAxisArrowLength = 2.0f * scaleMultiply;
         debugDisplay.SetColor(AZ::Color(1.0f, 0.0f, 0.0f, 1.0f));
@@ -276,8 +270,7 @@ namespace PhysX
             debugDisplay.DrawTri(AZ::Vector3(0.0f, 0.0f, 0.0f), ellipseSamples[i], ellipseSamples[nextIndex]);
         }
 
-        debugDisplay.PopMatrix();//pop local transform
-        debugDisplay.PopMatrix();//pop world transform
+        debugDisplay.PopMatrix();//pop joint world transform
 
         debugDisplay.SetState(stateBefore);
     }

--- a/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
@@ -235,11 +235,12 @@ namespace PhysX
         AZ::Vector3 axis = AZ::Vector3::CreateAxisX();
 
         const AZ::EntityId& entityId = GetEntityId();
-        AZ::Transform worldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId);
+        AZ::Transform jointWorldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId) *
+            GetTransformValue(PhysX::JointsComponentModeCommon::ParameterNames::Transform);
         const AzFramework::CameraState cameraState = AzToolsFramework::GetCameraState(viewportInfo.m_viewportId);
 
         // scaleMultiply will represent a scale for the debug draw that makes it remain the same size on screen
-        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(worldTransform.GetTranslation(), cameraState);
+        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(jointWorldTransform.GetTranslation(), cameraState);
 
         const float size = 2.0f * scaleMultiply;
 
@@ -247,15 +248,7 @@ namespace PhysX
         debugDisplay.CullOff();
         debugDisplay.SetAlpha(s_alpha);
 
-        AZ::Transform localTransform;
-        EditorJointRequestBus::EventResult(
-            localTransform,
-            AZ::EntityComponentIdPair(entityId, GetId()),
-            &EditorJointRequests::GetTransformValue,
-            PhysX::JointsComponentModeCommon::ParameterNames::Transform);
-
-        debugDisplay.PushMatrix(worldTransform);
-        debugDisplay.PushMatrix(localTransform);
+        debugDisplay.PushMatrix(jointWorldTransform);
 
         // draw a cylinder to indicate the axis of revolution.
         const float cylinderThickness = 0.05f * scaleMultiply;
@@ -336,8 +329,7 @@ namespace PhysX
             debugDisplay.DrawWireCone(pointOnCircle, -AZ::Vector3::CreateAxisY(), coneRadius, coneHeight);
         }
 
-        debugDisplay.PopMatrix(); // pop local transform
-        debugDisplay.PopMatrix(); // pop global transform
+        debugDisplay.PopMatrix(); // pop joint world transform
         debugDisplay.SetState(stateBefore);
     }
 }

--- a/Gems/PhysX/Code/Source/EditorJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorJointComponent.cpp
@@ -80,13 +80,13 @@ namespace PhysX
     {
         if (m_config.m_fixJointLocation)
         {
-            const AZ::Transform jointWorldTM = m_cachedWorldTM * 
-                AZ::Transform::CreateFromQuaternionAndTranslation(
-                    AZ::Quaternion::CreateFromEulerAnglesDegrees(m_config.m_localRotation), m_config.m_localPosition);
+            const AZ::Transform localJoint = GetTransformValue(JointsComponentModeCommon::ParameterNames::Transform);
+            const AZ::Transform worldJoint = m_cachedWorldTM * localJoint;
 
-            const AZ::Transform newJointLocalTM = worldTM.GetInverse() * jointWorldTM;
-            m_config.m_localPosition = newJointLocalTM.GetTranslation();
-            m_config.m_localRotation = newJointLocalTM.GetEulerDegrees();
+            const AZ::Transform localFromWorld = worldTM.GetInverse();
+            const AZ::Transform newLocalJoint = localFromWorld * worldJoint;
+            m_config.m_localPosition = newLocalJoint.GetTranslation();
+            m_config.m_localRotation = newLocalJoint.GetEulerDegrees();
 
             AzToolsFramework::ToolsApplicationEvents::Bus::Broadcast(
                 &AzToolsFramework::ToolsApplicationEvents::InvalidatePropertyDisplay, AzToolsFramework::Refresh_Values);

--- a/Gems/PhysX/Code/Source/EditorJointComponent.h
+++ b/Gems/PhysX/Code/Source/EditorJointComponent.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzFramework/Visibility/BoundsBus.h>
 
@@ -23,6 +24,7 @@ namespace PhysX
     /// Base class for editor joint components.
     class EditorJointComponent
         : public AzToolsFramework::Components::EditorComponentBase
+        , protected AZ::TransformNotificationBus::Handler
         , protected AzToolsFramework::EditorComponentSelectionRequestsBus::Handler
         , protected AzToolsFramework::EditorComponentSelectionNotificationsBus::Handler
         , protected PhysX::EditorJointRequestBus::Handler
@@ -42,6 +44,9 @@ namespace PhysX
         AZ::Aabb GetLocalBounds() override;
 
     protected:
+        // TransformNotificationBus overrides ...
+        void OnTransformChanged(const AZ::Transform& localTM, const AZ::Transform& worldTM) override;
+
         // EditorComponentSelectionRequestsBus overrides ....
         AZ::Aabb GetEditorSelectionBoundsViewport(
             const AzFramework::ViewportInfo& viewportInfo) override;
@@ -70,5 +75,7 @@ namespace PhysX
             AzFramework::DebugDisplayRequests& debugDisplay) override;
 
         EditorJointConfig m_config;
+
+        AZ::Transform m_cachedWorldTM;
     };
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorPrismaticJointComponent.cpp
@@ -190,22 +190,16 @@ namespace PhysX
 
         const AZ::EntityId& entityId = GetEntityId();
 
-        AZ::Transform worldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId);
+        AZ::Transform jointWorldTransform = PhysX::Utils::GetEntityWorldTransformWithoutScale(entityId) *
+            GetTransformValue(PhysX::JointsComponentModeCommon::ParameterNames::Transform);
 
         const AzFramework::CameraState cameraState = AzToolsFramework::GetCameraState(viewportInfo.m_viewportId);
         // scaleMultiply will represent a scale for the debug draw that makes it remain the same size on screen
-        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(worldTransform.GetTranslation(), cameraState);
+        float scaleMultiply = AzToolsFramework::CalculateScreenToWorldMultiplier(jointWorldTransform.GetTranslation(), cameraState);
 
         const float size = 1.0f * scaleMultiply;
 
-        AZ::Transform localTransform;
-        EditorJointRequestBus::EventResult(localTransform,
-            AZ::EntityComponentIdPair(entityId, GetId()),
-            &EditorJointRequests::GetTransformValue,
-            PhysX::JointsComponentModeCommon::ParameterNames::Transform);
-
-        debugDisplay.PushMatrix(worldTransform);
-        debugDisplay.PushMatrix(localTransform);
+        debugDisplay.PushMatrix(jointWorldTransform);
 
         debugDisplay.SetColor(colorDefault);
         debugDisplay.DrawLine(AZ::Vector3::CreateAxisX(m_linearLimit.m_limitLower), AZ::Vector3::CreateAxisX(m_linearLimit.m_limitUpper));
@@ -224,8 +218,7 @@ namespace PhysX
             AZ::Vector3(m_linearLimit.m_limitUpper, size, size),
             AZ::Vector3(m_linearLimit.m_limitUpper, size, -size));
 
-        debugDisplay.PopMatrix(); // pop local transform
-        debugDisplay.PopMatrix(); // pop world transform
+        debugDisplay.PopMatrix(); // pop joint world transform
         debugDisplay.SetState(stateBefore);
     }
 } // namespace PhysX


### PR DESCRIPTION
## What does this PR do?

Improve joints authoring experience by adding the option to fix joint location, which allows to move the entity without affecting the location of the joint.

Closes https://github.com/o3de/o3de/issues/15315

https://user-images.githubusercontent.com/27999040/227983475-d5466d3f-b8fd-47b7-8576-e3b8b4e1cbe3.mp4

## How was this PR tested?

Run PhysX unit tests.
Manually tested all joint types. Made sure the gizmos behave as expected when using the new option.
