### PR TITLE
TIAF: Native Test Sharding Python

### DIFF
--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Include/TestImpactFramework/Python/TestImpactPythonRuntimeConfigurationFactory.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Include/TestImpactFramework/Python/TestImpactPythonRuntimeConfigurationFactory.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <TestImpactFramework/Python/TestImpactPythonConfiguration.h>
+
+namespace TestImpact
+{
+    //! Parses the python-specific configuration data (in JSON format) and returns the constructed runtime configuration.
+    PythonRuntimeConfig PythonRuntimeConfigurationFactory(const AZStd::string& configurationData);
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.cpp
@@ -35,7 +35,7 @@ namespace TestImpact
             "labels"
         };
 
-        enum
+        enum Fields
         {
             PythonKey,
             TestKey,
@@ -47,9 +47,12 @@ namespace TestImpact
             TimeoutKey,
             ScriptKey,
             TestCommandKey,
-            SuiteLabelsKey
+            SuiteLabelsKey,
+            // Checksum
+            _CHECKSUM_
         };
 
+        static_assert(Fields::_CHECKSUM_ == AZStd::size(Keys));
         AZ_TestImpact_Eval(!testListData.empty(), ArtifactException, "Test meta-data cannot be empty");
 
         PythonTestTargetMetaMap testMetas;

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Target/Python/TestImpactPythonTestTarget.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Target/Python/TestImpactPythonTestTarget.cpp
@@ -10,6 +10,12 @@
 
 namespace TestImpact
 {
+    namespace SupportedTestFrameworks
+    {
+        //! The CTest label for the PyTest framework.
+        inline constexpr auto PyTest = "FRAMEWORK_pytest";
+    } // namespace SupportedTestFrameworks
+
     PythonTestTarget::PythonTestTarget(TargetDescriptor&& descriptor, PythonTestTargetMeta&& testMetaData)
         : TestTarget(AZStd::move(descriptor), AZStd::move(testMetaData.m_testTargetMeta))
         , m_scriptMetaData(AZStd::move(testMetaData.m_scriptMeta))
@@ -24,5 +30,10 @@ namespace TestImpact
     const AZStd::string& PythonTestTarget::GetCommand() const
     {
         return m_scriptMetaData.m_testCommand;
+    }
+
+     bool PythonTestTarget::CanEnumerate() const
+    {
+        return GetSuiteLabelSet().contains(SupportedTestFrameworks::PyTest);
     }
 } // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Target/Python/TestImpactPythonTestTarget.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/Target/Python/TestImpactPythonTestTarget.h
@@ -28,6 +28,9 @@ namespace TestImpact
         //! Returns the command to execute this test.
         const AZStd::string& GetCommand() const;
 
+        // TestTarget overrides ...
+        bool CanEnumerate() const override;
+
     private:
         PythonTargetScriptMeta m_scriptMetaData;
     };

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.cpp
@@ -18,7 +18,6 @@
 #include <TestRunner/Python/TestImpactPythonRegularTestRunner.h>
 #include <TestRunner/Python/TestImpactPythonRegularNullTestRunner.h>
 
-#include <iostream>
 namespace TestImpact
 {
     AZStd::optional<Client::TestRunResult> PythonRegularTestRunnerErrorCodeChecker(

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestEngine/Python/TestImpactPythonTestEngine.h
@@ -53,7 +53,6 @@ namespace TestImpact
         //! Performs a test run without any instrumentation and, for each test target, returns the test run results and metrics about the
         //! run.
         //! @param testTargets The test targets to run.
-        //! @param testShardingPolicy Test sharding policy to use for test targets in this run.
         //! @param executionFailurePolicy Policy for how test execution failures should be handled.
         //! @param testFailurePolicy Policy for how test targets with failing tests should be handled.
         //! @param targetOutputCapture Policy for how test target standard output should be captured and handled.

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntimeConfigurationFactory.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestImpactPythonRuntimeConfigurationFactory.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <TestImpactFramework/TestImpactConfigurationException.h>
+#include <TestImpactFramework/TestImpactUtils.h>
+#include <TestImpactFramework/Python/TestImpactPythonRuntimeConfigurationFactory.h>
+
+#include <TestImpactRuntimeConfigurationFactory.h>
+
+namespace TestImpact
+{
+    namespace PythonConfigFactory
+    {
+        // Keys for pertinent JSON elements
+        constexpr const char* Keys[] = {
+            "exclude",
+            "python",
+            "target",
+            "test_engine",
+            "test_runner",
+            "bin",
+            "workspace",
+        };
+
+        enum Fields
+        {
+            TargetExclude,
+            Python,
+            TargetConfig,
+            TestEngine,
+            TestRunner,
+            PythonCmd,
+            Workspace,
+            // Checksum
+            _CHECKSUM_
+        };
+    } // namespace Config
+
+    PythonTestEngineConfig ParseTestEngineConfig(const rapidjson::Value& testEngine)
+    {
+        PythonTestEngineConfig testEngineConfig;
+        testEngineConfig.m_testRunner.m_pythonCmd = testEngine[PythonConfigFactory::Keys[PythonConfigFactory::TestRunner]][PythonConfigFactory::Keys[PythonConfigFactory::PythonCmd]].GetString();
+        return testEngineConfig;
+    }
+
+    PythonTargetConfig ParseTargetConfig(const rapidjson::Value& target)
+    {
+        PythonTargetConfig targetConfig;
+        targetConfig.m_excludedTargets = ParseTargetExcludeList(target[PythonConfigFactory::Keys[PythonConfigFactory::TargetExclude]].GetArray());
+
+        return targetConfig;
+    }
+
+    PythonRuntimeConfig PythonRuntimeConfigurationFactory(const AZStd::string& configurationData)
+    {
+        static_assert(PythonConfigFactory::Fields::_CHECKSUM_ == AZStd::size(PythonConfigFactory::Keys));
+        rapidjson::Document configurationFile;
+
+        if (configurationFile.Parse(configurationData.c_str()).HasParseError())
+        {
+            throw TestImpact::ConfigurationException("Could not parse runtimeConfig data, JSON has errors");
+        }
+
+        PythonRuntimeConfig runtimeConfig;
+        runtimeConfig.m_commonConfig = RuntimeConfigurationFactory(configurationData);
+        runtimeConfig.m_workspace = ParseWorkspaceConfig(configurationFile[PythonConfigFactory::Keys[PythonConfigFactory::Python]][PythonConfigFactory::Keys[PythonConfigFactory::Workspace]]);
+        runtimeConfig.m_testEngine = ParseTestEngineConfig(configurationFile[PythonConfigFactory::Keys[PythonConfigFactory::Python]][PythonConfigFactory::Keys[PythonConfigFactory::TestEngine]]);
+        runtimeConfig.m_target = ParseTargetConfig(configurationFile[PythonConfigFactory::Keys[PythonConfigFactory::Python]][PythonConfigFactory::Keys[PythonConfigFactory::TargetConfig]]);
+
+        return runtimeConfig;
+    }
+} // namespace TestImpact

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/Job/TestImpactPythonTestJobInfoGenerator.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/Job/TestImpactPythonTestJobInfoGenerator.h
@@ -19,7 +19,7 @@ namespace TestImpact
 {
     //! Generates job information for the instrumented test job runner.
     class PythonInstrumentedTestRunJobInfoGenerator
-        : public TestJobInfoGenerator<PythonInstrumentedTestRunnerBase, PythonTestTarget>
+        : public TestJobInfoGeneratorBase<PythonInstrumentedTestRunnerBase, PythonTestTarget>
     {
     public:
         //! Configures the test job info generator with the necessary path information for launching test targets.
@@ -29,9 +29,7 @@ namespace TestImpact
         PythonInstrumentedTestRunJobInfoGenerator(
             const RepoPath& repoDir, const RepoPath& buildDir, const ArtifactDir& artifactDir);
 
-        //! Generates the information for a test run job.
-        //! @param testTarget The test target to generate the job information for.
-        //! @param jobId The id to assign for this job.
+        // TestJobInfoGeneratorBase overrides...
         PythonInstrumentedTestRunnerBase::JobInfo GenerateJobInfo(const PythonTestTarget* testTarget, PythonInstrumentedTestRunnerBase::JobInfo::Id jobId) const;
 
     private:
@@ -42,7 +40,7 @@ namespace TestImpact
 
     //! Generates job information for the regular test job runner.
     class PythonRegularTestRunJobInfoGenerator
-        : public TestJobInfoGenerator<PythonRegularTestRunnerBase, PythonTestTarget>
+        : public TestJobInfoGeneratorBase<PythonRegularTestRunnerBase, PythonTestTarget>
     {
     public:
         //! Configures the test job info generator with the necessary path information for launching test targets.
@@ -52,9 +50,7 @@ namespace TestImpact
         PythonRegularTestRunJobInfoGenerator(
             const RepoPath& repoDir, const RepoPath& buildDir, const ArtifactDir& artifactDir);
 
-        //! Generates the information for a test run job.
-        //! @param testTarget The test target to generate the job information for.
-        //! @param jobId The id to assign for this job.
+        // TestJobInfoGeneratorBase overrides...
         PythonRegularTestRunnerBase::JobInfo GenerateJobInfo(const PythonTestTarget* testTarget, PythonRegularTestRunnerBase::JobInfo::Id jobId) const;
 
     private:

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonInstrumentedNullTestRunner.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonInstrumentedNullTestRunner.cpp
@@ -13,7 +13,7 @@ namespace TestImpact
 {
     AZStd::pair<ProcessSchedulerResult, AZStd::vector<PythonInstrumentedNullTestRunner::TestJobRunner::Job>>
     PythonInstrumentedNullTestRunner::RunTests(
-        const AZStd::vector<TestJobRunner::JobInfo>& jobInfos,
+        const TestJobRunner::JobInfos& jobInfos,
         [[maybe_unused]] StdOutputRouting stdOutRouting,
         [[maybe_unused]] StdErrorRouting stdErrRouting,
         [[maybe_unused]] AZStd::optional<AZStd::chrono::milliseconds> runTimeout,

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonInstrumentedNullTestRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonInstrumentedNullTestRunner.h
@@ -22,7 +22,7 @@ namespace TestImpact
         using PythonInstrumentedTestRunnerBase::PythonInstrumentedTestRunnerBase;
 
         AZStd::pair<ProcessSchedulerResult, AZStd::vector<TestJobRunner::Job>> RunTests(
-            const AZStd::vector<TestJobRunner::JobInfo>& jobInfos,
+            const TestJobRunner::JobInfos& jobInfos,
             StdOutputRouting stdOutRouting,
             StdErrorRouting stdErrRouting,
             AZStd::optional<AZStd::chrono::milliseconds> runTimeout,

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonRegularNullTestRunner.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonRegularNullTestRunner.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-
 #include <TestRunner/Python/TestImpactPythonErrorCodeChecker.h>
 #include <TestRunner/Python/TestImpactPythonRegularNullTestRunner.h>
 
@@ -14,7 +13,7 @@ namespace TestImpact
 {
     AZStd::pair<ProcessSchedulerResult, AZStd::vector<PythonRegularNullTestRunner::TestJobRunner::Job>>
     PythonRegularNullTestRunner::RunTests(
-        const AZStd::vector<TestJobRunner::JobInfo>& jobInfos,
+        const TestJobRunner::JobInfos& jobInfos,
         [[maybe_unused]] StdOutputRouting stdOutRouting,
         [[maybe_unused]] StdErrorRouting stdErrRouting,
         [[maybe_unused]] AZStd::optional<AZStd::chrono::milliseconds> runTimeout,

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonRegularNullTestRunner.h
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonRegularNullTestRunner.h
@@ -21,7 +21,7 @@ namespace TestImpact
         using PythonRegularTestRunnerBase::PythonRegularTestRunnerBase;
 
         AZStd::pair<ProcessSchedulerResult, AZStd::vector<TestJobRunner::Job>> RunTests(
-            const AZStd::vector<TestJobRunner::JobInfo>& jobInfos,
+            const TestJobRunner::JobInfos& jobInfos,
             StdOutputRouting stdOutRouting,
             StdErrorRouting stdErrRouting,
             AZStd::optional<AZStd::chrono::milliseconds> runTimeout,

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonRegularTestRunnerBase.cpp
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/Source/TestRunner/Python/TestImpactPythonRegularTestRunnerBase.cpp
@@ -6,7 +6,6 @@
  *
  */
 
-
 #include <TestImpactFramework/TestImpactUtils.h>
 
 #include <TestRunner/Python/TestImpactPythonRegularTestRunnerBase.h>

--- a/Code/Tools/TestImpactFramework/Runtime/Python/Code/testimpactframework_runtime_python_files.cmake
+++ b/Code/Tools/TestImpactFramework/Runtime/Python/Code/testimpactframework_runtime_python_files.cmake
@@ -9,6 +9,7 @@
 set(FILES
     Include/TestImpactFramework/Python/TestImpactPythonRuntime.h
     Include/TestImpactFramework/Python/TestImpactPythonConfiguration.h
+    Include/TestImpactFramework/Python/TestImpactPythonRuntimeConfigurationFactory.h
     Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.cpp
     Source/Artifact/Factory/TestImpactPythonTestTargetMetaMapFactory.h
     Source/Artifact/Static/TestImpactPythonTestTargetMeta.h
@@ -35,4 +36,5 @@ set(FILES
     Source/TestEngine/Python/TestImpactPythonTestEngine.cpp
     Source/TestEngine/Python/TestImpactPythonTestEngine.h
     Source/TestImpactPythonRuntime.cpp
+    Source/TestImpactPythonRuntimeConfigurationFactory.cpp
 )


### PR DESCRIPTION
## What does this PR do?

This PR adds the necessary Python support for native test sharding (see https://github.com/aws-lumberyard-dev/o3de/pull/510).

## How was this PR tested?

Local testing and will be tested in AR.