### PR TITLE
Articulation sensor

### DIFF
--- a/Gems/PhysX/Code/Include/PhysX/ArticulationSensorBus.h
+++ b/Gems/PhysX/Code/Include/PhysX/ArticulationSensorBus.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <AzCore/Component/ComponentBus.h>
+
+namespace AZ
+{
+    class Vector3;
+    class Transform;
+}
+
+namespace PhysX
+{
+    //! Interface to communicate with a sensor in a PhysX reduced co-ordinate articulation.
+    class ArticulationSensorRequests : public AZ::ComponentBus
+    {
+    public:
+        //! Get the transform of the sensor relative to the body frame of the link it is attached to.
+        //! The sensor index is per-link, and differs from the per-actuation indices used internally by PhysX.
+        virtual AZ::Transform GetSensorTransform(AZ::u32 sensorIndex) const = 0;
+
+        //! Set the transform of the sensor relative to the body frame of the link it is attached to.
+        //! The sensor index is per-link, and differs from the per-actuation indices used internally by PhysX.
+        virtual void SetSensorTransform(AZ::u32 sensorIndex, const AZ::Transform& sensorTransform) = 0;
+
+        //! Get the force reported by the sensor.
+        //! The sensor index is per-link, and differs from the per-actuation indices used internally by PhysX.
+        virtual AZ::Vector3 GetForce(AZ::u32 sensorIndex) const = 0;
+
+        //! Get the torque reported by the sensor.
+        //! The sensor index is per-link, and differs from the per-actuation indices used internally by PhysX.
+        virtual AZ::Vector3 GetTorque(AZ::u32 sensorIndex) const = 0;
+    };
+
+    using ArticulationSensorRequestBus = AZ::EBus<ArticulationSensorRequests>;
+} // namespace PhysX

--- a/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.cpp
+++ b/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.cpp
@@ -16,7 +16,52 @@
 
 namespace PhysX
 {
+    AZ_CLASS_ALLOCATOR_IMPL(ArticulationSensorConfiguration, AZ::SystemAllocator);
     AZ_CLASS_ALLOCATOR_IMPL(ArticulationLinkConfiguration, AZ::SystemAllocator);
+
+    void ArticulationSensorConfiguration::Reflect(AZ::ReflectContext* context)
+    {
+        if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
+        {
+            serializeContext->Class<ArticulationSensorConfiguration>()
+                ->Version(1)
+                ->Field("Local Position", &ArticulationSensorConfiguration::m_localPosition)
+                ->Field("Local Rotation", &ArticulationSensorConfiguration::m_localRotation)
+                ->Field("Include Forward Dynamics Forces", &ArticulationSensorConfiguration::m_includeForwardDynamicsForces)
+                ->Field("Include Constraint Solver Forces", &ArticulationSensorConfiguration::m_includeConstraintSolverForces)
+                ->Field("Use World Frame", &ArticulationSensorConfiguration::m_useWorldFrame);
+
+            if (auto* editContext = serializeContext->GetEditContext())
+            {
+                editContext->Class<ArticulationSensorConfiguration>("PhysX Articulation Sensor Configuration", "")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ArticulationSensorConfiguration::m_localPosition,
+                        "Local Position",
+                        "The local position of the sensor relative to the articulation link")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ArticulationSensorConfiguration::m_localRotation,
+                        "Local Rotation",
+                        "The local rotation of the sensor relative to the articulation link")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ArticulationSensorConfiguration::m_includeForwardDynamicsForces,
+                        "Include Forward Dynamics Forces",
+                        "Whether the output reported by the sensor should include forward dynamics forces")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ArticulationSensorConfiguration::m_includeConstraintSolverForces,
+                        "Include Constraint Solver Forces",
+                        "Whether the output reported by the sensor should include constraint solver forces")
+                    ->DataElement(
+                        AZ::Edit::UIHandlers::Default,
+                        &ArticulationSensorConfiguration::m_useWorldFrame,
+                        "Use World Frame",
+                        "If true, the output will be reported in world space, otherwise in the local space of the sensor");
+            }
+        }
+    }
 
     void ArticulationLinkConfiguration::Reflect(AZ::ReflectContext* context)
     {
@@ -50,7 +95,7 @@ namespace PhysX
                 ->Field("Angular Limit Negative", &ArticulationLinkConfiguration::m_angularLimitNegative)
                 ->Field("Angular Limit Positive", &ArticulationLinkConfiguration::m_angularLimitPositive)
                 ->Field("Motor configuration", &ArticulationLinkConfiguration::m_motorConfiguration)
-                ;
+                ->Field("Sensor Configurations", &ArticulationLinkConfiguration::m_sensorConfigs);
         }
     }
 

--- a/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.h
+++ b/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.h
@@ -24,6 +24,23 @@ namespace AZ
 
 namespace PhysX
 {
+    //! Configuration used to describe force/torque sensors attached to articulation links.
+    struct ArticulationSensorConfiguration
+    {
+        AZ_CLASS_ALLOCATOR_DECL;
+        AZ_RTTI(ArticulationSensorConfiguration, "{83960469-C92D-405D-B12E-EB235BCFFECA}");
+        static void Reflect(AZ::ReflectContext* context);
+
+        ArticulationSensorConfiguration() = default;
+        virtual ~ArticulationSensorConfiguration() = default;
+
+        AZ::Vector3 m_localPosition = AZ::Vector3::CreateZero(); //!< Position of the sensor relative to its link.
+        AZ::Vector3 m_localRotation = AZ::Vector3::CreateZero(); //!< Euler angle rotation of the sensor relative to its link.
+        bool m_includeForwardDynamicsForces = true; //!< Whether the output reported by the sensor should include forward dynamics forces.
+        bool m_includeConstraintSolverForces = true; //!< Whether the output reported by the sensor should include constraint solver forces.
+        bool m_useWorldFrame = false; //!< If true, the output will be reported in world space, otherwise in the local space of the sensor.
+    };
+
     //! Configuration used to Add Articulations to a Scene.
     struct ArticulationLinkConfiguration
     {
@@ -82,6 +99,8 @@ namespace PhysX
         AZ::Vector3 m_leadLocalPosition = AZ::Vector3::CreateZero(); 
         AZ::Vector3 m_LeadLocalRotation =
             AZ::Vector3::CreateZero(); //!< Local rotation angles about X, Y, Z axes in degrees, relative to lead body.
+
+        AZStd::vector<ArticulationSensorConfiguration> m_sensorConfigs;
 
         enum class DisplaySetupState : AZ::u8
         {

--- a/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.h
+++ b/Gems/PhysX/Code/Source/Articulation/ArticulationLinkConfiguration.h
@@ -28,11 +28,10 @@ namespace PhysX
     struct ArticulationSensorConfiguration
     {
         AZ_CLASS_ALLOCATOR_DECL;
-        AZ_RTTI(ArticulationSensorConfiguration, "{83960469-C92D-405D-B12E-EB235BCFFECA}");
+        AZ_TYPE_INFO(ArticulationSensorConfiguration, "{83960469-C92D-405D-B12E-EB235BCFFECA}");
         static void Reflect(AZ::ReflectContext* context);
 
         ArticulationSensorConfiguration() = default;
-        virtual ~ArticulationSensorConfiguration() = default;
 
         AZ::Vector3 m_localPosition = AZ::Vector3::CreateZero(); //!< Position of the sensor relative to its link.
         AZ::Vector3 m_localRotation = AZ::Vector3::CreateZero(); //!< Euler angle rotation of the sensor relative to its link.

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -193,17 +193,18 @@ namespace PhysX
         pxScene->addArticulation(*m_articulation);
 
         const AZ::u32 numSensors = m_articulation->getNbSensors();
-        physx::PxArticulationSensor* sensor;
         for (AZ::u32 sensorIndex = 0; sensorIndex < numSensors; sensorIndex++)
         {
+            physx::PxArticulationSensor* sensor = nullptr;
             m_articulation->getSensors(&sensor, 1, sensorIndex);
             ActorData* linkActorData = Utils::GetUserData(sensor->getLink());
             if (linkActorData)
             {
                 const auto entityId = linkActorData->GetEntityId();
-                if (m_sensorIndicesByEntityId.contains(entityId))
+                if (auto iterator = m_sensorIndicesByEntityId.find(entityId);
+                    iterator != m_sensorIndicesByEntityId.end())
                 {
-                    m_sensorIndicesByEntityId[entityId].push_back(sensor->getIndex());
+                    iterator->second.push_back(sensor->getIndex());
                 }
                 else
                 {
@@ -608,14 +609,14 @@ namespace PhysX
             return nullptr;
         }
 
-        AZ::u32 internalIndex = m_sensorIndices[sensorIndex];
         if (!m_link)
         {
             AZ_ErrorOnce("Articulation Link Component", false, "Invalid link pointer for entity %s", GetEntity()->GetName().c_str());
             return nullptr;
         }
 
-        auto& articulation = m_link->getArticulation();            
+        AZ::u32 internalIndex = m_sensorIndices[sensorIndex];
+        auto& articulation = m_link->getArticulation();
         const auto numSensors = articulation.getNbSensors();
         if (internalIndex >= numSensors)
         {

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -267,7 +267,7 @@ namespace PhysX
         {
             const AZ::Transform sensorTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
                 AZ::Quaternion::CreateFromEulerAnglesDegrees(sensorConfig.m_localRotation), sensorConfig.m_localPosition);
-            auto* sensor = thisLink->getArticulation().createSensor(thisLink, PxMathConvert(sensorTransform));
+            auto* sensor = thisPxLink->getArticulation().createSensor(thisPxLink, PxMathConvert(sensorTransform));
             sensor->setFlag(physx::PxArticulationSensorFlag::eFORWARD_DYNAMICS_FORCES, sensorConfig.m_includeForwardDynamicsForces);
             sensor->setFlag(physx::PxArticulationSensorFlag::eCONSTRAINT_SOLVER_FORCES, sensorConfig.m_includeConstraintSolverForces);
             sensor->setFlag(physx::PxArticulationSensorFlag::eWORLD_FRAME, sensorConfig.m_useWorldFrame);

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -135,10 +135,20 @@ namespace PhysX
                 }
             }
         }
+
+#if (PX_PHYSICS_VERSION_MAJOR == 5)
+        ArticulationJointRequestBus::Handler::BusConnect(GetEntityId());
+        ArticulationSensorRequestBus::Handler::BusConnect(GetEntityId());
+#endif
     }
 
     void ArticulationLinkComponent::Deactivate()
     {
+#if (PX_PHYSICS_VERSION_MAJOR == 5)
+        ArticulationSensorRequestBus::Handler::BusDisconnect();
+        ArticulationJointRequestBus::Handler::BusDisconnect();
+#endif
+
         if (m_attachedSceneHandle == AzPhysics::InvalidSceneHandle)
         {
             return;

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -306,6 +306,17 @@ namespace PhysX
             thisLink->attachShape(*static_cast<physx::PxShape*>(physicsShape->GetNativePointer()));
         }
 
+        // set up sensors
+        for (const auto& sensorConfig : thisLinkData.m_sensorConfigs)
+        {
+            const AZ::Transform sensorTransform = AZ::Transform::CreateFromQuaternionAndTranslation(
+                AZ::Quaternion::CreateFromEulerAnglesDegrees(sensorConfig.m_localRotation), sensorConfig.m_localPosition);
+            auto* sensor = thisLink->getArticulation().createSensor(thisLink, PxMathConvert(sensorTransform));
+            sensor->setFlag(physx::PxArticulationSensorFlag::eFORWARD_DYNAMICS_FORCES, sensorConfig.m_includeForwardDynamicsForces);
+            sensor->setFlag(physx::PxArticulationSensorFlag::eCONSTRAINT_SOLVER_FORCES, sensorConfig.m_includeConstraintSolverForces);
+            sensor->setFlag(physx::PxArticulationSensorFlag::eWORLD_FRAME, sensorConfig.m_useWorldFrame);
+        }
+        
         m_articulationLinksByEntityId.insert(EntityIdArticulationLinkPair{ thisLinkData.m_entityId, thisLink });
 
         for (const auto& childLink : thisLinkData.m_childLinks)

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
@@ -75,6 +75,7 @@ namespace PhysX
         float GetMaxJointVelocity() const override;
 #endif
         physx::PxArticulationLink* GetArticulationLink(const AZ::EntityId entityId);
+        const AZStd::vector<AZ::u32> GetSensorIndices(const AZ::EntityId entityId);
         const physx::PxArticulationJointReducedCoordinate* GetDriveJoint() const;
         physx::PxArticulationJointReducedCoordinate* GetDriveJoint();
         AZStd::shared_ptr<ArticulationLinkData> m_articulationLinkData;
@@ -110,12 +111,16 @@ namespace PhysX
         physx::PxArticulationLink* m_link = nullptr;
         physx::PxArticulationJointReducedCoordinate* m_driveJoint = nullptr;
 
+        AZStd::vector<AZ::u32> m_sensorIndices;
+
         AzPhysics::SceneHandle m_attachedSceneHandle = AzPhysics::InvalidSceneHandle;
         AZStd::vector<AzPhysics::SimulatedBodyHandle> m_articulationLinks;
         AzPhysics::SceneEvents::OnSceneSimulationFinishHandler m_sceneFinishSimHandler;
 
         using EntityIdArticulationLinkPair = AZStd::pair<AZ::EntityId, physx::PxArticulationLink*>;
         AZStd::unordered_map<AZ::EntityId, physx::PxArticulationLink*> m_articulationLinksByEntityId;
+        using EntityIdSensorIndexListPair = AZStd::pair<AZ::EntityId, AZStd::vector<AZ::u32>>;
+        AZStd::unordered_map<AZ::EntityId, AZStd::vector<AZ::u32>> m_sensorIndicesByEntityId;
     };
 
     //! Utility function for detecting if the current entity is the root of articulation.

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
@@ -15,6 +15,7 @@
 #include <AzFramework/Physics/RigidBodyBus.h>
 #include <AzFramework/Physics/Shape.h>
 #include <PhysX/ArticulationJointBus.h>
+#include <PhysX/ArticulationSensorBus.h>
 #include <PhysX/ComponentTypeIds.h>
 #include <PhysX/Joint/Configuration/PhysXJointConfiguration.h>
 #include <PhysX/UserDataTypes.h>
@@ -35,6 +36,7 @@ namespace PhysX
         , private AZ::TransformNotificationBus::Handler
 #if (PX_PHYSICS_VERSION_MAJOR == 5)
         , public PhysX::ArticulationJointRequestBus::Handler
+        , public PhysX::ArticulationSensorRequestBus::Handler
 #endif
     {
     public:
@@ -73,6 +75,12 @@ namespace PhysX
         float GetFrictionCoefficient() const override;
         void SetMaxJointVelocity(float maxJointVelocity) override;
         float GetMaxJointVelocity() const override;
+
+        // ArticulationSensorRequestBus overrides ...
+        AZ::Transform GetSensorTransform(AZ::u32 sensorIndex) const override;
+        void SetSensorTransform(AZ::u32 sensorIndex, const AZ::Transform& sensorTransform) override;
+        AZ::Vector3 GetForce(AZ::u32 sensorIndex) const override;
+        AZ::Vector3 GetTorque(AZ::u32 sensorIndex) const override;
 #endif
         physx::PxArticulationLink* GetArticulationLink(const AZ::EntityId entityId);
         const AZStd::vector<AZ::u32> GetSensorIndices(const AZ::EntityId entityId);
@@ -84,6 +92,9 @@ namespace PhysX
     private:
         bool IsRootArticulation() const;
         const AZ::Entity* GetArticulationRootEntity() const;
+
+        const physx::PxArticulationSensor* GetSensor(AZ::u32 sensorIndex) const;
+        physx::PxArticulationSensor* GetSensor(AZ::u32 sensorIndex);
 
 #if (PX_PHYSICS_VERSION_MAJOR == 5)
         void CreateArticulation();

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
@@ -64,6 +64,7 @@ namespace PhysX
         ArticulationJointData m_articulationJointData;
 
         AZStd::vector<AZStd::shared_ptr<ArticulationLinkData>> m_childLinks;
+        AZStd::vector<ArticulationSensorConfiguration> m_sensorConfigs;
     };
 
     //! Component implementing articulation link logic.

--- a/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
@@ -193,7 +193,12 @@ namespace PhysX
 
                     ->DataElement(
                         0, &ArticulationLinkConfiguration::m_motorConfiguration, "Motor Configuration", "Joint's motor configuration.")
-                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsSingleDofJointType);
+                    ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsSingleDofJointType)
+
+                    ->ClassElement(AZ::Edit::ClassElements::Group, "Sensors")
+                    ->Attribute(AZ::Edit::Attributes::AutoExpand, true)
+                    ->DataElement(0, &ArticulationLinkConfiguration::m_sensorConfigs, "Sensor Configurations", "Sensor configurations")
+                    ->EndGroup();
             }
         }
     }

--- a/Gems/PhysX/Code/Source/Pipeline/PhysicsPrefabProcessor.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/PhysicsPrefabProcessor.cpp
@@ -58,13 +58,13 @@ namespace PhysX
         // If the entity has a parent then it's not a root articulation and we fill the joint information.
         if (parentLinkData)
         {
-            AZ_Assert(articulationComponent, "Entity being proceessed for articulation has not articulation link component.");
+            AZ_Assert(articulationLinkComponent, "Entity being proceessed for articulation has not articulation link component.");
 
             linkData->m_articulationJointData.m_jointFollowerLocalFrame = AZ::Transform::CreateFromQuaternionAndTranslation(
-                AZ::Quaternion::CreateFromEulerAnglesDegrees(articulationComponent->m_config.m_localRotation),
-                articulationComponent->m_config.m_localPosition);
+                AZ::Quaternion::CreateFromEulerAnglesDegrees(articulationLinkComponent->m_config.m_localRotation),
+                articulationLinkComponent->m_config.m_localPosition);
 
-            if (articulationComponent->m_config.m_autoCalculateLeadFrame)
+            if (articulationLinkComponent->m_config.m_autoCalculateLeadFrame)
             {
                 linkData->m_articulationJointData.m_jointLeadLocalFrame =
                     linkData->m_localTransform * linkData->m_articulationJointData.m_jointFollowerLocalFrame;
@@ -72,8 +72,8 @@ namespace PhysX
             else
             {
                 linkData->m_articulationJointData.m_jointLeadLocalFrame = AZ::Transform::CreateFromQuaternionAndTranslation(
-                    AZ::Quaternion::CreateFromEulerAnglesDegrees(articulationComponent->m_config.m_leadLocalPosition),
-                    articulationComponent->m_config.m_leadLocalPosition);
+                    AZ::Quaternion::CreateFromEulerAnglesDegrees(articulationLinkComponent->m_config.m_leadLocalPosition),
+                    articulationLinkComponent->m_config.m_leadLocalPosition);
             }
         }
     }

--- a/Gems/PhysX/Code/Source/Pipeline/PhysicsPrefabProcessor.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/PhysicsPrefabProcessor.cpp
@@ -54,10 +54,12 @@ namespace PhysX
             linkData->m_shapeConfiguration = shapeColliderPair.second;
         }
 
+        auto* articulationComponent = entity->FindComponent<ArticulationLinkComponent>();
+        linkData->m_sensorConfigs = articulationComponent->m_config.m_sensorConfigs;
+
         // If the entity has a parent then it's not a root articulation and we fill the joint information.
         if (parentLinkData)
         {
-            auto* articulationComponent = entity->FindComponent<ArticulationLinkComponent>();
             AZ_Assert(articulationComponent, "Entity being proceessed for articulation has not articulation link component.");
 
             linkData->m_articulationJointData.m_jointType = articulationComponent->m_config.m_articulationJointType;

--- a/Gems/PhysX/Code/Source/Pipeline/PhysicsPrefabProcessor.cpp
+++ b/Gems/PhysX/Code/Source/Pipeline/PhysicsPrefabProcessor.cpp
@@ -51,6 +51,7 @@ namespace PhysX
         }
 
         auto* articulationLinkComponent = entity->FindComponent<ArticulationLinkComponent>();
+        AZ_Assert(articulationLinkComponent, "Entity being proceessed for articulation has not articulation link component.");
         linkData->m_articulationLinkConfiguration = articulationLinkComponent->m_config;
         linkData->m_articulationLinkConfiguration.m_entityId = entity->GetId();
         linkData->m_articulationLinkConfiguration.m_debugName = entity->GetName();
@@ -58,8 +59,6 @@ namespace PhysX
         // If the entity has a parent then it's not a root articulation and we fill the joint information.
         if (parentLinkData)
         {
-            AZ_Assert(articulationLinkComponent, "Entity being proceessed for articulation has not articulation link component.");
-
             linkData->m_articulationJointData.m_jointFollowerLocalFrame = AZ::Transform::CreateFromQuaternionAndTranslation(
                 AZ::Quaternion::CreateFromEulerAnglesDegrees(articulationLinkComponent->m_config.m_localRotation),
                 articulationLinkComponent->m_config.m_localPosition);

--- a/Gems/PhysX/Code/Source/Utils.cpp
+++ b/Gems/PhysX/Code/Source/Utils.cpp
@@ -1805,6 +1805,7 @@ namespace PhysX
             BallJointConfiguration::Reflect(context);
             HingeJointConfiguration::Reflect(context);
             PrismaticJointConfiguration::Reflect(context);
+            ArticulationSensorConfiguration::Reflect(context);
             ArticulationLinkConfiguration::Reflect(context);
 
             MaterialConfiguration::Reflect(context);

--- a/Gems/PhysX/Code/physx_files.cmake
+++ b/Gems/PhysX/Code/physx_files.cmake
@@ -31,6 +31,7 @@ set(FILES
     Include/PhysX/Material/PhysXMaterialConfiguration.h
     Include/PhysX/ArticulationTypes.h
     Include/PhysX/ArticulationJointBus.h
+    Include/PhysX/ArticulationSensorBus.h
     Source/Articulation/ArticulationLinkConfiguration.h
     Source/Articulation/ArticulationLinkConfiguration.cpp
     Source/ArticulationLinkComponent.cpp


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/15233

Adds option to add force/torque sensors in the editor configuration for an articulation link component, and bus for querying the sensors.

## How was this PR tested?
Debug printfs.
