### PR TITLE
add feature flag to show/hide articulation link component in add comp…

### DIFF
--- a/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
@@ -216,12 +216,18 @@ namespace PhysX
             {
                 constexpr const char* ToolTip = "Articulated rigid body.";
 
+                AZStd::vector<AZ::Crc32> componentMenus;
+                if (ReducedCoordinateArticulationsEnabled())
+                {
+                    componentMenus.push_back(AZ::Crc32("Game"));
+                }
+
                 editContext->Class<EditorArticulationLinkComponent>("PhysX Articulation Link", ToolTip)
                     ->ClassElement(AZ::Edit::ClassElements::EditorData, "")
                     ->Attribute(AZ::Edit::Attributes::Category, "PhysX")
                     ->Attribute(AZ::Edit::Attributes::Icon, "Icons/Components/PhysXRigidBody.svg")
                     ->Attribute(AZ::Edit::Attributes::ViewportIcon, "Icons/Components/Viewport/PhysXRigidBody.svg")
-                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, AZ_CRC_CE("Game"))
+                    ->Attribute(AZ::Edit::Attributes::AppearsInAddComponentMenu, componentMenus)
                     ->Attribute(AZ::Edit::Attributes::HelpPageURL, "")
 
                     ->DataElement(

--- a/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.h
@@ -19,7 +19,7 @@
 namespace PhysX
 {
     //! Feature flag for work in progress on PhysX reduced co-ordinate articulations (see https://github.com/o3de/sig-simulation/issues/60).
-    constexpr AZStd::string_view ReducedCoordinateArticulationsFlag = "/Amazon/Preferences/EnableReducedCoordinateArticulations";
+    constexpr AZStd::string_view ReducedCoordinateArticulationsFlag = "/Amazon/Physics/EnableReducedCoordinateArticulations";
 
     //! Helper function for checking whether feature flag for in progress PhysX reduced co-ordinate articulations work is enabled.
     //! See https://github.com/o3de/sig-simulation/issues/60 for more details.

--- a/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.h
@@ -9,14 +9,32 @@
 #pragma once
 
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/Settings/SettingsRegistry.h>
 #include <AzFramework/Entity/EntityDebugDisplayBus.h>
 #include <AzToolsFramework/ToolsComponents/EditorComponentBase.h>
 #include <Editor/EditorJointConfiguration.h>
-#include <Source/EditorRigidBodyComponent.h>
 #include <Source/Articulation/ArticulationLinkConfiguration.h>
+#include <Source/EditorRigidBodyComponent.h>
 
 namespace PhysX
 {
+    //! Feature flag for work in progress on PhysX reduced co-ordinate articulations (see https://github.com/o3de/sig-simulation/issues/60).
+    constexpr AZStd::string_view ReducedCoordinateArticulationsFlag = "/Amazon/Preferences/EnableReducedCoordinateArticulations";
+
+    //! Helper function for checking whether feature flag for in progress PhysX reduced co-ordinate articulations work is enabled.
+    //! See https://github.com/o3de/sig-simulation/issues/60 for more details.
+    inline bool ReducedCoordinateArticulationsEnabled()
+    {
+        bool reducedCoordinateArticulationsEnabled = false;
+
+        if (auto* registry = AZ::SettingsRegistry::Get())
+        {
+            registry->Get(reducedCoordinateArticulationsEnabled, ReducedCoordinateArticulationsFlag);
+        }
+
+        return reducedCoordinateArticulationsEnabled;
+    }
+
     class EditorArticulationLinkComponent;
 
     //! Configuration data for EditorRigidBodyComponent.


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/o3de/o3de/issues/15496

Adds a feature flag to enable/disable showing the articulation link component in the add component menu.

## How was this PR tested?

Tested with and without registry setting enabled.