### PR TITLE
TIAF: Native Test Sharding

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeConfiguration.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeConfiguration.h
@@ -12,6 +12,14 @@
 
 namespace TestImpact
 {
+    //! Temporary workspace configuration.
+    struct NativeShardedArtifactDir
+    {
+        RepoPath m_shardedTestRunArtifactDirectory; //!< Path to read and write sharded test run artifacts to and from.
+        RepoPath m_shardedCoverageArtifactDirectory; //!< Path to read and write coverage artifacts to and from.
+    };
+
+
     //! Test engine configuration.
     struct NativeTestEngineConfig
     {
@@ -40,23 +48,16 @@ namespace TestImpact
     //! Build target configuration.
     struct NativeTargetConfig
     {
-        //! Test target sharding configuration.
-        struct ShardedTarget
-        {
-            AZStd::string m_name; //!< Name of test target this sharding configuration applies to.
-            ShardConfiguration m_configuration; //!< The shard configuration to use.
-        };
-
         RepoPath m_outputDirectory; //!< Path to the test target binary directory.
-        NativeExcludedTargets m_excludedTargets;
-        AZStd::vector<ShardedTarget> m_shardedTestTargets; //!< Test target shard configurations (opt-in).
+        NativeExcludedTargets m_excludedTargets; //!< Test targets to exclude from regular and/or instrumented runs.
     };
 
     //! Native runtime configuration.
     struct NativeRuntimeConfig
     {
         RuntimeConfig m_commonConfig;
-        WorkspaceConfig m_workspace;    
+        WorkspaceConfig m_workspace;
+        NativeShardedArtifactDir m_shardedArtifactDir;
         NativeTestEngineConfig m_testEngine;
         NativeTargetConfig m_target;
     };

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
@@ -56,7 +56,6 @@ namespace TestImpact
         //! @param executionFailureDraftingPolicy Determines how test targets that previously failed to execute are drafted into subsequent test sequences.
         //! @param testFailurePolicy Determines how to handle test targets that report test failures.
         //! @param integrationFailurePolicy Determines how to handle instances where the build system model and/or test impact analysis data is compromised.
-        //! @param testShardingPolicy  Determines how to handle test targets that have opted in to test sharding.
         NativeRuntime(
             NativeRuntimeConfig&& config,
             const AZStd::optional<RepoPath>& dataFile,
@@ -68,7 +67,6 @@ namespace TestImpact
             Policy::FailedTestCoverage failedTestCoveragePolicy,
             Policy::TestFailure testFailurePolicy,
             Policy::IntegrityFailure integrationFailurePolicy,
-            Policy::TestSharding testShardingPolicy,
             Policy::TargetOutputCapture targetOutputCapture,
             AZStd::optional<size_t> maxConcurrency = AZStd::nullopt);
 
@@ -161,7 +159,6 @@ namespace TestImpact
         Policy::FailedTestCoverage m_failedTestCoveragePolicy;
         Policy::TestFailure m_testFailurePolicy;
         Policy::IntegrityFailure m_integrationFailurePolicy;
-        Policy::TestSharding m_testShardingPolicy;
         Policy::TargetOutputCapture m_targetOutputCapture;
         size_t m_maxConcurrency = 0;
         AZStd::unique_ptr<BuildTargetList<NativeProductionTarget, NativeTestTarget>> m_buildTargets;
@@ -170,7 +167,6 @@ namespace TestImpact
         AZStd::unique_ptr<TestEngine> m_testEngine;
         AZStd::unique_ptr<TestTargetExclusionList<NativeTestTarget>> m_regularTestTargetExcludeList;
         AZStd::unique_ptr<TestTargetExclusionList<NativeTestTarget>> m_instrumentedTestTargetExcludeList;
-        AZStd::unordered_set<const NativeTestTarget*> m_testTargetShardList;
         AZStd::unordered_set<const NativeTestTarget*> m_previouslyFailingTestTargets;
         bool m_hasImpactAnalysisData = false;
     };

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <TestImpactFramework/Native/TestImpactNativeConfiguration.h>
+
+namespace TestImpact
+{
+    //! Parses the native-specific configuration data (in JSON format) and returns the constructed runtime configuration.
+    NativeRuntimeConfig NativeRuntimeConfigurationFactory(const AZStd::string& configurationData);
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
@@ -6,6 +6,8 @@
  *
  */
 
+#pragma once
+
 #include <TestImpactFramework/Native/TestImpactNativeConfiguration.h>
 
 namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
@@ -6,7 +6,7 @@
  *
  */
 
-#pragma once1
+#pragma once
 
 #include <TestImpactFramework/Native/TestImpactNativeConfiguration.h>
 

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
@@ -6,7 +6,7 @@
  *
  */
 
-#pragma once
+#pragma once1
 
 #include <TestImpactFramework/Native/TestImpactNativeConfiguration.h>
 

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.cpp
@@ -17,7 +17,9 @@
 namespace TestImpact
 {
     NativeTestTargetMetaMap NativeTestTargetMetaMapFactory(
-        const AZStd::string& masterTestListData, const SuiteSet& suiteSet, const SuiteLabelExcludeSet& suiteLabelExcludeSet)
+        const AZStd::string& masterTestListData,
+        const SuiteSet& suiteSet,
+        const SuiteLabelExcludeSet& suiteLabelExcludeSet)
     {
         // Keys for pertinent JSON node and attribute names
         constexpr const char* Keys[] =
@@ -37,7 +39,7 @@ namespace TestImpact
             "labels"
         };
 
-        enum
+        enum Fields
         {
             GoogleKey,
             TestKey,
@@ -51,9 +53,12 @@ namespace TestImpact
             NameKey,
             CommandKey,
             TimeoutKey,
-            SuiteLabelsKey
+            SuiteLabelsKey,
+            // Checksum
+            _CHECKSUM_
         };
 
+        static_assert(Fields::_CHECKSUM_ == AZStd::size(Keys));
         AZ_TestImpact_Eval(!masterTestListData.empty(), ArtifactException, "Test meta-data cannot be empty");
 
         NativeTestTargetMetaMap testMetas;

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <TestImpactFramework/TestImpactTestSequence.h>
+#include <TestImpactFramework/Native/TestImpactNativeConfiguration.h>
 
 #include <Artifact/Static/TestImpactNativeTestTargetMeta.h>
 
@@ -20,5 +21,7 @@ namespace TestImpact
     //! @param suiteLabelExcludeSet Any tests with suites that match a label from this set will be excluded.
     //! @return The constructed list of test target meta-data artifacts.
     NativeTestTargetMetaMap NativeTestTargetMetaMapFactory(
-        const AZStd::string& masterTestListData, const SuiteSet& suiteSet, const SuiteLabelExcludeSet& suiteLabelExcludeSet);
+        const AZStd::string& masterTestListData,
+        const SuiteSet& suiteSet,
+        const SuiteLabelExcludeSet& suiteLabelExcludeSet);
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Static/TestImpactNativeTestTargetMeta.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Artifact/Static/TestImpactNativeTestTargetMeta.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <TestImpactFramework/TestImpactRepoPath.h>
+#include <TestImpactFramework/TestImpactTestSequence.h>
 
 #include <Artifact/Static/TestImpactTestTargetMeta.h>
 

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Platform/Windows/TestRunner/Native/Job/TestImpactWin32_NativeTestJobInfoUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Platform/Windows/TestRunner/Native/Job/TestImpactWin32_NativeTestJobInfoUtils.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.h>
+
+namespace TestImpact
+{
+    typename NativeInstrumentedTestRunner::Command GenerateInstrumentedTestJobInfoCommand(
+        const RepoPath& instrumentBindaryPath,
+        const RepoPath& coverageArtifactPath,
+        CoverageLevel coverageLevel,
+        const RepoPath& modulesPath,
+        const RepoPath& excludedModulesPath,
+        const RepoPath& sourcesPath,
+        const typename NativeRegularTestRunner::Command& testRunLaunchCommand)
+    {
+        return {
+            AZStd::string::format(
+                "\"%s\" " // 1. Instrumented test runner
+                "--coverage_level %s " // 2. Coverage level
+                "--export_type cobertura:\"%s\" " // 3. Test coverage artifact path
+                "--modules \"%s\" " // 4. Modules path
+                "--excluded_modules \"%s\" " // 5. Exclude modules
+                "--sources \"%s\" -- " // 6. Sources path
+                "%s ", // 7. Launch command
+
+                instrumentBindaryPath.c_str(), // 1. Instrumented test runner
+                (coverageLevel == CoverageLevel::Line ? "line" : "source"), // 2. Coverage level
+                coverageArtifactPath.c_str(), // 3. Test coverage artifact path
+                modulesPath.c_str(), // 4. Modules path
+                excludedModulesPath.c_str(), // 5. Exclude modules
+                sourcesPath.c_str(), // 6. Sources path
+                testRunLaunchCommand.m_args.c_str() // 7. Launch command
+            )
+        };
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Platform/Windows/platform_windows_files.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Platform/Windows/platform_windows_files.cmake
@@ -9,4 +9,5 @@
 set(FILES
     TestEngine/Native/TestImpactWin32_NativeErrorCodeChecker.cpp
     TestEngine/Native/Job/TestImpactWin32_NativeTestTargetExtension.cpp
+    TestRunner/Native/Job/TestImpactWin32_NativeTestJobInfoUtils.cpp
 )

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.cpp
@@ -10,6 +10,12 @@
 
 namespace TestImpact
 {
+    namespace SupportedTestFrameworks
+    {
+        //! The CTest label for the GTest framework.
+        inline constexpr auto GTest = "FRAMEWORK_googletest";
+    } // namespace SupportedTestFrameworks
+
     NativeTestTarget::NativeTestTarget(
         TargetDescriptor&& descriptor, NativeTestTargetMeta&& testMetaData)
         : TestTarget(AZStd::move(descriptor), AZStd::move(testMetaData.m_testTargetMeta))
@@ -25,5 +31,10 @@ namespace TestImpact
     LaunchMethod NativeTestTarget::GetLaunchMethod() const
     {
         return m_launchMeta.m_launchMethod;
+    }
+
+    bool NativeTestTarget::CanEnumerate() const
+    {
+        return GetSuiteLabelSet().contains(SupportedTestFrameworks::GTest);
     }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/Target/Native/TestImpactNativeTestTarget.h
@@ -28,6 +28,9 @@ namespace TestImpact
         //! Returns the test target launch method.
         LaunchMethod GetLaunchMethod() const;
 
+        // TestTarget overrides ...
+        bool CanEnumerate() const override;
+
     private:
         NativeTargetLaunchMeta m_launchMeta;
     };

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.cpp
@@ -270,7 +270,7 @@ namespace TestImpact
     }
 
     AZStd::vector<TestTargetAndEnumeration> NativeTestEngine::GenerateTestTargetAndEnumerations(
-        const AZStd::vector<const NativeTestTarget*> testTargets) const
+        const AZStd::vector<const NativeTestTarget*>& testTargets) const
     {
         const auto enumerationJobInfos = m_enumerationTestJobInfoGenerator->GenerateJobInfos(testTargets);
         auto [enumerationResult, enumerations] =

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.cpp
@@ -13,9 +13,10 @@
 #include <TestEngine/Native/TestImpactNativeTestEngine.h>
 #include <TestRunner/Native/TestImpactNativeErrorCodeChecker.h>
 #include <TestRunner/Native/TestImpactNativeTestEnumerator.h>
-#include <TestRunner/Native/TestImpactNativeInstrumentedTestRunner.h>
-#include <TestRunner/Native/TestImpactNativeRegularTestRunner.h>
+#include <TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.h>
+#include <TestRunner/Native/TestImpactNativeShardedRegularTestRunner.h>
 #include <TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.h>
+#include <TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h>
 
 namespace TestImpact
 {
@@ -121,7 +122,7 @@ namespace TestImpact
         using TestEngineJobType = TestEngineEnumeration<NativeTestTarget>;
     };
 
-    // Type trait for the test runner
+    // Type trait for the regular test runner
     template<>
     struct TestJobRunnerTrait<NativeRegularTestRunner>
     {
@@ -135,29 +136,66 @@ namespace TestImpact
         using TestEngineJobType = TestEngineInstrumentedRun<NativeTestTarget, TestCoverage>;
     };
 
+    // Type trait for the sharded regular test runner
+    template<>
+    struct TestJobRunnerTrait<NativeShardedRegularTestRunner>
+    {
+        using TestEngineJobType = TestEngineRegularRun<NativeTestTarget>;
+    };
+
+
+    // Type trait for the sharded instrumented test runner
+    template<>
+    struct TestJobRunnerTrait<NativeShardedInstrumentedTestRunner>
+    {
+        using TestEngineJobType = TestEngineInstrumentedRun<NativeTestTarget, TestCoverage>;
+    };
+
     NativeTestEngine::NativeTestEngine(
-        const RepoPath& sourceDir,
+        const RepoPath& repoRootDir,
         const RepoPath& targetBinaryDir,
-        [[maybe_unused]]const RepoPath& cacheDir,
         const ArtifactDir& artifactDir,
+        const NativeShardedArtifactDir& shardedArtifactDir,
         const RepoPath& testRunnerBinary,
         const RepoPath& instrumentBinary,
         size_t maxConcurrentRuns)
-        : m_regularTestJobInfoGenerator(AZStd::make_unique<NativeRegularTestRunJobInfoGenerator>(
-            sourceDir,
+        : m_enumerationTestJobInfoGenerator(AZStd::make_unique<NativeTestEnumerationJobInfoGenerator>(
+            targetBinaryDir,
+            artifactDir,
+            testRunnerBinary))
+        , m_regularTestJobInfoGenerator(AZStd::make_unique<NativeRegularTestRunJobInfoGenerator>(
+            repoRootDir,
             targetBinaryDir,
             artifactDir,
             testRunnerBinary))
         , m_instrumentedTestJobInfoGenerator(AZStd::make_unique<NativeInstrumentedTestRunJobInfoGenerator>(
-            sourceDir,
+            repoRootDir,
             targetBinaryDir,
             artifactDir,
+            testRunnerBinary,
+            instrumentBinary))
+        , m_shardedRegularTestJobInfoGenerator(AZStd::make_unique<NativeShardedRegularTestRunJobInfoGenerator>(
+            *m_regularTestJobInfoGenerator.get(),
+            maxConcurrentRuns,
+            repoRootDir,
+            targetBinaryDir,
+            shardedArtifactDir,
+            testRunnerBinary))
+        , m_shardedInstrumentedTestJobInfoGenerator(AZStd::make_unique<NativeShardedInstrumentedTestRunJobInfoGenerator>(
+            *m_instrumentedTestJobInfoGenerator.get(),
+            maxConcurrentRuns,
+            repoRootDir,
+            targetBinaryDir,
+            shardedArtifactDir,
             testRunnerBinary,
             instrumentBinary))
         , m_testEnumerator(AZStd::make_unique<NativeTestEnumerator>(maxConcurrentRuns))
         , m_instrumentedTestRunner(AZStd::make_unique<NativeInstrumentedTestRunner>(maxConcurrentRuns))
         , m_testRunner(AZStd::make_unique<NativeRegularTestRunner>(maxConcurrentRuns))
+        , m_shardedInstrumentedTestRunner(AZStd::make_unique<NativeShardedInstrumentedTestRunner>(*m_instrumentedTestRunner.get(), repoRootDir, artifactDir))
+        , m_shardedTestRunner(AZStd::make_unique<NativeShardedRegularTestRunner>(*m_testRunner.get(), repoRootDir, artifactDir))
         , m_artifactDir(artifactDir)
+        , m_shardedArtifactDir(shardedArtifactDir)
     {
     }
 
@@ -167,6 +205,8 @@ namespace TestImpact
     {
         DeleteFiles(m_artifactDir.m_testRunArtifactDirectory, "*.xml");
         DeleteFiles(m_artifactDir.m_coverageArtifactDirectory, "*.xml");
+        DeleteFiles(m_shardedArtifactDir.m_shardedTestRunArtifactDirectory, "*.xml");
+        DeleteFiles(m_shardedArtifactDir.m_shardedCoverageArtifactDirectory, "*.xml");
     }
 
     TestEngineRegularRunResult<NativeTestTarget> NativeTestEngine::RegularRun(
@@ -179,11 +219,12 @@ namespace TestImpact
     {
         DeleteXmlArtifacts();
 
-        const auto jobInfos = m_regularTestJobInfoGenerator->GenerateJobInfos(testTargets);
+        const auto shardedJobInfos =
+            m_shardedRegularTestJobInfoGenerator->GenerateJobInfos(GenerateTestTargetAndEnumerations(testTargets));
 
         return RunTests(
-            m_testRunner.get(),
-            jobInfos,
+            m_shardedTestRunner.get(),
+            shardedJobInfos,
             testTargets,
             NativeRegularTestRunnerErrorCodeChecker,
             executionFailurePolicy,
@@ -204,30 +245,50 @@ namespace TestImpact
     {
         DeleteXmlArtifacts();
 
-        const auto jobInfos = m_instrumentedTestJobInfoGenerator->GenerateJobInfos(testTargets);
-
+        const auto shardedJobInfos =
+            m_shardedInstrumentedTestJobInfoGenerator->GenerateJobInfos(GenerateTestTargetAndEnumerations(testTargets));
+        
         const auto result = RunTests(
-                m_instrumentedTestRunner.get(),
-                jobInfos,
-                testTargets,
-                NativeInstrumentedTestRunnerErrorCodeChecker,
-                executionFailurePolicy,
-                testFailurePolicy,
-                targetOutputCapture,
-                testTargetTimeout,
-                globalTimeout);
+            m_shardedInstrumentedTestRunner.get(),
+            shardedJobInfos,
+            testTargets,
+            NativeInstrumentedTestRunnerErrorCodeChecker,
+            executionFailurePolicy,
+            testFailurePolicy,
+            targetOutputCapture,
+            testTargetTimeout,
+            globalTimeout);
+        
+        if (const auto integrityErrors = GenerateIntegrityErrorString(result); !integrityErrors.empty())
+        {
+            AZ_TestImpact_Eval(integrityFailurePolicy != Policy::IntegrityFailure::Abort, TestEngineException, integrityErrors);
+        
+            AZ_Error("InstrumentedRun", false, integrityErrors.c_str());
+        }
 
-            if(const auto integrityErrors = GenerateIntegrityErrorString(result);
-                !integrityErrors.empty())
-            {
-                AZ_TestImpact_Eval(
-                        integrityFailurePolicy != Policy::IntegrityFailure::Abort,
-                        TestEngineException,
-                        integrityErrors);
+        return result;
+    }
 
-                AZ_Error("InstrumentedRun", false, integrityErrors.c_str());
-            }
+    AZStd::vector<TestTargetAndEnumeration> NativeTestEngine::GenerateTestTargetAndEnumerations(
+        const AZStd::vector<const NativeTestTarget*> testTargets) const
+    {
+        const auto enumerationJobInfos = m_enumerationTestJobInfoGenerator->GenerateJobInfos(testTargets);
+        auto [enumerationResult, enumerations] =
+            m_testEnumerator->Enumerate(enumerationJobInfos, StdOutputRouting::None, StdErrorRouting::None, AZStd::nullopt, AZStd::nullopt);
 
-            return result;
+        if (enumerationResult != ProcessSchedulerResult::Graceful)
+        {
+            return {};
+        }
+
+        AZStd::vector<TestTargetAndEnumeration> testTargetsAndEnumerations;
+        testTargetsAndEnumerations.reserve(enumerations.size());
+        for (auto&& enumeration : enumerations)
+        {
+            testTargetsAndEnumerations.emplace_back(
+                testTargets[enumeration.GetJobInfo().GetId().m_value], AZStd::move(enumeration.ReleasePayload()));
+        }
+
+        return testTargetsAndEnumerations;
     }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
@@ -115,7 +115,7 @@ namespace TestImpact
         //! Cleans up the artifacts directory of any artifacts from previous runs.
         void DeleteXmlArtifacts() const;
 
-        //!
+        //! Helper function to generate the test target and enumeration pairs for a given set of test targets.
         AZStd::vector<TestTargetAndEnumeration> GenerateTestTargetAndEnumerations(const AZStd::vector<const NativeTestTarget*> testTargets) const;
 
         AZStd::unique_ptr<NativeTestEnumerationJobInfoGenerator> m_enumerationTestJobInfoGenerator;

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
@@ -116,7 +116,7 @@ namespace TestImpact
         void DeleteXmlArtifacts() const;
 
         //! Helper function to generate the test target and enumeration pairs for a given set of test targets.
-        AZStd::vector<TestTargetAndEnumeration> GenerateTestTargetAndEnumerations(const AZStd::vector<const NativeTestTarget*> testTargets) const;
+        AZStd::vector<TestTargetAndEnumeration> GenerateTestTargetAndEnumerations(const AZStd::vector<const NativeTestTarget*>& testTargets) const;
 
         AZStd::unique_ptr<NativeTestEnumerationJobInfoGenerator> m_enumerationTestJobInfoGenerator;
         AZStd::unique_ptr<NativeRegularTestRunJobInfoGenerator> m_regularTestJobInfoGenerator;

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestEngine/Native/TestImpactNativeTestEngine.h
@@ -23,29 +23,34 @@
 namespace TestImpact
 {
     class NativeTestTarget;
+    class NativeTestEnumerationJobInfoGenerator;
     class NativeRegularTestRunJobInfoGenerator;
     class NativeInstrumentedTestRunJobInfoGenerator;
+    class NativeShardedRegularTestRunJobInfoGenerator;
+    class NativeShardedInstrumentedTestRunJobInfoGenerator;
     class NativeTestEnumerator;
     class NativeInstrumentedTestRunner;
     class NativeRegularTestRunner;
+    class NativeShardedInstrumentedTestRunner;
+    class NativeShardedRegularTestRunner;
 
     //! Provides the front end for performing test enumerations and test runs.
     class NativeTestEngine
     {
     public:
         //! Configures the test engine with the necessary path information for launching test targets and managing the artifacts they produce.
-        //! @param sourceDir Root path where source files are found (including subfolders).
+        //! @param repoRootDir Root path where source files are found (including subfolders).
         //! @param targetBinaryDir Path to where the test target binaries are found.
-        //! @param cacheDir Path to the persistent folder where test target enumerations are cached.
         //! @param artifactDir Path to the transient directory where test artifacts are produced.
+        //! @param shardedArtifactDir Path to the transient directory where sharded test artifacts are produced.
         //! @param testRunnerBinary Path to the binary responsible for launching test targets that have the TestRunner launch method.
         //! @param instrumentBinary Path to the binary responsible for launching test targets with test coverage instrumentation.
         //! @param maxConcurrentRuns The maximum number of concurrent test targets that can be in flight at any given moment.
         NativeTestEngine(
-            const RepoPath& sourceDir,
+            const RepoPath& repoRootDir,
             const RepoPath& targetBinaryDir,
-            const RepoPath& cacheDir,
             const ArtifactDir& artifactDir,
+            const NativeShardedArtifactDir& shardedArtifactDir,
             const RepoPath& testRunnerBinary,
             const RepoPath& instrumentBinary,
             size_t maxConcurrentRuns);
@@ -72,7 +77,6 @@ namespace TestImpact
 
         //! Performs a test run without any instrumentation and, for each test target, returns the test run results and metrics about the run.
         //! @param testTargets The test targets to run.
-        //! @param testShardingPolicy Test sharding policy to use for test targets in this run.
         //! @param executionFailurePolicy Policy for how test execution failures should be handled.
         //! @param testFailurePolicy Policy for how test targets with failing tests should be handled.
         //! @param targetOutputCapture Policy for how test target standard output should be captured and handled.
@@ -111,11 +115,20 @@ namespace TestImpact
         //! Cleans up the artifacts directory of any artifacts from previous runs.
         void DeleteXmlArtifacts() const;
 
+        //!
+        AZStd::vector<TestTargetAndEnumeration> GenerateTestTargetAndEnumerations(const AZStd::vector<const NativeTestTarget*> testTargets) const;
+
+        AZStd::unique_ptr<NativeTestEnumerationJobInfoGenerator> m_enumerationTestJobInfoGenerator;
         AZStd::unique_ptr<NativeRegularTestRunJobInfoGenerator> m_regularTestJobInfoGenerator;
         AZStd::unique_ptr<NativeInstrumentedTestRunJobInfoGenerator> m_instrumentedTestJobInfoGenerator;
+        AZStd::unique_ptr<NativeShardedRegularTestRunJobInfoGenerator> m_shardedRegularTestJobInfoGenerator;
+        AZStd::unique_ptr<NativeShardedInstrumentedTestRunJobInfoGenerator> m_shardedInstrumentedTestJobInfoGenerator;
         AZStd::unique_ptr<NativeTestEnumerator> m_testEnumerator;
         AZStd::unique_ptr<NativeInstrumentedTestRunner> m_instrumentedTestRunner;
         AZStd::unique_ptr<NativeRegularTestRunner> m_testRunner;
+        AZStd::unique_ptr<NativeShardedInstrumentedTestRunner> m_shardedInstrumentedTestRunner;
+        AZStd::unique_ptr<NativeShardedRegularTestRunner> m_shardedTestRunner;
         ArtifactDir m_artifactDir;
+        NativeShardedArtifactDir m_shardedArtifactDir;
     };
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestImpactNativeRuntime.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestImpactNativeRuntime.cpp
@@ -26,7 +26,9 @@
 namespace TestImpact
 {
     NativeTestTargetMetaMap ReadNativeTestTargetMetaMapFile(
-        const SuiteSet& suiteSet, const SuiteLabelExcludeSet& suiteLabelExcludeSet, const RepoPath& testTargetMetaConfigFile)
+        const SuiteSet& suiteSet,
+        const SuiteLabelExcludeSet& suiteLabelExcludeSet,
+        const RepoPath& testTargetMetaConfigFile)
     {
         const auto masterTestListData = ReadFileContents<RuntimeException>(testTargetMetaConfigFile);
         return NativeTestTargetMetaMapFactory(masterTestListData, suiteSet, suiteLabelExcludeSet);
@@ -43,7 +45,6 @@ namespace TestImpact
         Policy::FailedTestCoverage failedTestCoveragePolicy,
         Policy::TestFailure testFailurePolicy,
         Policy::IntegrityFailure integrationFailurePolicy,
-        Policy::TestSharding testShardingPolicy,
         Policy::TargetOutputCapture targetOutputCapture,
         AZStd::optional<size_t> maxConcurrency)
         : m_config(AZStd::move(config))
@@ -53,7 +54,6 @@ namespace TestImpact
         , m_failedTestCoveragePolicy(failedTestCoveragePolicy)
         , m_testFailurePolicy(testFailurePolicy)
         , m_integrationFailurePolicy(integrationFailurePolicy)
-        , m_testShardingPolicy(testShardingPolicy)
         , m_targetOutputCapture(targetOutputCapture)
         , m_maxConcurrency(maxConcurrency.value_or(AZStd::thread::hardware_concurrency()))
     {
@@ -96,8 +96,8 @@ namespace TestImpact
         m_testEngine = AZStd::make_unique<TestEngine>(
             m_config.m_commonConfig.m_repo.m_root,
             m_config.m_target.m_outputDirectory,
-            m_config.m_workspace.m_temp.m_enumerationCacheDirectory,
             m_config.m_workspace.m_temp,
+            m_config.m_shardedArtifactDir,
             m_config.m_testEngine.m_testRunner.m_binary,
             m_config.m_testEngine.m_instrumentation.m_binary,
             m_maxConcurrency);
@@ -200,7 +200,6 @@ namespace TestImpact
         policyState.m_integrityFailurePolicy = m_integrationFailurePolicy;
         policyState.m_targetOutputCapture = m_targetOutputCapture;
         policyState.m_testFailurePolicy = m_testFailurePolicy;
-        policyState.m_testShardingPolicy = m_testShardingPolicy;
 
         return policyState;
     }

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestImpactNativeRuntimeConfigurationFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestImpactNativeRuntimeConfigurationFactory.cpp
@@ -64,8 +64,12 @@ namespace TestImpact
     NativeTestEngineConfig ParseTestEngineConfig(const rapidjson::Value& testEngine)
     {
         NativeTestEngineConfig testEngineConfig;
-        testEngineConfig.m_testRunner.m_binary = testEngine[NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestRunner]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::BinaryFile]].GetString();
-        testEngineConfig.m_instrumentation.m_binary = testEngine[NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestInstrumentation]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::BinaryFile]].GetString();
+        testEngineConfig.m_testRunner.m_binary =
+            testEngine[NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestRunner]]
+                [NativeConfigFactory::Keys[NativeConfigFactory::Fields::BinaryFile]].GetString();
+        testEngineConfig.m_instrumentation.m_binary =
+            testEngine[NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestInstrumentation]]
+                [NativeConfigFactory::Keys[NativeConfigFactory::Fields::BinaryFile]].GetString();
         return testEngineConfig;
     }
 
@@ -74,8 +78,10 @@ namespace TestImpact
         NativeTargetConfig targetConfig;
         targetConfig.m_outputDirectory = target[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Directory]].GetString();
         const auto& testExcludes = target[NativeConfigFactory::Keys[NativeConfigFactory::Fields::TargetExclude]];
-        targetConfig.m_excludedTargets.m_excludedRegularTestTargets = ParseTargetExcludeList(testExcludes[NativeConfigFactory::Keys[NativeConfigFactory::Fields::RegularTargetExcludeFilter]].GetArray());
-        targetConfig.m_excludedTargets.m_excludedInstrumentedTestTargets = ParseTargetExcludeList(testExcludes[NativeConfigFactory::Keys[NativeConfigFactory::Fields::InstrumentedTargetExcludeFilter]].GetArray());
+        targetConfig.m_excludedTargets.m_excludedRegularTestTargets =
+            ParseTargetExcludeList(testExcludes[NativeConfigFactory::Keys[NativeConfigFactory::Fields::RegularTargetExcludeFilter]].GetArray());
+        targetConfig.m_excludedTargets.m_excludedInstrumentedTestTargets =
+            ParseTargetExcludeList(testExcludes[NativeConfigFactory::Keys[NativeConfigFactory::Fields::InstrumentedTargetExcludeFilter]].GetArray());
 
         return targetConfig;
     }
@@ -83,8 +89,10 @@ namespace TestImpact
     NativeShardedArtifactDir ParseShardedArtifactConfig(const rapidjson::Value& tempWorkspace)
     {
         NativeShardedArtifactDir shardedWorkspaceConfig;
-        shardedWorkspaceConfig.m_shardedTestRunArtifactDirectory = tempWorkspace[NativeConfigFactory::Keys[NativeConfigFactory::Fields::ShardedRunArtifactDir]].GetString();
-        shardedWorkspaceConfig.m_shardedCoverageArtifactDirectory = tempWorkspace[NativeConfigFactory::Keys[NativeConfigFactory::Fields::ShardedCoverageArtifactDir]].GetString();
+        shardedWorkspaceConfig.m_shardedTestRunArtifactDirectory =
+            tempWorkspace[NativeConfigFactory::Keys[NativeConfigFactory::Fields::ShardedRunArtifactDir]].GetString();
+        shardedWorkspaceConfig.m_shardedCoverageArtifactDirectory =
+            tempWorkspace[NativeConfigFactory::Keys[NativeConfigFactory::Fields::ShardedCoverageArtifactDir]].GetString();
         return shardedWorkspaceConfig;
     }
 
@@ -100,11 +108,19 @@ namespace TestImpact
 
         NativeRuntimeConfig runtimeConfig;
         runtimeConfig.m_commonConfig = RuntimeConfigurationFactory(configurationData);
-        runtimeConfig.m_workspace = ParseWorkspaceConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::Workspace]]);
+        runtimeConfig.m_workspace =
+            ParseWorkspaceConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]]
+                [NativeConfigFactory::Keys[NativeConfigFactory::Fields::Workspace]]);
         runtimeConfig.m_shardedArtifactDir = ParseShardedArtifactConfig(
-            configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::Workspace]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::TempWorkspace]]);
-        runtimeConfig.m_testEngine = ParseTestEngineConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestEngine]]);
-        runtimeConfig.m_target = ParseTargetConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::TargetConfig]]);
+            configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]]
+                [NativeConfigFactory::Keys[NativeConfigFactory::Fields::Workspace]]
+                    [NativeConfigFactory::Keys[NativeConfigFactory::Fields::TempWorkspace]]);
+        runtimeConfig.m_testEngine =
+            ParseTestEngineConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]]
+                [NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestEngine]]);
+        runtimeConfig.m_target =
+            ParseTargetConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]]
+                [NativeConfigFactory::Keys[NativeConfigFactory::Fields::TargetConfig]]);
 
         return runtimeConfig;
     }

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestImpactNativeRuntimeConfigurationFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestImpactNativeRuntimeConfigurationFactory.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <TestImpactFramework/TestImpactConfigurationException.h>
+#include <TestImpactFramework/TestImpactUtils.h>
+#include <TestImpactFramework/Native/TestImpactNativeConfiguration.h>
+
+#include <TestImpactRuntimeConfigurationFactory.h>
+
+#include <AzCore/std/functional.h>
+#include <AzCore/std/optional.h>
+
+namespace TestImpact
+{
+    namespace NativeConfigFactory
+    {
+        // Keys for pertinent JSON elements
+        constexpr const char* Keys[] =
+        {
+            "native",
+            "test_engine",
+            "target",
+            "test_runner",
+            "bin",
+            "instrumentation",
+            "dir",
+            "exclude",
+            "regular",
+            "instrumented",
+            "target",
+            "workspace",
+            "temp",
+            "sharded_run_artifact_dir",
+            "sharded_coverage_artifact_dir"
+        };
+
+        enum Fields
+        {
+            Native,
+            TestEngine,
+            TargetConfig,
+            TestRunner,
+            BinaryFile,
+            TestInstrumentation,
+            Directory,
+            TargetExclude,
+            RegularTargetExcludeFilter,
+            InstrumentedTargetExcludeFilter,
+            TargetName,
+            Workspace,
+            TempWorkspace,
+            ShardedRunArtifactDir,
+            ShardedCoverageArtifactDir,
+            // Checksum
+            _CHECKSUM_
+        };
+    } // namespace NativeConfigFactory
+
+    NativeTestEngineConfig ParseTestEngineConfig(const rapidjson::Value& testEngine)
+    {
+        NativeTestEngineConfig testEngineConfig;
+        testEngineConfig.m_testRunner.m_binary = testEngine[NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestRunner]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::BinaryFile]].GetString();
+        testEngineConfig.m_instrumentation.m_binary = testEngine[NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestInstrumentation]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::BinaryFile]].GetString();
+        return testEngineConfig;
+    }
+
+    NativeTargetConfig ParseTargetConfig(const rapidjson::Value& target)
+    {
+        NativeTargetConfig targetConfig;
+        targetConfig.m_outputDirectory = target[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Directory]].GetString();
+        const auto& testExcludes = target[NativeConfigFactory::Keys[NativeConfigFactory::Fields::TargetExclude]];
+        targetConfig.m_excludedTargets.m_excludedRegularTestTargets = ParseTargetExcludeList(testExcludes[NativeConfigFactory::Keys[NativeConfigFactory::Fields::RegularTargetExcludeFilter]].GetArray());
+        targetConfig.m_excludedTargets.m_excludedInstrumentedTestTargets = ParseTargetExcludeList(testExcludes[NativeConfigFactory::Keys[NativeConfigFactory::Fields::InstrumentedTargetExcludeFilter]].GetArray());
+
+        return targetConfig;
+    }
+
+    NativeShardedArtifactDir ParseShardedArtifactConfig(const rapidjson::Value& tempWorkspace)
+    {
+        NativeShardedArtifactDir shardedWorkspaceConfig;
+        shardedWorkspaceConfig.m_shardedTestRunArtifactDirectory = tempWorkspace[NativeConfigFactory::Keys[NativeConfigFactory::Fields::ShardedRunArtifactDir]].GetString();
+        shardedWorkspaceConfig.m_shardedCoverageArtifactDirectory = tempWorkspace[NativeConfigFactory::Keys[NativeConfigFactory::Fields::ShardedCoverageArtifactDir]].GetString();
+        return shardedWorkspaceConfig;
+    }
+
+    NativeRuntimeConfig NativeRuntimeConfigurationFactory(const AZStd::string& configurationData)
+    {
+        static_assert(NativeConfigFactory::Fields::_CHECKSUM_ == AZStd::size(NativeConfigFactory::Keys));
+        rapidjson::Document configurationFile;
+
+        if (configurationFile.Parse(configurationData.c_str()).HasParseError())
+        {
+            throw TestImpact::ConfigurationException("Could not parse runtimeConfig data, JSON has errors");
+        }
+
+        NativeRuntimeConfig runtimeConfig;
+        runtimeConfig.m_commonConfig = RuntimeConfigurationFactory(configurationData);
+        runtimeConfig.m_workspace = ParseWorkspaceConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::Workspace]]);
+        runtimeConfig.m_shardedArtifactDir = ParseShardedArtifactConfig(
+            configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::Workspace]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::TempWorkspace]]);
+        runtimeConfig.m_testEngine = ParseTestEngineConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::TestEngine]]);
+        runtimeConfig.m_target = ParseTargetConfig(configurationFile[NativeConfigFactory::Keys[NativeConfigFactory::Fields::Native]][NativeConfigFactory::Keys[NativeConfigFactory::Fields::TargetConfig]]);
+
+        return runtimeConfig;
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <TestImpactFramework/TestImpactTestSequence.h>
+
+#include <TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h>
+
+namespace TestImpact
+{
+    NativeShardedInstrumentedTestRunJobInfoGenerator::NativeShardedInstrumentedTestRunJobInfoGenerator(
+        const JobInfoGenerator& jobInfoGenerator,
+        size_t maxConcurrency,
+        const RepoPath& sourceDir,
+        const RepoPath& targetBinaryDir,
+        const NativeShardedArtifactDir& artifactDir,
+        const RepoPath& testRunnerBinary,
+        const RepoPath& instrumentBinary,
+        CoverageLevel coverageLevel)
+        : NativeShardedTestRunJobInfoGeneratorBase<NativeInstrumentedTestRunner>(
+            jobInfoGenerator,
+            maxConcurrency,
+            sourceDir,
+            targetBinaryDir,
+            artifactDir,
+            testRunnerBinary)
+        , m_instrumentBinary(instrumentBinary)
+        , m_coverageLevel(coverageLevel)
+    {
+    }
+
+    RepoPath NativeShardedInstrumentedTestRunJobInfoGenerator::GenerateShardedTargetCoverageArtifactFilePath(
+        const NativeTestTarget* testTarget, size_t shardNumber) const
+    {
+        auto artifactFilePath = GenerateTargetCoverageArtifactFilePath(testTarget, m_artifactDir.m_shardedCoverageArtifactDirectory);
+        return artifactFilePath.ReplaceExtension(
+            AZStd::string::format("%zu%s", shardNumber, artifactFilePath.Extension().String().c_str()).c_str());
+    }
+
+    ShardedInstrumentedTestJobInfo NativeShardedInstrumentedTestRunJobInfoGenerator::GenerateJobInfoImpl(
+        const TestTargetAndEnumeration& testTargetAndEnumeration,
+        typename NativeInstrumentedTestRunner::JobInfo::Id startingId) const
+    {
+        const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
+        const auto testFilters = TestListsToTestFilters(ShardTestInterleaved(testTargetAndEnumeration));
+        typename ShardedInstrumentedTestJobInfo::JobInfos jobInfos;
+        jobInfos.reserve(testFilters.size());
+
+        for (size_t i = 0; i < testFilters.size(); i++)
+        {
+            const auto shardedRunArtifact = GenerateShardedTargetRunArtifactFilePath(testTarget, i);
+            const auto shardCoverageArtifact = GenerateShardedTargetCoverageArtifactFilePath(testTarget, i);
+            const RepoPath shardAdditionalArgsFile = GenerateShardedAdditionalArgsFilePath(testTarget, i);
+            const auto shardLaunchCommand = GenerateShardedLaunchCommand(testTarget, shardAdditionalArgsFile);
+            WriteFileContents<TestRunnerException>(testFilters[i], shardAdditionalArgsFile);
+
+            const auto command = GenerateInstrumentedTestJobInfoCommand(
+                m_instrumentBinary,
+                shardCoverageArtifact,
+                m_coverageLevel,
+                m_targetBinaryDir,
+                m_testRunnerBinary,
+                m_sourceDir,
+                GenerateRegularTestJobInfoCommand(shardLaunchCommand, shardedRunArtifact));
+
+            jobInfos.emplace_back(
+                NativeInstrumentedTestRunner::JobInfo::Id{ startingId.m_value + i },
+                command,
+                NativeInstrumentedTestRunner::JobData(testTarget->GetLaunchMethod(), shardedRunArtifact, shardCoverageArtifact));
+        }
+
+        return ShardedInstrumentedTestJobInfo(testTarget, AZStd::move(jobInfos));
+    }
+
+    ShardedRegularTestJobInfo NativeShardedRegularTestRunJobInfoGenerator::GenerateJobInfoImpl(
+        const TestTargetAndEnumeration& testTargetAndEnumeration,
+        typename NativeRegularTestRunner::JobInfo::Id startingId) const
+    {
+        const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
+        const auto testFilters = TestListsToTestFilters(ShardTestInterleaved(testTargetAndEnumeration));
+        typename ShardedRegularTestJobInfo::JobInfos jobInfos;
+        jobInfos.reserve(testFilters.size());
+
+        for (size_t i = 0; i < testFilters.size(); i++)
+        {
+            const auto shardedRunArtifact = GenerateShardedTargetRunArtifactFilePath(testTarget,  i);
+            const RepoPath shardAdditionalArgsFile = GenerateShardedAdditionalArgsFilePath(testTarget, i);
+            const auto shardLaunchCommand = GenerateShardedLaunchCommand(testTarget, shardAdditionalArgsFile);
+            WriteFileContents<TestRunnerException>(testFilters[i], shardAdditionalArgsFile);
+            const auto command = GenerateRegularTestJobInfoCommand(shardLaunchCommand, shardedRunArtifact);
+
+            jobInfos.emplace_back(
+                NativeRegularTestRunner::JobInfo::Id{ startingId.m_value + i },
+                command,
+                NativeRegularTestRunner::JobData(testTarget->GetLaunchMethod(), shardedRunArtifact));
+        }
+
+        return ShardedRegularTestJobInfo(testTarget, AZStd::move(jobInfos));
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
@@ -272,6 +272,9 @@ namespace TestImpact
         for (size_t testTargetIndex = 0, jobId = 0; testTargetIndex < testTargetsAndEnumerations.size(); testTargetIndex++)
         {
             jobInfos.push_back(GenerateJobInfo(testTargetsAndEnumerations[testTargetIndex], { jobId }));
+
+            // Increment the job id by the number of sharded job infos generated for the most recently added test target so that the next
+            // job id used is contiguous in seqeunce
             jobId += jobInfos.back().GetJobInfos().size();
         }
 

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <TestImpactFramework/Native/TestImpactNativeConfiguration.h>
+
+#include <Target/Native/TestImpactNativeTestTarget.h>
+#include <TestEngine/Common/Enumeration/TestImpactTestEngineEnumeration.h>
+#include <TestRunner/Common/Job/TestImpactTestJobInfoUtils.h>
+#include <TestRunner/Native/TestImpactNativeRegularTestRunner.h>
+#include <TestRunner/Native/TestImpactNativeInstrumentedTestRunner.h>
+#include <TestRunner/Native/TestImpactNativeRegularTestRunner.h>
+#include <TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.h>
+#include <TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.h>
+
+namespace TestImpact
+{
+    //!
+    template<typename TestJobRunner>
+    class ShardedTestJobInfo
+    {
+    public:
+        using Id = typename TestJobRunner::JobInfo::Id;
+        using IdType = typename TestJobRunner::JobInfo::IdType;
+        using JobInfos = typename TestJobRunner::JobInfos;
+
+        ShardedTestJobInfo(const NativeTestTarget* testTarget, JobInfos&& jobInfos)
+            : m_testTarget(testTarget)
+            , m_jobInfos(AZStd::move(jobInfos))
+        {
+            AZ_TestImpact_Eval(!m_jobInfos.empty(), TestRunnerException, "Attepted to instantiate a sharded test job info no sub job infos");
+        }
+
+        //!
+        Id GetId() const
+        {
+            return m_jobInfos.front().GetId();
+        }
+
+        const NativeTestTarget* GetTestTarget() const
+        {
+            return m_testTarget;
+        }
+
+        const JobInfos& GetJobInfos() const
+        {
+            return m_jobInfos;
+        }
+
+    private:
+        const NativeTestTarget* m_testTarget = nullptr;
+        JobInfos m_jobInfos;
+    };
+
+    //!
+    using ShardedInstrumentedTestJobInfo = ShardedTestJobInfo<NativeInstrumentedTestRunner>;
+
+    //!
+    using ShardedRegularTestJobInfo = ShardedTestJobInfo<NativeRegularTestRunner>;
+
+    using TestTargetAndEnumeration = AZStd::pair<const NativeTestTarget*, AZStd::optional<TestEnumeration>>;
+
+    //!
+    template<typename TestJobRunner>
+    class NativeShardedTestRunJobInfoGeneratorBase
+    {
+    public:
+        //!
+        using JobInfoGenerator = typename TestJobRunner::JobInfoGenerator;
+
+        NativeShardedTestRunJobInfoGeneratorBase(
+            const JobInfoGenerator& jobInfoGenerator,
+            size_t maxConcurrency,
+            const RepoPath& sourceDir,
+            const RepoPath& targetBinaryDir,
+            const NativeShardedArtifactDir& artifactDir,
+            const RepoPath& testRunnerBinary);
+
+        virtual ~NativeShardedTestRunJobInfoGeneratorBase() = default;
+
+        //!
+        ShardedTestJobInfo<TestJobRunner> GenerateJobInfo(
+            const TestTargetAndEnumeration& testTargetAndEnumeration,
+            typename TestJobRunner::JobInfo::Id startingId);
+
+        AZStd::vector<ShardedTestJobInfo<TestJobRunner>> GenerateJobInfos(
+            const AZStd::vector<TestTargetAndEnumeration>& testTargetsAndEnumerations);
+
+    protected:
+        //!
+        using ShardedTestsList = AZStd::vector<AZStd::vector<AZStd::string>>;
+
+        //!
+        using ShardedTestsFilter = AZStd::vector<AZStd::string>;
+
+        //!
+        virtual ShardedTestJobInfo<TestJobRunner> GenerateJobInfoImpl(
+            const TestTargetAndEnumeration& testTargetAndEnumeration, typename TestJobRunner::JobInfo::Id startingId) const = 0;
+
+        //!
+        ShardedTestsList ShardTestInterleaved(const TestTargetAndEnumeration& testTargetAndEnumeration) const;
+
+        //!
+        ShardedTestsFilter TestListsToTestFilters(const ShardedTestsList& shardedTestList) const;
+
+        //!
+        RepoPath GenerateShardedTargetRunArtifactFilePath(const NativeTestTarget* testTarget, size_t shardNumber) const;
+
+        //!
+        RepoPath GenerateShardedAdditionalArgsFilePath(const NativeTestTarget* testTarget, size_t shardNumber) const;
+
+        //!
+        AZStd::string GenerateShardedLaunchCommand(
+            const NativeTestTarget* testTarget, const RepoPath& shardAdditionalArgsFile) const;
+
+        const JobInfoGenerator* m_jobInfoGenerator = nullptr;
+        size_t m_maxConcurrency;
+        RepoPath m_sourceDir;
+        RepoPath m_targetBinaryDir;
+        NativeShardedArtifactDir m_artifactDir;
+        RepoPath m_testRunnerBinary;
+    };
+
+    //!
+    class NativeShardedInstrumentedTestRunJobInfoGenerator
+        : public NativeShardedTestRunJobInfoGeneratorBase<NativeInstrumentedTestRunner>
+    {
+    public:
+        NativeShardedInstrumentedTestRunJobInfoGenerator(
+            const JobInfoGenerator& jobInfoGenerator,
+            size_t maxConcurrency,
+            const RepoPath& sourceDir,
+            const RepoPath& targetBinaryDir,
+            const NativeShardedArtifactDir& artifactDir,
+            const RepoPath& testRunnerBinary,
+            const RepoPath& instrumentBinary,
+            CoverageLevel coverageLevel = CoverageLevel::Source);
+
+    protected:
+        // NativeShardedTestRunJobInfoGeneratorBase overrides ...
+        ShardedInstrumentedTestJobInfo GenerateJobInfoImpl(
+            const TestTargetAndEnumeration& testTargetAndEnumeration,
+            typename NativeInstrumentedTestRunner::JobInfo::Id startingId) const override;
+
+    private:
+        //!
+        RepoPath GenerateShardedTargetCoverageArtifactFilePath(const NativeTestTarget* testTarget, size_t shardNumber) const;
+
+        RepoPath m_cacheDir;
+        RepoPath m_instrumentBinary;
+        CoverageLevel m_coverageLevel;
+    };
+
+    //!
+    class NativeShardedRegularTestRunJobInfoGenerator
+        :  public NativeShardedTestRunJobInfoGeneratorBase<NativeRegularTestRunner>
+    {
+    public:
+        using NativeShardedTestRunJobInfoGeneratorBase<NativeRegularTestRunner>::NativeShardedTestRunJobInfoGeneratorBase;
+
+    protected:
+        // NativeShardedTestRunJobInfoGeneratorBase overrides ...
+        ShardedRegularTestJobInfo GenerateJobInfoImpl(
+            const TestTargetAndEnumeration& testTargetAndEnumeration,
+            typename NativeRegularTestRunner::JobInfo::Id startingId) const override;
+    };
+
+    template<typename TestJobRunner>
+    NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::NativeShardedTestRunJobInfoGeneratorBase(
+        const JobInfoGenerator& jobInfoGenerator,
+        size_t maxConcurrency,
+        const RepoPath& sourceDir,
+        const RepoPath& targetBinaryDir,
+        const NativeShardedArtifactDir& artifactDir,
+        const RepoPath& testRunnerBinary)
+        : m_jobInfoGenerator(&jobInfoGenerator)
+        , m_maxConcurrency(maxConcurrency)
+        , m_sourceDir(sourceDir)
+        , m_targetBinaryDir(targetBinaryDir)
+        , m_artifactDir(artifactDir)
+        , m_testRunnerBinary(testRunnerBinary)
+    {
+        AZ_TestImpact_Eval(maxConcurrency != 0, TestRunnerException, "Max Number of concurrent processes in flight cannot be 0");
+    }
+
+    template<typename TestJobRunner>
+    ShardedTestJobInfo<TestJobRunner> NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::GenerateJobInfo(
+        const TestTargetAndEnumeration& testTargetAndEnumeration, typename TestJobRunner::JobInfo::Id startingId)
+    {
+        if (const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
+            m_maxConcurrency > 1 && testEnumeration.has_value() && testEnumeration->GetNumEnabledTests() > 1)
+        {
+            return GenerateJobInfoImpl(testTargetAndEnumeration, startingId);
+        }
+        else
+        {
+            return { testTarget, { m_jobInfoGenerator->GenerateJobInfo(testTarget, startingId) } };
+        }
+    }
+
+    template<typename TestJobRunner>
+    typename NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::ShardedTestsList NativeShardedTestRunJobInfoGeneratorBase<
+        TestJobRunner>::ShardTestInterleaved(const TestTargetAndEnumeration& testTargetAndEnumeration) const
+    {
+        const auto [testTarget, testEnumeration] = testTargetAndEnumeration;
+        const auto numTests = testEnumeration->GetNumEnabledTests();
+        const auto numShards = std::min(m_maxConcurrency, numTests);
+        ShardedTestsList shardTestList(numShards);
+        const auto testsPerShard = numTests / numShards;
+
+        size_t testIndex = 0;
+        for (const auto fixture : testEnumeration->GetTestSuites())
+        {
+            if (!fixture.m_enabled)
+            {
+                continue;
+            }
+
+            for (const auto test : fixture.m_tests)
+            {
+                if (!test.m_enabled)
+                {
+                    continue;
+                }
+
+                shardTestList[testIndex++ % numShards].emplace_back(
+                    AZStd::string::format("%s.%s", fixture.m_name.c_str(), test.m_name.c_str()));
+            }
+        }
+
+        return shardTestList;
+    }
+
+    template<typename TestJobRunner>
+    auto NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::TestListsToTestFilters(const ShardedTestsList& shardedTestList) const
+        -> ShardedTestsFilter
+    {
+        ShardedTestsFilter shardedTestFilter;
+        shardedTestFilter.reserve(shardedTestList.size());
+
+        for (const auto& shardTests : shardedTestList)
+        {
+            AZStd::string testFilter = "--gtest_filter=";
+            for (const auto& test : shardTests)
+            {
+                // The trailing colon added by the last test is still a valid gtest filter
+                testFilter += AZStd::string::format("%s:", test.c_str());
+            }
+
+            shardedTestFilter.emplace_back(testFilter);
+        }
+
+        return shardedTestFilter;
+    }
+
+    template<typename TestJobRunner>
+    auto NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::GenerateJobInfos(
+        const AZStd::vector<TestTargetAndEnumeration>& testTargetsAndEnumerations)
+        -> AZStd::vector<ShardedTestJobInfo<TestJobRunner>>
+    {
+        AZStd::vector<ShardedTestJobInfo<TestJobRunner>> jobInfos;
+        for (size_t testTargetIndex = 0, jobId = 0; testTargetIndex < testTargetsAndEnumerations.size(); testTargetIndex++)
+        {
+            jobInfos.push_back(GenerateJobInfo(testTargetsAndEnumerations[testTargetIndex], { jobId }));
+            jobId += jobInfos.back().GetJobInfos().size();
+        }
+
+        return jobInfos;
+    }
+
+    template<typename TestJobRunner>
+    RepoPath NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::GenerateShardedTargetRunArtifactFilePath(
+        const NativeTestTarget* testTarget, const size_t shardNumber) const
+    {
+        auto artifactFilePath = GenerateTargetRunArtifactFilePath(testTarget, m_artifactDir.m_shardedTestRunArtifactDirectory);
+        return artifactFilePath.ReplaceExtension(AZStd::string::format("%zu%s", shardNumber, artifactFilePath.Extension().String().c_str()).c_str());
+    }
+
+    template<typename TestJobRunner>
+    AZStd::string NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::GenerateShardedLaunchCommand(
+        const NativeTestTarget* testTarget, const RepoPath& shardAdditionalArgsFile) const
+    {
+        return AZStd::string::format(
+            "%s --args_from_file \"%s\"",
+            GenerateLaunchArgument(testTarget, m_targetBinaryDir, m_testRunnerBinary).c_str(),
+            shardAdditionalArgsFile.c_str());
+    }
+
+    template<typename TestJobRunner>
+    RepoPath NativeShardedTestRunJobInfoGeneratorBase<TestJobRunner>::GenerateShardedAdditionalArgsFilePath(
+        const NativeTestTarget* testTarget, size_t shardNumber) const
+    {
+        return AZStd::string::format(
+            "%s.%zu.args", (m_artifactDir.m_shardedTestRunArtifactDirectory / RepoPath(testTarget->GetName())).c_str(), shardNumber);
+    }
+} // namespace TestImpact
+
+namespace AZStd
+{
+    //!
+    template<>
+    struct less<TestImpact::TestTargetAndEnumeration>
+    {
+        bool operator()(const TestImpact::TestTargetAndEnumeration& lhs, const TestImpact::TestTargetAndEnumeration& rhs) const
+        {
+            return reinterpret_cast<size_t>(lhs.first) < reinterpret_cast<size_t>(rhs.first);
+        }
+    };
+
+    //!
+    template<>
+    struct hash<TestImpact::TestTargetAndEnumeration>
+    {
+        size_t operator()(const TestImpact::TestTargetAndEnumeration& testTargetAndEnumeration) const noexcept
+        {
+            return reinterpret_cast<size_t>(testTargetAndEnumeration.first);
+        }
+    };
+} // namespace AZStd

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.cpp
@@ -14,42 +14,19 @@
 
 namespace TestImpact
 {
-    NativeTestEnumerationJobInfoGenerator::NativeTestEnumerationJobInfoGenerator(
-        const RepoPath& targetBinaryDir,
-        const RepoPath& cacheDir,
-        const ArtifactDir& artifactDir,
-        const RepoPath& testRunnerBinary)
-        : m_targetBinaryDir(targetBinaryDir)
-        , m_cacheDir(cacheDir)
-        , m_artifactDir(artifactDir)
-        , m_testRunnerBinary(testRunnerBinary)
-    {
-    }
-
-
-    NativeTestEnumerator::JobInfo NativeTestEnumerationJobInfoGenerator::GenerateJobInfo(
+    NativeTestEnumerator::JobInfo NativeTestEnumerationJobInfoGenerator::GenerateJobInfoImpl(
         const NativeTestTarget* testTarget, NativeTestEnumerator::JobInfo::Id jobId) const
     {
-        using Cache = NativeTestEnumerator::JobData::Cache;
-
         const auto enumerationArtifact = GenerateTargetEnumerationArtifactFilePath(testTarget, m_artifactDir.m_enumerationCacheDirectory);
-        const Command args = { AZStd::string::format(
-            "%s --gtest_list_tests --gtest_output=xml:\"%s\"",
-            GenerateLaunchArgument(testTarget, m_targetBinaryDir, m_testRunnerBinary).c_str(), enumerationArtifact.c_str()) };
+        const auto launchArgument = GenerateLaunchArgument(testTarget, m_targetBinaryDir, m_testRunnerBinary);
+        const auto command = GenerateTestEnumeratorJobInfoCommand(launchArgument, enumerationArtifact);
 
         return JobInfo(
-            jobId, args,
-            JobData(enumerationArtifact, Cache{ m_cachePolicy, GenerateTargetEnumerationCacheFilePath(testTarget, m_cacheDir) }));
-    }
-
-    void NativeTestEnumerationJobInfoGenerator::SetCachePolicy(NativeTestEnumerator::JobInfo::CachePolicy cachePolicy)
-    {
-        m_cachePolicy = cachePolicy;
-    }
-
-    NativeTestEnumerator::JobInfo::CachePolicy NativeTestEnumerationJobInfoGenerator::GetCachePolicy() const
-    {
-        return m_cachePolicy;
+            jobId,
+            command,
+            JobData(
+                enumerationArtifact,
+                Cache{ GetCachePolicy(), GenerateTargetEnumerationCacheFilePath(testTarget, m_artifactDir.m_enumerationCacheDirectory) }));
     }
 
     NativeRegularTestRunJobInfoGenerator::NativeRegularTestRunJobInfoGenerator(
@@ -64,12 +41,10 @@ namespace TestImpact
     NativeRegularTestRunner::JobInfo NativeRegularTestRunJobInfoGenerator::GenerateJobInfo(
         const NativeTestTarget* testTarget, NativeRegularTestRunner::JobInfo::Id jobId) const
     {
+        const auto launchArgument = GenerateLaunchArgument(testTarget, m_targetBinaryDir, m_testRunnerBinary);
         const auto runArtifact = GenerateTargetRunArtifactFilePath(testTarget, m_artifactDir.m_testRunArtifactDirectory);
-        const Command args = { AZStd::string::format(
-            "%s --gtest_output=xml:\"%s\"", GenerateLaunchArgument(testTarget, m_targetBinaryDir, m_testRunnerBinary).c_str(),
-            runArtifact.c_str()) };
-
-        return JobInfo(jobId, args, JobData(testTarget->GetLaunchMethod(), runArtifact));
+        const auto command = GenerateRegularTestJobInfoCommand(launchArgument, runArtifact);
+        return JobInfo(jobId, command, JobData(testTarget->GetLaunchMethod(), runArtifact));
     }
 
     NativeInstrumentedTestRunJobInfoGenerator::NativeInstrumentedTestRunJobInfoGenerator(
@@ -91,30 +66,19 @@ namespace TestImpact
     NativeInstrumentedTestRunner::JobInfo NativeInstrumentedTestRunJobInfoGenerator::GenerateJobInfo(
         const NativeTestTarget* testTarget, NativeInstrumentedTestRunner::JobInfo::Id jobId) const
     {
-        const auto coverageArtifact = GenerateTargetCoverageArtifactFilePath(testTarget, m_artifactDir.m_coverageArtifactDirectory);
+        const auto launchArgument = GenerateLaunchArgument(testTarget, m_targetBinaryDir, m_testRunnerBinary);
         const auto runArtifact = GenerateTargetRunArtifactFilePath(testTarget, m_artifactDir.m_testRunArtifactDirectory);
-        const Command args = {
-            AZStd::string::format(
-                "\"%s\" " // 1. Instrumented test runner
-                "--coverage_level %s " // 2. Coverage level
-                "--export_type cobertura:\"%s\" " // 3. Test coverage artifact path
-                "--modules \"%s\" " // 4. Modules path
-                "--excluded_modules \"%s\" " // 5. Exclude modules
-                "--sources \"%s\" -- " // 6. Sources path
-                "%s " // 7. Launch command
-                "--gtest_output=xml:\"%s\"", // 8. Result artifact
+        const auto coverageArtifact = GenerateTargetCoverageArtifactFilePath(testTarget, m_artifactDir.m_coverageArtifactDirectory);
+        const auto command = GenerateInstrumentedTestJobInfoCommand(
+            m_instrumentBinary,
+            coverageArtifact,
+            m_coverageLevel,
+            m_targetBinaryDir,
+            m_testRunnerBinary,
+            m_sourceDir,
+            GenerateRegularTestJobInfoCommand(launchArgument, runArtifact));
 
-                m_instrumentBinary.c_str(), // 1. Instrumented test runner
-                (m_coverageLevel == CoverageLevel::Line ? "line" : "source"), // 2. Coverage level
-                coverageArtifact.c_str(), // 3. Test coverage artifact path
-                m_targetBinaryDir.c_str(), // 4. Modules path
-                m_testRunnerBinary.c_str(), // 5. Exclude modules
-                m_sourceDir.c_str(), // 6. Sources path
-                GenerateLaunchArgument(testTarget, m_targetBinaryDir, m_testRunnerBinary).c_str(), // 7. Launch command
-                runArtifact.c_str()) // 8. Result artifact
-        };
-
-        return JobInfo(jobId, args, JobData(testTarget->GetLaunchMethod(), runArtifact, coverageArtifact));
+        return JobInfo(jobId, command, JobData(testTarget->GetLaunchMethod(), runArtifact, coverageArtifact));
     }
 
     void NativeInstrumentedTestRunJobInfoGenerator::SetCoverageLevel(CoverageLevel coverageLevel)

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.h
@@ -74,11 +74,11 @@ namespace TestImpact
             const RepoPath& instrumentBinary,
             CoverageLevel coverageLevel = CoverageLevel::Source);
 
-        //!
+        //! Sets the coverage level of the job info generator.
         //! @param cachePolicy The cache policy to use for job generation.
         void SetCoverageLevel(CoverageLevel coverageLevel);
 
-        //!
+        //! Returns the coverage level of the job info generator.
         CoverageLevel GetCoverageLevel() const;
 
         // TestJobInfoGeneratorBase overrides...

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.h
@@ -20,46 +20,20 @@ namespace TestImpact
 {
     //! Generates job information for the different test job runner types.
     class NativeTestEnumerationJobInfoGenerator
-        : public TestJobInfoGenerator<NativeTestEnumerator, NativeTestTarget>
+        : public TestEnumerationJobInfoGeneratorBase<NativeTestEnumerator, NativeTestTarget>
     {
     public:
-        //! Configures the test job info generator with the necessary path information for launching test targets.
-        //! @param targetBinaryDir Path to where the test target binaries are found.
-        //! @param cacheDir Path to the persistent folder where test target enumerations are cached.
-        //! @param artifactDir Path to the transient directory where test artifacts are produced.
-        //! @param testRunnerBinary Path to the binary responsible for launching test targets that have the TestRunner launch method.
-        NativeTestEnumerationJobInfoGenerator(
-            const RepoPath& targetBinaryDir,
-            const RepoPath& cacheDir,
-            const ArtifactDir& artifactDir,
-            const RepoPath& testRunnerBinary);
+        using TestEnumerationJobInfoGeneratorBase<NativeTestEnumerator, NativeTestTarget>::TestEnumerationJobInfoGeneratorBase;
 
-        //! Generates the information for a test enumeration job.
-        //! @param testTarget The test target to generate the job information for.
-        //! @param jobId The id to assign for this job.
-        NativeTestEnumerator::JobInfo GenerateJobInfo(
-            const NativeTestTarget* testTarget,
-            NativeTestEnumerator::JobInfo::Id jobId) const override;
-
-        //!
-        //! @param cachePolicy The cache policy to use for job generation.
-        void SetCachePolicy(NativeTestEnumerator::JobInfo::CachePolicy cachePolicy);
-
-        //!
-        NativeTestEnumerator::JobInfo::CachePolicy GetCachePolicy() const;
-
-    private:
-        RepoPath m_targetBinaryDir;
-        RepoPath m_cacheDir;
-        ArtifactDir m_artifactDir;
-        RepoPath m_testRunnerBinary;
-
-        NativeTestEnumerator::JobInfo::CachePolicy m_cachePolicy;
+    protected:
+        // TestEnumerationJobInfoGenerator overrides...
+        NativeTestEnumerator::JobInfo GenerateJobInfoImpl(
+            const NativeTestTarget* testTarget, NativeTestEnumerator::JobInfo::Id jobId) const override;
     };
 
     //! Generates job information for the different test job runner types.
     class NativeRegularTestRunJobInfoGenerator
-        : public TestJobInfoGenerator<NativeRegularTestRunner, NativeTestTarget>
+        : public TestJobInfoGeneratorBase<NativeRegularTestRunner, NativeTestTarget>
     {
     public:
         //! Configures the test job info generator with the necessary path information for launching test targets.
@@ -70,11 +44,9 @@ namespace TestImpact
         NativeRegularTestRunJobInfoGenerator(
             const RepoPath& sourceDir, const RepoPath& targetBinaryDir, const ArtifactDir& artifactDir, const RepoPath& testRunnerBinary);
 
-        //! Generates the information for a test run job.
-        //! @param testTarget The test target to generate the job information for.
-        //! @param jobId The id to assign for this job.
+        // TestJobInfoGeneratorBase overrides...
         NativeRegularTestRunner::JobInfo GenerateJobInfo(
-            const NativeTestTarget* testTarget, NativeRegularTestRunner::JobInfo::Id jobId) const;
+            const NativeTestTarget* testTarget, NativeRegularTestRunner::JobInfo::Id jobId) const override;
 
     private:
         RepoPath m_sourceDir;
@@ -85,7 +57,7 @@ namespace TestImpact
 
     //! Generates job information for the different test job runner types.
     class NativeInstrumentedTestRunJobInfoGenerator
-        : public TestJobInfoGenerator<NativeInstrumentedTestRunner, NativeTestTarget>
+        : public TestJobInfoGeneratorBase<NativeInstrumentedTestRunner, NativeTestTarget>
     {
     public:
         //! Configures the test job info generator with the necessary path information for launching test targets.
@@ -102,12 +74,6 @@ namespace TestImpact
             const RepoPath& instrumentBinary,
             CoverageLevel coverageLevel = CoverageLevel::Source);
 
-        //! Generates the information for a test run job.
-        //! @param testTarget The test target to generate the job information for.
-        //! @param jobId The id to assign for this job.
-        NativeInstrumentedTestRunner::JobInfo GenerateJobInfo(
-            const NativeTestTarget* testTarget, NativeInstrumentedTestRunner::JobInfo::Id jobId) const;
-
         //!
         //! @param cachePolicy The cache policy to use for job generation.
         void SetCoverageLevel(CoverageLevel coverageLevel);
@@ -115,10 +81,13 @@ namespace TestImpact
         //!
         CoverageLevel GetCoverageLevel() const;
 
+        // TestJobInfoGeneratorBase overrides...
+        NativeInstrumentedTestRunner::JobInfo GenerateJobInfo(
+            const NativeTestTarget* testTarget, NativeInstrumentedTestRunner::JobInfo::Id jobId) const override;
+
     private:
         RepoPath m_sourceDir;
         RepoPath m_targetBinaryDir;
-        RepoPath m_cacheDir;
         ArtifactDir m_artifactDir;
         RepoPath m_testRunnerBinary;
         RepoPath m_instrumentBinary;

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <Target/Native/TestImpactNativeTestTarget.h>
+#include <TestRunner/Common/Job/TestImpactTestJobInfoUtils.h>
 #include <TestEngine/Native/TestImpactNativeTestTargetExtension.h>
 #include <TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.h>
 
@@ -30,5 +31,20 @@ namespace TestImpact
                        testTarget->GetCustomArgs().c_str())
                 .c_str();
         }
+    }
+
+    typename NativeTestEnumerator::Command GenerateTestEnumeratorJobInfoCommand(
+        const AZStd::string& launchArguement, const RepoPath& runArtifact)
+    {
+        const auto regularCommand = GenerateRegularTestJobInfoCommand(launchArguement, runArtifact);
+        return { AZStd::string::format("%s --gtest_list_tests", regularCommand.m_args.c_str()) };
+    }
+
+    typename NativeRegularTestRunner::Command GenerateRegularTestJobInfoCommand(
+        const AZStd::string& launchArguement,
+        const RepoPath& runArtifact
+    )
+    {
+        return { AZStd::string::format("%s --gtest_output=xml:\"%s\"", launchArguement.c_str(), runArtifact.c_str()) };
     }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.cpp
@@ -33,14 +33,14 @@ namespace TestImpact
         }
     }
 
-    typename NativeTestEnumerator::Command GenerateTestEnumeratorJobInfoCommand(
+    NativeTestEnumerator::Command GenerateTestEnumeratorJobInfoCommand(
         const AZStd::string& launchArguement, const RepoPath& runArtifact)
     {
         const auto regularCommand = GenerateRegularTestJobInfoCommand(launchArguement, runArtifact);
         return { AZStd::string::format("%s --gtest_list_tests", regularCommand.m_args.c_str()) };
     }
 
-    typename NativeRegularTestRunner::Command GenerateRegularTestJobInfoCommand(
+    NativeRegularTestRunner::Command GenerateRegularTestJobInfoCommand(
         const AZStd::string& launchArguement,
         const RepoPath& runArtifact
     )

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.h
@@ -23,17 +23,17 @@ namespace TestImpact
     AZStd::string GenerateLaunchArgument(
         const NativeTestTarget* testTarget, const RepoPath& targetBinaryDir, const RepoPath& testRunnerBinary);
 
-    //!
+    //! Generates a test enumeration job command.
     typename NativeTestEnumerator::Command GenerateTestEnumeratorJobInfoCommand(
         const AZStd::string& launchArguement, const RepoPath& runArtifact);
 
-    //!
+    //! Generates a regular test run job command.
     typename NativeRegularTestRunner::Command GenerateRegularTestJobInfoCommand(
         const AZStd::string& launchArguement,
         const RepoPath& runArtifact
     );
 
-    //!
+    //! Generates an instrumented test run job command.
     typename NativeInstrumentedTestRunner::Command GenerateInstrumentedTestJobInfoCommand(
         const RepoPath& instrumentBindaryPath,
         const RepoPath& coverageArtifactPath,

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.h
@@ -9,6 +9,11 @@
 #pragma once
 
 #include <TestImpactFramework/TestImpactRepoPath.h>
+#include <TestImpactFramework/TestImpactConfiguration.h>
+
+#include <TestRunner/Native/TestImpactNativeInstrumentedTestRunner.h>
+#include <TestRunner/Native/TestImpactNativeRegularTestRunner.h>
+#include <TestRunner/Native/TestImpactNativeTestEnumerator.h>
 
 namespace TestImpact
 {
@@ -17,4 +22,24 @@ namespace TestImpact
     //! Generates the command string to launch the specified test target.
     AZStd::string GenerateLaunchArgument(
         const NativeTestTarget* testTarget, const RepoPath& targetBinaryDir, const RepoPath& testRunnerBinary);
+
+    //!
+    typename NativeTestEnumerator::Command GenerateTestEnumeratorJobInfoCommand(
+        const AZStd::string& launchArguement, const RepoPath& runArtifact);
+
+    //!
+    typename NativeRegularTestRunner::Command GenerateRegularTestJobInfoCommand(
+        const AZStd::string& launchArguement,
+        const RepoPath& runArtifact
+    );
+
+    //!
+    typename NativeInstrumentedTestRunner::Command GenerateInstrumentedTestJobInfoCommand(
+        const RepoPath& instrumentBindaryPath,
+        const RepoPath& coverageArtifactPath,
+        CoverageLevel coverageLevel,
+        const RepoPath& modulesPath,
+        const RepoPath& excludedModulesPath,
+        const RepoPath& sourcesPath,
+        const typename NativeRegularTestRunner::Command& testRunLaunchCommand);
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestRunJobData.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestRunJobData.h
@@ -25,31 +25,12 @@ namespace TestImpact
         }
 
         //! Copy and move constructors/assignment operators.
-        NativeTestRunJobData(const NativeTestRunJobData& other)
-            : Parent(other)
-            , m_launchMethod(other.m_launchMethod)
-        {
-        }
+        NativeTestRunJobData(const NativeTestRunJobData& other);
+        NativeTestRunJobData(NativeTestRunJobData&& other);
+        NativeTestRunJobData& operator=(const NativeTestRunJobData& other);
+        NativeTestRunJobData& operator=(NativeTestRunJobData&& other);
 
-        NativeTestRunJobData(NativeTestRunJobData&& other)
-            : Parent(AZStd::move(other))
-            , m_launchMethod(AZStd::move(other.m_launchMethod))
-        {
-        }
-
-        NativeTestRunJobData& operator=(const NativeTestRunJobData& other)
-        {
-            m_launchMethod = other.m_launchMethod;
-            return *this;
-        }
-
-        NativeTestRunJobData& operator=(NativeTestRunJobData&& other)
-        {
-            m_launchMethod = AZStd::move(other.m_launchMethod);
-            return *this;
-        }
-
-
+        //! Returns the launch method used by this test target.
         LaunchMethod GetLaunchMethod() const
         {
             return m_launchMethod;
@@ -58,4 +39,37 @@ namespace TestImpact
     private:
         LaunchMethod m_launchMethod = LaunchMethod::TestRunner;
     };
+
+    template<typename Parent>
+    NativeTestRunJobData<Parent>::NativeTestRunJobData(const NativeTestRunJobData& other)
+        : Parent(other)
+        , m_launchMethod(other.m_launchMethod)
+    {
+    }
+
+    template<typename Parent>
+    NativeTestRunJobData<Parent>::NativeTestRunJobData(NativeTestRunJobData&& other)
+        : Parent(AZStd::move(other))
+        , m_launchMethod(AZStd::move(other.m_launchMethod))
+    {
+    }
+
+    template<typename Parent>
+    NativeTestRunJobData<Parent>& NativeTestRunJobData<Parent>::operator=(const NativeTestRunJobData& other)
+    {
+        m_launchMethod = other.m_launchMethod;
+        return *this;
+    }
+
+    template<typename Parent>
+    NativeTestRunJobData<Parent>& NativeTestRunJobData<Parent>::operator=(NativeTestRunJobData&& other)
+    {
+        m_launchMethod = AZStd::move(other.m_launchMethod);
+        return *this;
+    }
+
+    LaunchMethod GetLaunchMethod() const
+    {
+        return m_launchMethod;
+    }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestRunJobData.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestRunJobData.h
@@ -19,56 +19,26 @@ namespace TestImpact
     public:
         template<typename... AdditionalInfoArgs>
         NativeTestRunJobData(LaunchMethod launchMethod, AdditionalInfoArgs&&... additionalInfo)
-            : Parent(std::forward<AdditionalInfoArgs>(additionalInfo)...)
+            : Parent(std::forward<AdditionalInfoArgs>(additionalInfo)...)   
             , m_launchMethod(launchMethod)
         {
         }
 
         //! Copy and move constructors/assignment operators.
-        NativeTestRunJobData(const NativeTestRunJobData& other);
-        NativeTestRunJobData(NativeTestRunJobData&& other);
-        NativeTestRunJobData& operator=(const NativeTestRunJobData& other);
-        NativeTestRunJobData& operator=(NativeTestRunJobData&& other);
+        NativeTestRunJobData(const NativeTestRunJobData& other) = default;
+        NativeTestRunJobData(NativeTestRunJobData&& other) = default;
+        NativeTestRunJobData& operator=(const NativeTestRunJobData& other) = default;
+        NativeTestRunJobData& operator=(NativeTestRunJobData&& other) = default;
 
         //! Returns the launch method used by this test target.
-        LaunchMethod GetLaunchMethod() const
-        {
-            return m_launchMethod;
-        }
+        LaunchMethod GetLaunchMethod() const;
 
     private:
         LaunchMethod m_launchMethod = LaunchMethod::TestRunner;
     };
 
     template<typename Parent>
-    NativeTestRunJobData<Parent>::NativeTestRunJobData(const NativeTestRunJobData& other)
-        : Parent(other)
-        , m_launchMethod(other.m_launchMethod)
-    {
-    }
-
-    template<typename Parent>
-    NativeTestRunJobData<Parent>::NativeTestRunJobData(NativeTestRunJobData&& other)
-        : Parent(AZStd::move(other))
-        , m_launchMethod(AZStd::move(other.m_launchMethod))
-    {
-    }
-
-    template<typename Parent>
-    NativeTestRunJobData<Parent>& NativeTestRunJobData<Parent>::operator=(const NativeTestRunJobData& other)
-    {
-        m_launchMethod = other.m_launchMethod;
-        return *this;
-    }
-
-    template<typename Parent>
-    NativeTestRunJobData<Parent>& NativeTestRunJobData<Parent>::operator=(NativeTestRunJobData&& other)
-    {
-        m_launchMethod = AZStd::move(other.m_launchMethod);
-        return *this;
-    }
-
-    LaunchMethod GetLaunchMethod() const
+    LaunchMethod NativeTestRunJobData<Parent>::GetLaunchMethod() const
     {
         return m_launchMethod;
     }

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestRunJobData.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Job/TestImpactNativeTestRunJobData.h
@@ -24,6 +24,32 @@ namespace TestImpact
         {
         }
 
+        //! Copy and move constructors/assignment operators.
+        NativeTestRunJobData(const NativeTestRunJobData& other)
+            : Parent(other)
+            , m_launchMethod(other.m_launchMethod)
+        {
+        }
+
+        NativeTestRunJobData(NativeTestRunJobData&& other)
+            : Parent(AZStd::move(other))
+            , m_launchMethod(AZStd::move(other.m_launchMethod))
+        {
+        }
+
+        NativeTestRunJobData& operator=(const NativeTestRunJobData& other)
+        {
+            m_launchMethod = other.m_launchMethod;
+            return *this;
+        }
+
+        NativeTestRunJobData& operator=(NativeTestRunJobData&& other)
+        {
+            m_launchMethod = AZStd::move(other.m_launchMethod);
+            return *this;
+        }
+
+
         LaunchMethod GetLaunchMethod() const
         {
             return m_launchMethod;

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestJob.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestJob.h
@@ -19,7 +19,7 @@
 
 namespace TestImpact
 {
-    //!
+    //! Composite test job for all test shards of a given test target.
     template<typename TestRunnerType>
     class ShardedTestJob
     {
@@ -27,32 +27,32 @@ namespace TestImpact
         using ShardedTestJobInfoType = ShardedTestJobInfo<TestRunnerType>;
         using JobInfo = typename TestRunnerType::Job::Info;
 
-        //!
+        //! Consolidated job data for all sharded sub jobs.
         struct JobData;
 
-        //!
+        //! Constructs a sharded test job from the specified sharded test job info.
         ShardedTestJob(const ShardedTestJobInfoType& shardedTestJobInfo);
 
-        //!
+        //! Returns `true` if all shards in this job have completed, otherwise `false`.
         bool IsComplete() const;
 
-        //!
+        //! Registers the specified sharded sub job as complete.
         void RegisterCompletedSubJob(const JobInfo& jobInfo, const JobMeta& meta, const StdContent& std);
 
-        //!
+        //! Returns the consolidated job data when all sharded sub jobs have completed, otherwise `AZStd::nullopt`.
         const AZStd::optional<JobData>& GetConsolidatedJobData() const;
 
-        //!
+        //! Returns the vector of sub job data that may or may not be complete.
         const AZStd::vector<JobData>& GetSubJobs() const;
 
-        //!
+        //! Resolves the test run results of each sharded sub job into one consolidated test run result.
         static JobResult ResolveJobResult(const AZStd::optional<JobResult> jobResult, const JobResult subJobResult);
 
     private:
-        const ShardedTestJobInfoType* m_shardedTestJobInfo = nullptr; //!<
-        AZStd::vector<JobData> m_subJobs; //!<
-        AZStd::optional<JobData> m_consolidatedJobData; //!<
-        Timer m_timer; //!<
+        const ShardedTestJobInfoType* m_shardedTestJobInfo = nullptr; //!< Pointer to the sharded test job info of this sharded job.
+        AZStd::vector<JobData> m_subJobs; //!< The sharded sub jobs that belong this job.
+        AZStd::optional<JobData> m_consolidatedJobData; //!< The consolidated sub job data.
+        Timer m_timer; //!< The timer to measure the total runtime of all ahrded sub jobs.
     };
 
     template<typename TestRunnerType>
@@ -80,7 +80,7 @@ namespace TestImpact
     {
         if (jobResult.has_value())
         {
-            // Unless the subjob result is not executed, take the job result in reverse order of precedence
+            // Unless the sub job result is not executed, take the job result in reverse order of precedence
             // of the JobResult enumeration
             if (AZStd::to_underlying(subJobResult) < AZStd::to_underlying(jobResult.value()))
             {

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestJob.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestJob.h
@@ -70,9 +70,9 @@ namespace TestImpact
         {
         }
 
-        JobInfo m_jobInfo;
-        JobMeta m_meta;
-        StdContent m_std;
+        JobInfo m_jobInfo; //!< The job info for this shard.
+        JobMeta m_meta; //<! The job meta for this shard.
+        StdContent m_std; //!< The standard output/error for this shard.
     };
 
     template<typename TestRunnerType>
@@ -117,7 +117,7 @@ namespace TestImpact
         if (IsComplete())
         {
             // Take the first job to be scheduled as for no sharding this will be the actual job and for sharding it
-            // doesn't make a great deal of sense to try and consolodate the jobs at this level anyway (the completed
+            // doesn't make a great deal of sense to try and consolidate the jobs at this level anyway (the completed
             // jobs returned by the sharded test runner will present all shards as a single completed job)
             m_consolidatedJobData = JobData(m_shardedTestJobInfo->GetJobInfos().front());
 

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestJob.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestJob.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <TestImpactFramework/TestImpactUtils.h>
+
+#include <Process/JobRunner/TestImpactProcessJobInfo.h>
+#include <Process/JobRunner/TestImpactProcessJobMeta.h>
+#include <TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h>
+
+#include <AzCore/std/optional.h>
+#include <AzCore/std/utility/to_underlying.h>
+
+namespace TestImpact
+{
+    //!
+    template<typename TestRunnerType>
+    class ShardedTestJob
+    {
+    public:
+        using ShardedTestJobInfoType = ShardedTestJobInfo<TestRunnerType>;
+        using JobInfo = typename TestRunnerType::Job::Info;
+
+        //!
+        struct JobData;
+
+        //!
+        ShardedTestJob(const ShardedTestJobInfoType& shardedTestJobInfo);
+
+        //!
+        bool IsComplete() const;
+
+        //!
+        void RegisterCompletedSubJob(const JobInfo& jobInfo, const JobMeta& meta, const StdContent& std);
+
+        //!
+        const AZStd::optional<JobData>& GetConsolidatedJobData() const;
+
+        //!
+        const AZStd::vector<JobData>& GetSubJobs() const;
+
+        //!
+        static JobResult ResolveJobResult(const AZStd::optional<JobResult> jobResult, const JobResult subJobResult);
+
+    private:
+        const ShardedTestJobInfoType* m_shardedTestJobInfo = nullptr; //!<
+        AZStd::vector<JobData> m_subJobs; //!<
+        AZStd::optional<JobData> m_consolidatedJobData; //!<
+        Timer m_timer; //!<
+    };
+
+    template<typename TestRunnerType>
+    struct ShardedTestJob<TestRunnerType>::JobData
+    {
+        JobData(const JobInfo& jobInfo)
+            : m_jobInfo(jobInfo)
+        {
+        }
+
+        JobData(const JobInfo& jobInfo, const JobMeta& meta, const StdContent& std)
+            : m_jobInfo(jobInfo)
+            , m_meta(meta)
+            , m_std(std)
+        {
+        }
+
+        JobInfo m_jobInfo;
+        JobMeta m_meta;
+        StdContent m_std;
+    };
+
+    template<typename TestRunnerType>
+    JobResult ShardedTestJob<TestRunnerType>::ResolveJobResult(const AZStd::optional<JobResult> jobResult, const JobResult subJobResult)
+    {
+        if (jobResult.has_value())
+        {
+            // Unless the subjob result is not executed, take the job result in reverse order of precedence
+            // of the JobResult enumeration
+            if (AZStd::to_underlying(subJobResult) < AZStd::to_underlying(jobResult.value()))
+            {
+                if (subJobResult == JobResult::NotExecuted)
+                {
+                    return jobResult.value();
+                }
+
+                return subJobResult;
+            }
+        }
+
+        return subJobResult;
+    }
+
+    template<typename TestRunnerType>
+    ShardedTestJob<TestRunnerType>::ShardedTestJob(const ShardedTestJobInfoType& shardedTestJobInfo)
+        : m_shardedTestJobInfo(&shardedTestJobInfo)
+    {
+        m_subJobs.reserve(m_shardedTestJobInfo->GetJobInfos().size());
+    }
+
+    template<typename TestRunnerType>
+    bool ShardedTestJob<TestRunnerType>::IsComplete() const
+    {
+        return m_subJobs.size() == m_shardedTestJobInfo->GetJobInfos().size();
+    }
+
+    template<typename TestRunnerType>
+    void ShardedTestJob<TestRunnerType>::RegisterCompletedSubJob(const JobInfo& jobInfo, const JobMeta& meta, const StdContent& std)
+    {
+        m_subJobs.emplace_back(jobInfo, meta, std);
+
+        if (IsComplete())
+        {
+            // Take the first job to be scheduled as for no sharding this will be the actual job and for sharding it
+            // doesn't make a great deal of sense to try and consolodate the jobs at this level anyway (the completed
+            // jobs returned by the sharded test runner will present all shards as a single completed job)
+            m_consolidatedJobData = JobData(m_shardedTestJobInfo->GetJobInfos().front());
+
+            AZStd::optional<JobResult> consolidatedJobResult;
+            JobMeta& consolidatedMeta = m_consolidatedJobData->m_meta;
+
+            consolidatedMeta.m_startTime = m_timer.GetStartTimePoint();
+            consolidatedMeta.m_duration = m_timer.GetElapsedMs();
+
+            for (const auto& subJob : m_subJobs)
+            {
+                // Resolve consolidated job result from existing sub job results
+                consolidatedJobResult = ResolveJobResult(consolidatedJobResult, subJob.m_meta.m_result);
+
+                // Technically, it would be possible to consolidate return codes at the job level as we could use the
+                // platform/framework error code checkers that the test engine uses to determine what error codes map
+                // to what test run results but it's not worth it so just take the highest error code value
+                if (subJob.m_meta.m_returnCode.has_value() &&
+                    (!consolidatedMeta.m_returnCode.has_value() ||
+                     consolidatedMeta.m_returnCode.value() < subJob.m_meta.m_returnCode.value()))
+                {
+                    consolidatedMeta.m_returnCode = subJob.m_meta.m_returnCode;
+                }
+
+                // Accumulate the standard out/error of each sub job
+                const auto stdAccumulator = [](const AZStd::optional<AZStd::string>& source, AZStd::optional<AZStd::string>& dest)
+                {
+                    if (source.has_value())
+                    {
+                        dest = dest.has_value() ? dest.value() + source.value() : source.value();
+                    }
+                };
+                stdAccumulator(subJob.m_std.m_out, m_consolidatedJobData->m_std.m_out);
+                stdAccumulator(subJob.m_std.m_err, m_consolidatedJobData->m_std.m_err);
+            }
+
+            consolidatedMeta.m_result = consolidatedJobResult.value_or(JobResult::NotExecuted);
+        }
+    }
+
+    template<typename TestRunnerType>
+    auto ShardedTestJob<TestRunnerType>::GetConsolidatedJobData() const -> const AZStd::optional<JobData>&
+    {
+        return m_consolidatedJobData;
+    }
+
+    template<typename TestRunnerType>
+    auto ShardedTestJob<TestRunnerType>::GetSubJobs() const -> const AZStd::vector<JobData>&
+    {
+        return m_subJobs;
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestRunnerBase.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestRunnerBase.h
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <TestRunner/Common/Run/TestImpactTestCoverageSerializer.h>
+#include <TestRunner/Common/Run/TestImpactTestRunSerializer.h>
+#include <TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h>
+#include <TestRunner/Native/Shard/TestImpactNativeShardedTestJob.h>
+
+#include <AzCore/std/numeric.h>
+
+namespace TestImpact
+{
+    //! 
+    template<typename TestRunnerType>
+    class NativeShardedTestRunnerBase
+    {
+    public:
+        //! Public-facing `JobInfo` for interoperability with the various helper functions and event handlers.
+        using JobInfo = typename TestRunnerType::JobInfo;
+
+        //! The actual collection of `JobInfo`s condumed by this runner.
+        using JobInfos = AZStd::vector<ShardedTestJobInfo<TestRunnerType>>;
+
+        using JobId = typename JobInfo::Id;
+        using Job = typename TestRunnerType::Job;
+
+        //! Constructs the sharded test system to wrap around the specified test runner.
+        NativeShardedTestRunnerBase(TestRunnerType& testRunner, const RepoPath& repoRoot, const ArtifactDir& artifactDir);
+        virtual ~NativeShardedTestRunnerBase() = default;
+
+        //! Wrapper around the test runner's `RunTests` method to present the sharded test running interface to the user.
+        [[nodiscard]] AZStd::pair<ProcessSchedulerResult, AZStd::vector<Job>> RunTests(
+            const JobInfos& shardedJobInfos,
+            StdOutputRouting stdOutRouting,
+            StdErrorRouting stdErrRouting,
+            AZStd::optional<AZStd::chrono::milliseconds> runTimeout,
+            AZStd::optional<AZStd::chrono::milliseconds> runnerTimeout);
+
+        //! Bus for native sharded test system notifications.
+        class Notifications
+            : public AZ::EBusTraits
+        {
+        public:
+            // EBusTraits overrides ...
+            static constexpr AZ::EBusAddressPolicy AddressPolicy = AZ::EBusAddressPolicy::Single;
+            static constexpr AZ::EBusHandlerPolicy HandlerPolicy = AZ::EBusHandlerPolicy::Multiple;
+
+            //! Callback for sharded job completion/failure.
+            //! @param jobInfo The job information associated with this job.
+            //! @param meta The meta-data about the job run.
+            //! @param std The standard output and standard error of the process running the job.
+            virtual ProcessCallbackResult OnJobComplete(
+                [[maybe_unused]] const JobInfo& jobInfo,
+                [[maybe_unused]] const JobMeta& meta,
+                [[maybe_unused]] const StdContent& std)
+            {
+                return ProcessCallbackResult::Continue;
+            }
+
+            //! Callback for sharded sub-job completion/failure.
+            //! @param subJobCount The number of sub-jobs that make up this job.
+            //! @param jobId The id of the sharded job.
+            //! @param subJobInfo The job information associated with this sharded sub-job.
+            //! @param subJobMeta The meta-data about the sharded sub-job run.
+            //! @param subJobStd The standard output and standard error of the process running the sharded sub-job.
+            virtual ProcessCallbackResult OnShardedJobComplete(
+                [[maybe_unused]] JobId jobId,
+                [[maybe_unused]] size_t subJobCount,
+                [[maybe_unused]] const JobInfo& subJobInfo,
+                [[maybe_unused]] const JobMeta& subJobMeta,
+                [[maybe_unused]] const StdContent& subJobStd)
+            {
+                return ProcessCallbackResult::Continue;
+            }
+        };
+
+        using NotificationBus = AZ::EBus<Notifications>;
+
+    protected:
+        //!
+        using ShardToParentShardedJobMap = AZStd::unordered_map<typename JobId::IdType, const ShardedTestJobInfo<TestRunnerType>*>;
+
+        //!
+        using CompletedShardMap = AZStd::unordered_map<const ShardedTestJobInfo<TestRunnerType>*, ShardedTestJob<TestRunnerType>>;
+
+        //!
+        static void LogSuspectedShardFileRaceCondition(
+            const Job& subJob, const ShardToParentShardedJobMap& shardToParentShardedJobMap, const CompletedShardMap& completedShardMap);
+
+        //!
+        [[nodiscard]] virtual typename TestRunnerType::ResultType ConsolidateSubJobs(
+            const typename TestRunnerType::ResultType& result,
+            const ShardToParentShardedJobMap& shardToParentShardedJobMap,
+            const CompletedShardMap& completedShardMap) = 0;
+
+        RepoPath m_repoRoot; //!<
+        ArtifactDir m_artifactDir; //!<
+
+    private:
+        //!
+        class TestJobRunnerNotificationHandler;
+
+        TestRunnerType* m_testRunner = nullptr; //!<
+    };
+
+    template<typename TestRunnerType>
+    class NativeShardedTestRunnerBase<TestRunnerType>::TestJobRunnerNotificationHandler
+        : private TestRunnerType::NotificationBus::Handler
+    {
+    public:
+        using JobInfo = typename TestRunnerType::JobInfo;
+
+        TestJobRunnerNotificationHandler(ShardToParentShardedJobMap& shardToParentShardedJobMap, CompletedShardMap& completedShardMap);
+        virtual ~TestJobRunnerNotificationHandler();
+
+    private:
+        // NotificationsBus overrides ...
+        ProcessCallbackResult OnJobComplete(
+            const typename TestRunnerType::Job::Info& jobInfo, const JobMeta& meta, const StdContent& std) override;
+
+        ShardToParentShardedJobMap* m_shardToParentShardedJobMap = nullptr;
+        CompletedShardMap* m_completedShardMap = nullptr;
+    };
+
+    template<typename TestRunnerType>
+    NativeShardedTestRunnerBase<TestRunnerType>::TestJobRunnerNotificationHandler::TestJobRunnerNotificationHandler(
+        ShardToParentShardedJobMap& shardToParentShardedJobMap, CompletedShardMap& completedShardMap)
+        : m_shardToParentShardedJobMap(&shardToParentShardedJobMap)
+        , m_completedShardMap(&completedShardMap)
+    {
+        TestRunnerType::NotificationBus::Handler::BusConnect();
+    }
+
+    template<typename TestRunnerType>
+    NativeShardedTestRunnerBase<TestRunnerType>::TestJobRunnerNotificationHandler::~TestJobRunnerNotificationHandler()
+    {
+        TestRunnerType::NotificationBus::Handler::BusDisconnect();
+    }
+
+    template<typename TestRunnerType>
+    ProcessCallbackResult NativeShardedTestRunnerBase<TestRunnerType>::TestJobRunnerNotificationHandler::OnJobComplete(
+        const typename TestRunnerType::Job::Info& jobInfo, const JobMeta& meta, const StdContent& std)
+    {
+        const auto& shardedJobInfo = m_shardToParentShardedJobMap->at(jobInfo.GetId().m_value);
+        auto& shardedTestJob = m_completedShardMap->at(shardedJobInfo);
+        
+        {
+            AZ::EBusAggregateResults<ProcessCallbackResult> results;
+            NotificationBus::BroadcastResult(
+                results,
+                &NotificationBus::Events::OnShardedJobComplete,
+                shardedJobInfo->GetJobInfos().begin()->GetId(),
+                shardedJobInfo->GetJobInfos().size(),
+                jobInfo,
+                meta,
+                std);
+
+            const auto result = GetAggregateProcessCallbackResult(results);
+            if (result == ProcessCallbackResult::Abort)
+            {
+                return result;
+            }
+        }
+
+        shardedTestJob.RegisterCompletedSubJob(jobInfo, meta, std);
+
+        if (shardedTestJob.IsComplete())
+        {
+            auto& consolidatedJobData = *shardedTestJob.GetConsolidatedJobData();
+            AZ::EBusAggregateResults<ProcessCallbackResult> results;
+            NotificationBus::BroadcastResult(
+                results,
+                &NotificationBus::Events::OnJobComplete,
+                consolidatedJobData.m_jobInfo,
+                consolidatedJobData.m_meta,
+                consolidatedJobData.m_std);
+            return GetAggregateProcessCallbackResult(results);
+        }
+
+        return ProcessCallbackResult::Continue;
+    }
+
+    template<typename TestRunnerType>
+    NativeShardedTestRunnerBase<TestRunnerType>::NativeShardedTestRunnerBase(
+        TestRunnerType& testRunner, const RepoPath& repoRoot, const ArtifactDir& artifactDir)
+        : m_testRunner(&testRunner)
+        , m_repoRoot(repoRoot)
+        , m_artifactDir(artifactDir)
+    {
+    }
+
+    template<typename TestRunnerType>
+    AZStd::pair<ProcessSchedulerResult, AZStd::vector<typename TestRunnerType::Job>> NativeShardedTestRunnerBase<TestRunnerType>::RunTests(
+        const JobInfos& shardedJobInfos,
+        StdOutputRouting stdOutRouting,
+        StdErrorRouting stdErrRouting,
+        AZStd::optional<AZStd::chrono::milliseconds> runTimeout,
+        AZStd::optional<AZStd::chrono::milliseconds> runnerTimeout)
+    {
+        // Key: sub-job shard
+        // Value: parent sharded job info
+        ShardToParentShardedJobMap shardToParentShardedJobMap;
+        CompletedShardMap completedShardMap;
+
+        const auto totalJobShards = AZStd::accumulate(
+            shardedJobInfos.begin(),
+            shardedJobInfos.end(),
+            size_t{ 0 },
+            [](size_t sum, const ShardedTestJobInfo<TestRunnerType>& shardedJobInfo)
+            {
+                return sum + shardedJobInfo.GetJobInfos().size();
+            });
+
+        AZStd::vector<JobInfo> subJobInfos;
+        subJobInfos.reserve(totalJobShards);
+        for (const auto& shardedJobInfo : shardedJobInfos)
+        {
+            completedShardMap.emplace(
+                AZStd::piecewise_construct, AZStd::forward_as_tuple(&shardedJobInfo), std::forward_as_tuple(shardedJobInfo));
+            const auto& jobInfos = shardedJobInfo.GetJobInfos();
+            subJobInfos.insert(subJobInfos.end(), jobInfos.begin(), jobInfos.end());
+            for (const auto& jobInfo : jobInfos)
+            {
+                shardToParentShardedJobMap[jobInfo.GetId().m_value] = &shardedJobInfo;
+            }
+        }
+
+        TestJobRunnerNotificationHandler handler(shardToParentShardedJobMap, completedShardMap);
+        const auto result = m_testRunner->RunTests(
+            subJobInfos,
+            stdOutRouting,
+            stdErrRouting,
+            runTimeout,
+            runnerTimeout);
+
+         return ConsolidateSubJobs(result, shardToParentShardedJobMap, completedShardMap);
+    }
+
+    template<typename TestRunnerType>
+    void NativeShardedTestRunnerBase<TestRunnerType>::LogSuspectedShardFileRaceCondition(
+        const Job& subJob, const ShardToParentShardedJobMap& shardToParentShardedJobMap, const CompletedShardMap& completedShardMap)
+    {
+         const auto jobId = subJob.GetJobInfo().GetId().m_value;
+         const auto shardedTestJobInfo = shardToParentShardedJobMap.at(jobId);
+         const auto& shardedTestJob = completedShardMap.at(shardedTestJobInfo);
+         const auto& shardedSubJobs = shardedTestJob.GetSubJobs();
+         auto jobData = AZStd::find_if(
+             shardedSubJobs.begin(),
+             shardedSubJobs.end(),
+             [&](const typename ShardedTestJob<TestRunnerType>::JobData& jobData)
+             {
+                 return jobData.m_jobInfo.GetId().m_value == jobId;
+             });
+
+         if (jobData != shardedSubJobs.end())
+         {
+            const size_t shardNumber = jobData->m_jobInfo.GetId().m_value - shardedTestJobInfo->GetJobInfos().front().GetId().m_value;
+
+            if (jobData->m_std.m_out.has_value())
+            {
+                const size_t subStringLength = AZStd::min(size_t{ 500 }, jobData->m_std.m_out->length());
+                const auto subString = jobData->m_std.m_out->substr(jobData->m_std.m_out->length() - subStringLength);
+                AZ_Warning(
+                    "Shard",
+                    false,
+                    AZStd::string::format(
+                        "Possible file race condition detected for test target '%s' on shard '%zu', backtrace of std out for last %zu "
+                        "characters (check for properly terminated test log output):\n%s",
+                        shardedTestJobInfo->GetTestTarget()->GetName().c_str(),
+                        shardNumber,
+                        subStringLength,
+                        subString.c_str())
+                        .c_str());
+            }
+            else
+            {
+                AZ_Warning(
+                    "Shard",
+                    false,
+                    AZStd::string::format(
+                        "Possible race condition detected for test target '%s' on shard '%zu', backtrace of std out unavailable",
+                        shardedTestJobInfo->GetTestTarget()->GetName().c_str(),
+                        shardNumber)
+                        .c_str());
+            }
+         }
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestRunnerBase.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/Shard/TestImpactNativeShardedTestRunnerBase.h
@@ -275,8 +275,9 @@ namespace TestImpact
 
             if (jobData->m_std.m_out.has_value())
             {
-                // Offending sub job has std output available, print a truncated summary of the last know output
-                const size_t subStringLength = AZStd::min(size_t{ 500 }, jobData->m_std.m_out->length());
+                // Offending sub job has std output available, print a truncated summary of the last 500 characters of known output
+                constexpr size_t numCharsToPrint = 500;
+                const size_t subStringLength = AZStd::min(size_t{ numCharsToPrint }, jobData->m_std.m_out->length());
                 const auto subString = jobData->m_std.m_out->substr(jobData->m_std.m_out->length() - subStringLength);
                 AZ_Warning(
                     "Shard",

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeInstrumentedTestRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeInstrumentedTestRunner.h
@@ -20,10 +20,13 @@
 
 namespace TestImpact
 {
+    class NativeInstrumentedTestRunJobInfoGenerator;
+
     class NativeInstrumentedTestRunner
         : public TestRunnerWithCoverage<NativeTestRunJobData<TestRunWithCoverageJobData>, TestCoverage>
     {
     public:
+        using JobInfoGenerator = NativeInstrumentedTestRunJobInfoGenerator;
         using TestRunnerWithCoverage<NativeTestRunJobData<TestRunWithCoverageJobData>, TestCoverage>::TestRunnerWithCoverage;
 
     protected:

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeRegularTestRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeRegularTestRunner.h
@@ -18,10 +18,13 @@
 
 namespace TestImpact
 {
+    class NativeRegularTestRunJobInfoGenerator;
+
     class NativeRegularTestRunner
         : public TestRunner<NativeTestRunJobData<TestRunJobData>>
     {
     public:
+        using JobInfoGenerator = NativeRegularTestRunJobInfoGenerator;
         using TestRunner<NativeTestRunJobData<TestRunJobData>>::TestRunner;
 
     protected:

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <TestRunner/Common/Job/TestImpactTestJobInfoUtils.h>
+#include <TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.h>
+
+namespace TestImpact
+{
+    typename NativeInstrumentedTestRunner::ResultType NativeShardedInstrumentedTestRunner::ConsolidateSubJobs(
+        const typename NativeInstrumentedTestRunner::ResultType& result,
+        const ShardToParentShardedJobMap& shardToParentShardedJobMap,
+        const CompletedShardMap& completedShardMap)
+    {
+        const auto& [returnCode, subJobs] = result;
+        AZStd::unordered_map<
+            typename JobId::IdType,
+            std::pair<AZStd::unordered_map<AZStd::string, TestRunSuite>, AZStd::unordered_map<RepoPath, ModuleCoverage>>>
+            consolidatedJobArtifacts;
+
+        for (const auto& subJob : subJobs)
+        {
+            if (const auto payload = subJob.GetPayload();
+                payload.has_value())
+            {
+                const auto& [subTestRun, subTestCoverage] = payload.value();
+                const auto shardedTestJobInfo = shardToParentShardedJobMap.at(subJob.GetJobInfo().GetId().m_value);
+                const auto parentJobInfoId = shardedTestJobInfo->GetId();
+                auto& [testSuites, testCoverage] = consolidatedJobArtifacts[parentJobInfoId.m_value];
+
+                // Accumulate test results
+                if (subTestRun.has_value())
+                {
+                    for (const auto& subTestSuite : subTestRun->GetTestSuites())
+                    {
+                        auto& testSuite = testSuites[subTestSuite.m_name];
+                        if (testSuite.m_name.empty())
+                        {
+                            testSuite.m_name = subTestSuite.m_name;
+                        }
+
+                        testSuite.m_enabled = subTestSuite.m_enabled;
+                        testSuite.m_duration += subTestSuite.m_duration;
+                        testSuite.m_tests.insert(testSuite.m_tests.end(), subTestSuite.m_tests.begin(), subTestSuite.m_tests.end());
+                    }
+                }
+
+                // Accumulate test coverage
+                for (const auto& subModuleCoverage : subTestCoverage.GetModuleCoverages())
+                {
+                    auto& moduleCoverage = testCoverage[subModuleCoverage.m_path];
+                    if (moduleCoverage.m_path.empty())
+                    {
+                        moduleCoverage.m_path = subModuleCoverage.m_path;
+                        moduleCoverage.m_sources.insert(
+                            moduleCoverage.m_sources.end(), subModuleCoverage.m_sources.begin(), subModuleCoverage.m_sources.end());
+                    }
+                }
+            }
+            else
+            {
+                LogSuspectedShardFileRaceCondition(subJob, shardToParentShardedJobMap, completedShardMap);
+            }
+        }
+
+        AZStd::vector<typename NativeInstrumentedTestRunner::Job> consolidatedJobs;
+        consolidatedJobs.reserve(consolidatedJobArtifacts.size());
+
+        for (auto&& [jobId, artifacts] : consolidatedJobArtifacts)
+        {
+            auto&& [testSuites, testCoverage] = artifacts;
+            const auto shardedTestJobInfo = shardToParentShardedJobMap.at(jobId);
+            const auto& shardedTestJob = completedShardMap.at(shardedTestJobInfo);
+            const auto& jobData = shardedTestJob.GetConsolidatedJobData();
+
+            // Consolidate test runs
+            AZStd::optional<TestRun> run;
+            if (testSuites.size())
+            {
+                AZStd::vector<TestRunSuite> suites;
+                suites.reserve(testSuites.size());
+                for (auto&& [suiteName, suite] : testSuites)
+                {
+                    suites.emplace_back(AZStd::move(suite));
+                }
+
+                if (jobData.has_value())
+                {
+                    run = TestRun(AZStd::move(suites), jobData->m_meta.m_duration.value_or(AZStd::chrono::milliseconds{ 0 }));
+                }
+            }          
+
+            // Consolidate test coverages
+            AZStd::vector<ModuleCoverage> moduleCoverages;
+            moduleCoverages.reserve(testCoverage.size());
+            for (auto&& [modulePath, moduleCoverage] : testCoverage)
+            {
+                moduleCoverages.emplace_back(AZStd::move(moduleCoverage));
+            }
+
+            auto payload =
+                typename NativeInstrumentedTestRunner::JobPayload{ AZStd::move(run), TestCoverage(AZStd::move(moduleCoverages)) };
+
+            if (shardedTestJobInfo->GetJobInfos().size() > 1)
+            {
+                // Serialize the consolidated run and coverage as artifacts in the canonical run and coverage directories
+                WriteFileContents<TestRunnerException>(
+                    Cobertura::SerializeTestCoverage(payload.second, m_repoRoot),
+                    m_artifactDir.m_coverageArtifactDirectory / RepoPath(shardedTestJobInfo->GetTestTarget()->GetName() + ".xml"));
+                if (payload.first.has_value())
+                {
+                    WriteFileContents<TestRunnerException>(
+                        GTest::SerializeTestRun(payload.first.value()),
+                        m_artifactDir.m_testRunArtifactDirectory /
+                            RepoPath(GenerateFullQualifiedTargetNameStem(shardedTestJobInfo->GetTestTarget()).String() + ".xml"));
+                }
+            }
+
+            consolidatedJobs.emplace_back(jobData->m_jobInfo, JobMeta{ jobData->m_meta }, AZStd::move(payload));
+        }
+
+        return { result.first, consolidatedJobs };
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.h
@@ -13,12 +13,11 @@
 
 namespace TestImpact
 {
-    //!
+    //! Sharded test runner for instrumented tests.
     class NativeShardedInstrumentedTestRunner
         : public NativeShardedTestRunnerBase<NativeInstrumentedTestRunner>
     {
-    public:        
-        //!
+    public:
         using NativeShardedTestRunnerBase<NativeInstrumentedTestRunner>::NativeShardedTestRunnerBase;
 
     private:

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <TestRunner/Native/TestImpactNativeInstrumentedTestRunner.h>
+#include <TestRunner/Native/Shard/TestImpactNativeShardedTestRunnerBase.h>
+
+namespace TestImpact
+{
+    //!
+    class NativeShardedInstrumentedTestRunner
+        : public NativeShardedTestRunnerBase<NativeInstrumentedTestRunner>
+    {
+    public:        
+        //!
+        using NativeShardedTestRunnerBase<NativeInstrumentedTestRunner>::NativeShardedTestRunnerBase;
+
+    private:
+        // NativeShardedTestSystem overrides ...
+        [[nodiscard]] typename NativeInstrumentedTestRunner::ResultType ConsolidateSubJobs(
+            const typename NativeInstrumentedTestRunner::ResultType& result,
+            const ShardToParentShardedJobMap& shardToParentShardedJobMap,
+            const CompletedShardMap& completedShardMap) override;
+    };
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <TestRunner/Common/Job/TestImpactTestJobInfoUtils.h>
+#include <TestRunner/Native/TestImpactNativeShardedRegularTestRunner.h>
+
+namespace TestImpact
+{
+    typename NativeRegularTestRunner::ResultType NativeShardedRegularTestRunner::ConsolidateSubJobs(
+        const typename NativeRegularTestRunner::ResultType& result,
+        const ShardToParentShardedJobMap& shardToParentShardedJobMap,
+        const CompletedShardMap& completedShardMap)
+    {
+        const auto& [returnCode, subJobs] = result;
+        AZStd::unordered_map<
+            typename JobId::IdType,
+            std::pair<AZStd::unordered_map<AZStd::string, TestRunSuite>, AZStd::unordered_map<RepoPath, ModuleCoverage>>>
+            consolidatedJobArtifacts;
+
+        for (const auto& subJob : subJobs)
+        {
+            if (const auto payload = subJob.GetPayload();
+                payload.has_value())
+            {
+                const auto& subTestRun = payload.value();
+                const auto shardedTestJobInfo = shardToParentShardedJobMap.at(subJob.GetJobInfo().GetId().m_value);
+                const auto parentJobInfoId = shardedTestJobInfo->GetId();
+                auto& [testSuites, testCoverage] = consolidatedJobArtifacts[parentJobInfoId.m_value];
+
+                // Accumulate test results
+                for (const auto& subTestSuite : subTestRun.GetTestSuites())
+                {
+                    auto& testSuite = testSuites[subTestSuite.m_name];
+                    if (testSuite.m_name.empty())
+                    {
+                        testSuite.m_name = subTestSuite.m_name;
+                    }
+
+                    testSuite.m_enabled = subTestSuite.m_enabled;
+                    testSuite.m_duration += subTestSuite.m_duration;
+                    testSuite.m_tests.insert(testSuite.m_tests.end(), subTestSuite.m_tests.begin(), subTestSuite.m_tests.end());
+                }
+            }
+            else
+            {
+                LogSuspectedShardFileRaceCondition(subJob, shardToParentShardedJobMap, completedShardMap);
+            }
+        }
+
+        AZStd::vector<typename NativeRegularTestRunner::Job> consolidatedJobs;
+        consolidatedJobs.reserve(consolidatedJobArtifacts.size());
+
+        for (auto&& [jobId, artifacts] : consolidatedJobArtifacts)
+        {
+            auto&& [testSuites, testCoverage] = artifacts;
+            const auto shardedTestJobInfo = shardToParentShardedJobMap.at(jobId);
+            const auto& shardedTestJob = completedShardMap.at(shardedTestJobInfo);
+            const auto& jobData = shardedTestJob.GetConsolidatedJobData();
+
+            // Consolidate test runs
+            AZStd::optional<TestRun> run;
+            if (testSuites.size())
+            {
+                AZStd::vector<TestRunSuite> suites;
+                suites.reserve(testSuites.size());
+                for (auto&& [suiteName, suite] : testSuites)
+                {
+                    suites.emplace_back(AZStd::move(suite));
+                }
+
+                if (jobData.has_value())
+                {
+                    run = TestRun(AZStd::move(suites), jobData->m_meta.m_duration.value_or(AZStd::chrono::milliseconds{ 0 }));
+                }
+            }
+
+            // Serialize the consolidated run as and artifact in the canonical run directory
+            if (run.has_value() && shardedTestJobInfo->GetJobInfos().size() > 1)
+            {
+                WriteFileContents<TestRunnerException>(
+                    GTest::SerializeTestRun(run.value()),
+                    m_artifactDir.m_testRunArtifactDirectory /
+                        RepoPath(GenerateFullQualifiedTargetNameStem(shardedTestJobInfo->GetTestTarget()).String() + ".xml"));
+            }
+
+            consolidatedJobs.emplace_back(jobData->m_jobInfo, JobMeta{ jobData->m_meta }, AZStd::move(run));
+        }
+
+        return { result.first, consolidatedJobs };
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.h
@@ -13,12 +13,11 @@
 
 namespace TestImpact
 {
-    //!
+    //! Sharded test runner for regular tests.
     class NativeShardedRegularTestRunner
         : public NativeShardedTestRunnerBase<NativeRegularTestRunner>
     {
     public:
-        //!
         using NativeShardedTestRunnerBase<NativeRegularTestRunner>::NativeShardedTestRunnerBase;
 
     private:

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <TestRunner/Native/TestImpactNativeRegularTestRunner.h>
+#include <TestRunner/Native/Shard/TestImpactNativeShardedTestRunnerBase.h>
+
+namespace TestImpact
+{
+    //!
+    class NativeShardedRegularTestRunner
+        : public NativeShardedTestRunnerBase<NativeRegularTestRunner>
+    {
+    public:
+        //!
+        using NativeShardedTestRunnerBase<NativeRegularTestRunner>::NativeShardedTestRunnerBase;
+
+    private:
+        // NativeShardedTestSystem overrides ...
+        [[nodiscard]] typename NativeRegularTestRunner::ResultType ConsolidateSubJobs(
+            const typename NativeRegularTestRunner::ResultType& result,
+            const ShardToParentShardedJobMap& shardToParentShardedJobMap,
+            const CompletedShardMap& completedShardMap) override;
+    };
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeTestEnumerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/Source/TestRunner/Native/TestImpactNativeTestEnumerator.h
@@ -18,6 +18,8 @@
 
 namespace TestImpact
 {
+    class NativeTestEnumerationJobInfoGenerator;
+
     struct NativeTestEnumerationJobData
         : public TestEnumerationJobData
     {
@@ -28,6 +30,7 @@ namespace TestImpact
         : public TestEnumerator<NativeTestEnumerationJobData>
     {
     public:
+        using JobInfoGenerator = NativeTestEnumerationJobInfoGenerator;
         using TestEnumerator<NativeTestEnumerationJobData>::TestEnumerator;
 
     protected:

--- a/Code/Tools/TestImpactFramework/Runtime/Native/Code/testimpactframework_runtime_native_files.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Native/Code/testimpactframework_runtime_native_files.cmake
@@ -9,6 +9,7 @@
 set(FILES
     Include/TestImpactFramework/Native/TestImpactNativeRuntime.h
     Include/TestImpactFramework/Native/TestImpactNativeConfiguration.h
+    Include/TestImpactFramework/Native/TestImpactNativeRuntimeConfigurationFactory.h
     Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.cpp
     Source/Artifact/Factory/TestImpactNativeTestTargetMetaMapFactory.h
     Source/Artifact/Static/TestImpactNativeTestTargetMeta.h
@@ -21,14 +22,23 @@ set(FILES
     Source/TestRunner/Native/TestImpactNativeErrorCodeChecker.h
     Source/TestRunner/Native/TestImpactNativeInstrumentedTestRunner.h
     Source/TestRunner/Native/TestImpactNativeRegularTestRunner.h
+    Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.cpp
+    Source/TestRunner/Native/TestImpactNativeShardedInstrumentedTestRunner.h
+    Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.cpp
+    Source/TestRunner/Native/TestImpactNativeShardedRegularTestRunner.h
     Source/TestRunner/Native/TestImpactNativeTestEnumerator.h
+    Source/TestRunner/Native/Shard/TestImpactNativeShardedTestJob.h
+    Source/TestRunner/Native/Shard/TestImpactNativeShardedTestRunnerBase.h
     Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.cpp
     Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoGenerator.h
     Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.cpp
     Source/TestRunner/Native/Job/TestImpactNativeTestJobInfoUtils.h
     Source/TestRunner/Native/Job/TestImpactNativeTestRunJobData.h
+    Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.cpp
+    Source/TestRunner/Native/Job/TestImpactNativeShardedTestJobInfoGenerator.h
     Source/TestEngine/Native/TestImpactNativeTestEngine.cpp
     Source/TestEngine/Native/TestImpactNativeTestEngine.h
     Source/TestEngine/Native/TestImpactNativeTestTargetExtension.h
     Source/TestImpactNativeRuntime.cpp
+    Source/TestImpactNativeRuntimeConfigurationFactory.cpp
 )


### PR DESCRIPTION
## What does this PR do?

This PR introduces the sharded test runners to greatly increase the speed of instrumented native C++ tests.

## What is test sharding?

Test sharding is where a given test target has all of its enumerated tests interleaved over a number of sub test runs across the hardware cores before the results and coverage of those sub test runs being consolidated into the final test run result and coverage artifacts for the test target, as if it were run by one of the standard test runners. This differs from standard test runs where the test targets themselves are interleaved over the hardware cores, causing long pole test targets to stall the single core that they are running on. By sharding these test targets themselves, we can leverage the hardware cores available to offer impressive performance boosts that scales with the number of hardware cores available.

## Why is test sharding needed?

For reasons that have yet to be adequately explained, the _OpenCppCoverage_ instrumentation can cause certain tests to take significantly longer to run that without said instrumentation. In the extreme case, this has caused `AzFramework.Tests` to take over 20 minutes to complete when instrumented with _OpenCppCoverage_. Clearly, this is not only an unacceptable amount of time to take but also long enough to cause Jenkins to pull the plug on the AR run entirely, preventing AR from succeeding.

## What are the performance results of test sharding?

Below is the performance analysis of the top offending test targets that take the most time in AR. Note that some of the tests in the instrumented column take an extraordinary amount of time. This appears to be intrinsic to the instrumentation used and not something that can be fixed in any meaningful way. However, with test sharding we are seeing up to 20x the speed increase of certain instrumented test targets compared to their unsharded instrumented counterparts, bringing their run times back into the realm of practicality for use in Test Impact Analysis.

| Test                             | Standard  |      |           |      | Sharding  |      |           |      |
|----------------------------------|-----------|------|-----------|------|-----------|------|-----------|------|
|                                  | Regular   |      | Instrum.  |      | Regular   |      | Instrum.  |      |
|                                  | Time (ms) | Norm | Time (ms) | Norm | Time (ms) | Norm | Time (ms) | Norm |
| AzToolsFramework.Tests           | 376.422   | 1    | 1366.962  | 3.63 | 32.956    | 0.09 | 79.502    | 0.21 |
| EMotionFX.Editor.Tests           | 144.199   | 1    | 376.894   | 2.61 | 24.919    | 0.17 | 63.291    | 0.44 |
| EMotionFX.Tests                  | 176.95    | 1    | 456.677   | 2.58 | 9.194     | 0.05 | 40.376    | 0.23 |
| AssetProcessor.Tests             | 152.177   | 1    | 355.193   | 2.33 | 14.207    | 0.09 | 33.228    | 0.22 |
| AzCore.Tests                     | 61.668    | 1    | 211.96    | 3.44 | 10.239    | 0.17 | 25.406    | 0.41 |
| ImageProcessingAtom.Editor.Tests | 36.667    | 1    | 39.816    | 1.09 | 30.736    | 0.84 | 35.018    | 0.96 |
| AzFramework.Tests                | 115.163   | 1    | 562.032   | 4.88 | 21.263    | 0.18 | 36.355    | 0.32 |
| LmbrCentral.Editor.Tests         | 38.313    | 1    | 192.511   | 5.02 | 2.796     | 0.07 | 18.226    | 0.48 |
| PhysX.Tests                      | 29.566    | 1    | 30.754    | 1.04 | 2.569     | 0.09 | 7.664     | 0.26 |
| ScriptCanvasTesting.Editor.Tests | 12.73     | 1    | 18.035    | 1.42 | 3.085     | 0.24 | 36.791    | 2.89 |
| EditorLib.Tests                  | 28.546    | 1    | 103.586   | 3.63 | 2.105     | 0.07 | 34.034    | 1.19 |
| EditorPythonBindings.Tests       | 15.789    | 1    | 21.507    | 1.36 | 1.201     | 0.08 | 3.941     | 0.25 |
| AzManipulatorTestFramework.Tests | 7.736     | 1    | 27.681    | 3.58 | 0.895     | 0.12 | 7.569     | 0.98 |
| SceneProcessing.Editor.Tests     | 9.797     | 1    | 39.254    | 4.01 | 1.546     | 0.16 | 15.771    | 1.61 |
| PrefabBuilder.Tests              | 9.817     | 1    | 11.613    | 1.18 | 0.926     | 0.09 | 9.042     | 0.92 |
| DeltaCataloger.Tests             | 5.728     | 1    | 18.666    | 3.26 | 1.285     | 0.22 | 5.149     | 0.90 |
| AWSCore.Tests                    | 8.28      | 1    | 15.889    | 1.92 | 0.955     | 0.12 | 4.374     | 0.53 |
| Atom_RPI.Tests                   | 9.561     | 1    | 22.515    | 2.35 | 1.079     | 0.11 | 8.47      | 0.89 |

## How are test targets opted in to test sharding?

If you wish to opt a test target into test sharding, add the `TIAF_sharding` label when registering the test target in CMake. Note that a test target must be capable of enumerating its tests (i.e. it uses the `gtest` framework). Test targets that are not registered for test sharding or are registered but incapable of enumerating their tests will not use test sharding when being run.

## How do I fix a test target that crashes when test sharing is enabled?

If you're in a rush you can just remove the test sharding label to get it to run without sharding. However, if you search the output logs for `Possible file race condition detected for test target` you will find the test target, shard number and the last 500 characters of output for that test target shard. If the output ends abruptly, the last test you can see in that output snippet is almost certainly the offending test. You can fix this test by ensuring all file reads/writes used by any surrounding tests use `AZ::Test::ScopedAutoTempDirectory.GetDirectory()` to obtain a unique filename so concurrent test runs will not clash with their filenames and attempt to mutate the same file. Note that a static member that generates random names for each test is not sufficient because test shards are individual **processes** and thus do not share any address space!

## How was this PR tested?

Each test target in the table above has been tested for sharding compatibility (i.e. no file race conditions in any tests when run concurrently). This will be further tested in AR.
