### PR TITLE
Add additional config when user selects hinge or prismatic joint type

### DIFF
--- a/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.cpp
+++ b/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.cpp
@@ -27,31 +27,50 @@ namespace PhysX
                 ->Field("Fixed Base", &ArticulationLinkConfiguration::m_isFixedBase)
                 ->Field("Mass", &ArticulationLinkConfiguration::m_mass)
                 ->Field("Gravity Enabled", &ArticulationLinkConfiguration::m_gravityEnabled)
-                ->Field("Local Position", &ArticulationLinkConfiguration::m_localPosition)
-                ->Field("Local Rotation", &ArticulationLinkConfiguration::m_localRotation)
-                ->Field("Auto-calculate Leader frame", &ArticulationLinkConfiguration::m_autoCalculateLeaderFrame)
-                ->Field("Leader Local Position", &ArticulationLinkConfiguration::m_leaderLocalPosition)
-                ->Field("Leader Local Rotation", &ArticulationLinkConfiguration::m_LeaderLocalRotation)
-                ->Field("Initial linear velocity", &ArticulationLinkConfiguration::m_initialLinearVelocity)
-                ->Field("Initial angular velocity", &ArticulationLinkConfiguration::m_initialAngularVelocity)
                 ->Field("Linear damping", &ArticulationLinkConfiguration::m_linearDamping)
                 ->Field("Angular damping", &ArticulationLinkConfiguration::m_angularDamping)
                 ->Field("Sleep threshold", &ArticulationLinkConfiguration::m_sleepMinEnergy)
                 ->Field("Start Asleep", &ArticulationLinkConfiguration::m_startAsleep)
                 ->Field("Centre of mass offset", &ArticulationLinkConfiguration::m_centerOfMassOffset)
                 ->Field("Maximum Angular Velocity", &ArticulationLinkConfiguration::m_maxAngularVelocity)
-                ->Field("Articulation Joint Type", &ArticulationLinkConfiguration::m_articulationJointType)
-                ->Field("Motor configuration", &ArticulationLinkConfiguration::m_motorConfiguration)
-                ->Field("Fix Joint Location", &ArticulationLinkConfiguration::m_fixJointLocation)
-                ->Field("Select Lead on Snap", &ArticulationLinkConfiguration::m_selectLeadOnSnap)
-                ->Field("Self Collide", &ArticulationLinkConfiguration::m_selfCollide)
                 ->Field("SolverPositionIterations", &ArticulationLinkConfiguration::m_solverPositionIterations)
-                ->Field("SolverVelocityIterations", &ArticulationLinkConfiguration::m_solverVelocityIterations);
+                ->Field("SolverVelocityIterations", &ArticulationLinkConfiguration::m_solverVelocityIterations)
+                ->Field("Articulation Joint Type", &ArticulationLinkConfiguration::m_articulationJointType)
+                ->Field("Local Position", &ArticulationLinkConfiguration::m_localPosition)
+                ->Field("Local Rotation", &ArticulationLinkConfiguration::m_localRotation)
+                ->Field("Fix Joint Location", &ArticulationLinkConfiguration::m_fixJointLocation)
+                ->Field("Self Collide", &ArticulationLinkConfiguration::m_selfCollide)
+                ->Field("Select Lead on Snap", &ArticulationLinkConfiguration::m_selectLeadOnSnap)
+                ->Field("Leader Local Position", &ArticulationLinkConfiguration::m_leaderLocalPosition)
+                ->Field("Leader Local Rotation", &ArticulationLinkConfiguration::m_LeaderLocalRotation)
+                ->Field("Auto-calculate Leader frame", &ArticulationLinkConfiguration::m_autoCalculateLeaderFrame)
+                ->Field("Is Limited", &ArticulationLinkConfiguration::m_isLimited)
+                ->Field("Linear Limit Lower", &ArticulationLinkConfiguration::m_linearLimitLower)
+                ->Field("Linear Limit Upper", &ArticulationLinkConfiguration::m_linearLimitUpper)
+                ->Field("Angular Limit Negative", &ArticulationLinkConfiguration::m_angularLimitNegative)
+                ->Field("Angular Limit Positive", &ArticulationLinkConfiguration::m_angularLimitPositive)
+                ->Field("Motor configuration", &ArticulationLinkConfiguration::m_motorConfiguration)
+                ;
         }
     }
 
     bool ArticulationLinkConfiguration::IsNotRootArticulation() const
     {
         return !m_isRootArticulation;
+    }
+
+    bool ArticulationLinkConfiguration::HingePropertiesVisible() const
+    {
+        return m_articulationJointType == ArticulationJointType::Hinge && IsNotRootArticulation();
+    }
+
+    bool ArticulationLinkConfiguration::PrismaticPropertiesVisible() const
+    {
+        return m_articulationJointType == ArticulationJointType::Prismatic && IsNotRootArticulation();
+    }
+
+    bool ArticulationLinkConfiguration::IsSingleDOFJointType() const
+    {
+        return HingePropertiesVisible() || PrismaticPropertiesVisible();
     }
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.h
+++ b/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.h
@@ -23,6 +23,13 @@ namespace AZ
 
 namespace PhysX
 {
+    enum class ArticulationJointType
+    {
+        Fix,
+        Hinge,
+        Prismatic
+    };
+
     //! Configuration used to Add Articulations to a Scene.
     struct ArticulationLinkConfiguration
     {
@@ -41,8 +48,6 @@ namespace PhysX
         // Rigid Body configuration
 
         // Basic initial settings.
-        AZ::Vector3 m_initialLinearVelocity = AZ::Vector3::CreateZero();
-        AZ::Vector3 m_initialAngularVelocity = AZ::Vector3::CreateZero();
         AZ::Vector3 m_centerOfMassOffset = AZ::Vector3::CreateZero();
 
         // Simulation parameters.
@@ -62,10 +67,17 @@ namespace PhysX
 
         // Joint configuration
 
-        physx::PxArticulationJointType::Enum m_articulationJointType = physx::PxArticulationJointType::Enum::eFIX;
+        ArticulationJointType m_articulationJointType = ArticulationJointType::Fix;
         bool m_selectLeadOnSnap = true;
         bool m_selfCollide = false;
         bool m_fixJointLocation = false;
+
+        bool m_isLimited = true; ///< Indicates if this joint has limits, e.g. maximum swing angles.
+        float m_linearLimitLower = -1.0f;
+        float m_linearLimitUpper = 1.0f;
+        float m_angularLimitPositive = 45.0f;
+        float m_angularLimitNegative = -45.0f;
+
         JointMotorProperties m_motorConfiguration;
 
         AZ::Vector3 m_localPosition = AZ::Vector3::CreateZero();
@@ -82,5 +94,8 @@ namespace PhysX
         bool m_isRootArticulation = false;
 
         bool IsNotRootArticulation() const;
+        bool HingePropertiesVisible() const;
+        bool PrismaticPropertiesVisible() const;
+        bool IsSingleDOFJointType() const;
     };
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
@@ -122,7 +122,7 @@ namespace PhysX
                     ->DataElement(
                         AZ::Edit::UIHandlers::ComboBox,
                         &ArticulationLinkConfiguration::m_articulationJointType,
-                        "Articulation Link Joint Type",
+                        "Joint Type",
                         "Set the type of joint for this link")
                     ->EnumAttribute(ArticulationJointType::Fix, "Fix")
                     ->EnumAttribute(ArticulationJointType::Hinge, "Hinge")
@@ -171,7 +171,7 @@ namespace PhysX
                         0, &ArticulationLinkConfiguration::m_linearLimitLower, "Lower Linear Limit", "Lower limit of linear motion.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::HingePropertiesVisible)
                     ->DataElement(
-                        0, &ArticulationLinkConfiguration::m_linearLimitUpper, "Upper Linear Limi", "Upper limit for linear motion.")
+                        0, &ArticulationLinkConfiguration::m_linearLimitUpper, "Upper Linear Limit", "Upper limit for linear motion.")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::HingePropertiesVisible)
                     ->DataElement(
                         0, &ArticulationLinkConfiguration::m_angularLimitNegative, "Lower Angular Limit", "Lower limit of angular motion..")

--- a/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
@@ -36,6 +36,8 @@ namespace PhysX
                     ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ->UIElement(AZ::Edit::UIHandlers::Label, "<b>Root Link</b>")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::m_isRootArticulation)
+                    ->UIElement(AZ::Edit::UIHandlers::Label, "<b>Child Link</b>")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsNotRootArticulation)
                     ->DataElement(
                         AZ::Edit::UIHandlers::Default,
                         &ArticulationLinkConfiguration::m_isFixedBase,
@@ -113,9 +115,20 @@ namespace PhysX
                         "Higher values can improve stability at the cost of performance.")
                     ->Attribute(AZ::Edit::Attributes::Min, 1)
                     ->Attribute(AZ::Edit::Attributes::Max, 255)
+                    ->EndGroup()
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Joint configuration")
                     ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::ComboBox,
+                        &ArticulationLinkConfiguration::m_articulationJointType,
+                        "Articulation Link Joint Type",
+                        "Set the type of joint for this link")
+                    ->EnumAttribute(ArticulationJointType::Fix, "Fix")
+                    ->EnumAttribute(ArticulationJointType::Hinge, "Hinge")
+                    ->EnumAttribute(ArticulationJointType::Prismatic, "Prismatic")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsNotRootArticulation)
+                    ->Attribute(AZ::Edit::Attributes::ChangeNotify, AZ::Edit::PropertyRefreshLevels::EntireTree)
                     ->DataElement(
                         0,
                         &PhysX::ArticulationLinkConfiguration::m_localPosition,
@@ -129,15 +142,6 @@ namespace PhysX
                         "Local Rotation of joint, relative to its entity.")
                     ->Attribute(AZ::Edit::Attributes::Min, LocalRotationMin)
                     ->Attribute(AZ::Edit::Attributes::Max, LocalRotationMax)
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsNotRootArticulation)
-                    ->DataElement(
-                        AZ::Edit::UIHandlers::ComboBox,
-                        &ArticulationLinkConfiguration::m_articulationJointType,
-                        "Articulation LinkJoint Type",
-                        "Set the type of joint for this link")
-                    ->EnumAttribute(physx::PxArticulationJointType::Enum::eFIX, "Fix")
-                    ->EnumAttribute(physx::PxArticulationJointType::Enum::eREVOLUTE, "Hinge")
-                    ->EnumAttribute(physx::PxArticulationJointType::Enum::ePRISMATIC, "Prismatic")
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsNotRootArticulation)
                     ->DataElement(
                         0,
@@ -156,7 +160,30 @@ namespace PhysX
                         &ArticulationLinkConfiguration::m_selectLeadOnSnap,
                         "Select Lead on Snap",
                         "Select lead entity on snap to position in component mode.")
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsNotRootArticulation);
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsNotRootArticulation)
+
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Joint limits")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(
+                        0, &ArticulationLinkConfiguration::m_isLimited, "Limit", "When active, the joint's degrees of freedom are limited.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsSingleDOFJointType)
+                    ->DataElement(
+                        0, &ArticulationLinkConfiguration::m_linearLimitLower, "Lower Linear Limit", "Lower limit of linear motion.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::HingePropertiesVisible)
+                    ->DataElement(
+                        0, &ArticulationLinkConfiguration::m_linearLimitUpper, "Upper Linear Limi", "Upper limit for linear motion.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::HingePropertiesVisible)
+                    ->DataElement(
+                        0, &ArticulationLinkConfiguration::m_angularLimitNegative, "Lower Angular Limit", "Lower limit of angular motion..")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::PrismaticPropertiesVisible)
+                    ->DataElement(
+                        0, &ArticulationLinkConfiguration::m_angularLimitPositive, "Upper Angular Limit", "Lower limit of angular motion.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::PrismaticPropertiesVisible)
+                    ->EndGroup()
+
+                    ->DataElement(
+                        0, &ArticulationLinkConfiguration::m_motorConfiguration, "Motor Configuration", "Joint's motor configuration.")
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsSingleDOFJointType);
             }
         }
     }

--- a/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorHingeJointComponent.cpp
@@ -44,7 +44,7 @@ namespace PhysX
                     ->DataElement(0, &EditorHingeJointComponent::m_angularLimit, "Angular Limit", "The rotation angle limit around the joint's axis.")
                     ->DataElement(0, &EditorHingeJointComponent::m_motorConfiguration, "Motor Configuration", "Joint's motor configuration.")
                     ->DataElement(AZ::Edit::UIHandlers::Default, &EditorHingeJointComponent::m_componentModeDelegate, "Component Mode", "Hinge Joint Component Mode.")
-                      ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
+                    ->Attribute(AZ::Edit::Attributes::Visibility, AZ::Edit::PropertyVisibility::ShowChildrenOnly)
                     ;
             }
         }


### PR DESCRIPTION
## What does this PR do?

Reorders elements in edit context for the joint configuration and adds in new settings for when the user selects a Hinge or Prismatic joint

Before:
![Editor_K1McBzaEYY](https://user-images.githubusercontent.com/105638312/228612473-593c8cae-d19e-4a5f-b701-caca06d641b7.png)

After:
![Editor_cpzMX4DbRg](https://user-images.githubusercontent.com/105638312/228613928-3ea9ac94-3b73-45c2-9bc0-b49da5986d08.png)


## How was this PR tested?

manual testing
