### PR TITLE
TIAF: Native Test Sharding AzTestRunner

### DIFF
--- a/Code/Tools/AzTestRunner/src/main.cpp
+++ b/Code/Tools/AzTestRunner/src/main.cpp
@@ -199,14 +199,14 @@ namespace AzTestRunner
         if (testMainFunction->IsValid())
         {
             // collapse the arguments vector into a c-style array of character pointers
-            std::vector<char*> cArguments;
-            cArguments.reserve(arguments.size());
-            for (const auto& argument : arguments)
+            std::vector<const char*> charArguments;
+            charArguments.reserve(arguments.size());
+            for (const std::string_view argument : arguments)
             {
-                cArguments.push_back(const_cast<char*>(argument.c_str()));
+                charArguments.push_back(argument.data());
             }
 
-            result = (*testMainFunction)(static_cast<int>(cArguments.size()), cArguments.data());
+            result = (*testMainFunction)(static_cast<int>(charArguments.size()), const_cast<char**>(charArguments.data()));
             std::cout << "OKAY " << symbol << "() returned " << result << std::endl;
             testMainFunction.reset();
         }

--- a/Code/Tools/AzTestRunner/src/main.cpp
+++ b/Code/Tools/AzTestRunner/src/main.cpp
@@ -11,12 +11,14 @@
 
 #include "aztestrunner.h"
 
+#include <fstream>
 
 namespace AzTestRunner
 {
-    const int INCORRECT_USAGE = 101;
-    const int LIB_NOT_FOUND = 102;
-    const int SYMBOL_NOT_FOUND = 103;
+    constexpr int INCORRECT_USAGE = 101;
+    constexpr int LIB_NOT_FOUND = 102;
+    constexpr int SYMBOL_NOT_FOUND = 103;
+    constexpr char argFromFileSeparator = '\n';
 
     //! display proper usage of the application
     void usage([[maybe_unused]] AZ::Test::Platform& platform)
@@ -37,8 +39,10 @@ namespace AzTestRunner
             "   --wait-for-debugger: tells runner to wait for debugger to attach to process (on supported platforms)\n"
             "   --pause-on-completion: tells the runner to pause after running the tests\n"
             "   --quiet: disables stdout for minimal output while running tests\n"
+            "   --args_from_file <filename>: reads additional arguments (newline separated) from the specified file (can be used in conjunction with regular command line arguments)\n"
             "\n"
             "Example:\n"
+            "   AzTestRunner.exe AzCore.Tests.dll AzRunUnitTests --args_from_file args.txt\n"
             "   AzTestRunner.exe AzCore.Tests.dll AzRunUnitTests --pause-on-completion\n"
             "\n"
             "Exit Codes:\n"
@@ -62,40 +66,71 @@ namespace AzTestRunner
             return INCORRECT_USAGE;
         }
 
+        // copy over the command line args to a vector so we can expand with any arguments from file
+        std::vector<std::string> arguments(argv, argv + argc);
+
         // capture positional arguments
         // [0] is the program name
-        std::string lib = argv[1];
-        std::string symbol = argv[2];
+        std::string lib = arguments[1];
+        std::string symbol = arguments[2];
 
-        // shift argv parameters down as we don't need lib or symbol anymore
-        AZ::Test::RemoveParameters(argc, argv, 1, 2);
+        // shift args parameters down as we don't need lib or symbol anymore
+        arguments.erase(std::next(arguments.begin(), 1), std::next(arguments.begin(), 3));
 
         // capture optional arguments
         bool waitForDebugger = false;
         bool pauseOnCompletion = false;
         bool quiet = false;
-        for (int i = 0; i < argc; i++)
+        for (int i = 0; i < arguments.size(); i++)
         {
-            if (strcmp(argv[i], "--wait-for-debugger") == 0)
+            if (arguments[i] == "--wait-for-debugger")
             {
                 waitForDebugger = true;
-                AZ::Test::RemoveParameters(argc, argv, i, i);
+                arguments.erase(arguments.begin() + i);
                 i--;
             }
-            else if (strcmp(argv[i], "--pause-on-completion") == 0)
+            else if (arguments[i] == "--pause-on-completion")
             {
                 pauseOnCompletion = true;
-                AZ::Test::RemoveParameters(argc, argv, i, i);
+                arguments.erase(arguments.begin() + i);
                 i--;
             }
-            else if (strcmp(argv[i], "--quiet") == 0)
+            else if (arguments[i] == "--quiet")
             {
                 quiet = true;
-                AZ::Test::RemoveParameters(argc, argv, i, i);
+                arguments.erase(arguments.begin() + i);
+                i--;
+            }
+            else if (arguments[i] == "--args_from_file")
+            {
+                // check that the arg file path has been passed
+                if (i + 1 >= arguments.size())
+                {
+                    std::cout << "Incorrect number of args_from_file arguments\n";
+                    usage(platform);
+                    return INCORRECT_USAGE;
+                }
+
+                // attempt to read the contents of the file
+                std::ifstream infile(arguments[i + 1]);
+                if (!infile.is_open())
+                {
+                    std::cout << "Couldn't open " << arguments[i + 1] << " for args input, exiting" << std::endl;
+                    return INCORRECT_USAGE;
+                }
+            
+                // remove the args_from_file argument and value from the arg list
+                arguments.erase(std::next(arguments.begin(), i), std::next(arguments.begin(), i + 2));
+
+                // Insert the args at the current position in the command line
+                std::string arg;
+                while (std::getline(infile, arg, argFromFileSeparator))
+                {
+                    arguments.insert(arguments.begin() + i, arg);
+                }
                 i--;
             }
         }
-
         if (quiet)
         {
             AzTestRunner::set_quiet_mode();
@@ -107,7 +142,7 @@ namespace AzTestRunner
             std::cout << "LIB: " << lib << std::endl;
         }
 
-        // Wait for debugger
+        // wait for debugger
         if (waitForDebugger)
         {
             if (platform.SupportsWaitForDebugger())
@@ -163,12 +198,20 @@ namespace AzTestRunner
         // run the test main function.
         if (testMainFunction->IsValid())
         {
-            result = (*testMainFunction)(argc, argv);
+            // collapse the arguments vector into a c-style array of character pointers
+            std::vector<char*> cArguments;
+            cArguments.reserve(arguments.size());
+            for (const auto& argument : arguments)
+            {
+                cArguments.push_back(const_cast<char*>(argument.c_str()));
+            }
+
+            result = (*testMainFunction)(static_cast<int>(cArguments.size()), cArguments.data());
             std::cout << "OKAY " << symbol << "() returned " << result << std::endl;
             testMainFunction.reset();
         }
 
-        // Construct a retry command if the test fails
+        // construct a retry command if the test fails
         if (result != 0)
         {
             std::cout << "Retry command: " << std::endl << argv[0] << " " << lib << " " << symbol << std::endl;
@@ -185,7 +228,6 @@ namespace AzTestRunner
 
         return result;
     }
-
 
     int wrapped_main(int argc/*=0*/, char** argv/*=nullptr*/)
     {


### PR DESCRIPTION
## What does this PR do?

This PR adds the ability for `AzTestRunner` to read additional command line arguments from a file. This is required to circumvent the wildly conservative command line string limit when using the `Win32` API to launch processes.

An additional argument for `AzTestRunner` is provided: `--args_from_file` followed by the path of the file containing the additional command line arguments. Said arguments in the file are newline separated. The command line argument `args_from_file` is removed from the command line argument array and in its place are the additional command line arguments as read from said file.

The TIAF test sharding optimization requires this functionality to work as the com and line arguments generated by this optimization can be considerably large (see https://github.com/aws-lumberyard-dev/o3de/pull/510).

## How was this PR tested?

_Please describe any testing performed._
