### PR TITLE
fix build with physx 4

### DIFF
--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -99,6 +99,7 @@ namespace PhysX
         return currentEntity;
     }
 
+#if (PX_PHYSICS_VERSION_MAJOR == 5)
     void ArticulationLinkComponent::Activate()
     {
         if (IsRootArticulation())
@@ -129,25 +130,21 @@ namespace PhysX
                     m_link = rootArticulationLinkComponent->GetArticulationLink(GetEntityId());
                     if (m_link)
                     {
-                        m_driveJoint = m_link->getInboundJoint();
+                        m_driveJoint = m_link->getInboundJoint()->is<physx::PxArticulationJointReducedCoordinate>();
                     }
                     m_sensorIndices = rootArticulationLinkComponent->GetSensorIndices(GetEntityId());
                 }
             }
         }
 
-#if (PX_PHYSICS_VERSION_MAJOR == 5)
         ArticulationJointRequestBus::Handler::BusConnect(GetEntityId());
         ArticulationSensorRequestBus::Handler::BusConnect(GetEntityId());
-#endif
     }
 
     void ArticulationLinkComponent::Deactivate()
     {
-#if (PX_PHYSICS_VERSION_MAJOR == 5)
         ArticulationSensorRequestBus::Handler::BusDisconnect();
         ArticulationJointRequestBus::Handler::BusDisconnect();
-#endif
 
         if (m_attachedSceneHandle == AzPhysics::InvalidSceneHandle)
         {
@@ -161,6 +158,7 @@ namespace PhysX
 
         AZ::TransformNotificationBus::Handler::BusDisconnect();
     }
+#endif
 
     void ArticulationLinkComponent::OnTransformChanged(
         [[maybe_unused]] const AZ::Transform& local, [[maybe_unused]] const AZ::Transform& world)
@@ -673,5 +671,11 @@ namespace PhysX
         }
         return AZ::Vector3::CreateZero();
     }
+#else
+    void ArticulationLinkComponent::Activate() {}
+    void ArticulationLinkComponent::Deactivate() {}
+    void ArticulationLinkComponent::CreateArticulation() {}
+    void ArticulationLinkComponent::DestroyArticulation() {}
+    void ArticulationLinkComponent::InitPhysicsTickHandler() {}
 #endif
 } // namespace PhysX

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.h
@@ -93,11 +93,12 @@ namespace PhysX
         bool IsRootArticulation() const;
         const AZ::Entity* GetArticulationRootEntity() const;
 
+        void CreateArticulation();
+        void DestroyArticulation();
+        void InitPhysicsTickHandler();
+#if (PX_PHYSICS_VERSION_MAJOR == 5)
         const physx::PxArticulationSensor* GetSensor(AZ::u32 sensorIndex) const;
         physx::PxArticulationSensor* GetSensor(AZ::u32 sensorIndex);
-
-#if (PX_PHYSICS_VERSION_MAJOR == 5)
-        void CreateArticulation();
 
         void SetRootSpecificProperties(const ArticulationLinkConfiguration& rootLinkConfiguration);
 
@@ -105,9 +106,6 @@ namespace PhysX
 
         void AddCollisionShape(const ArticulationLinkData& thisLinkData, ArticulationLink* articulationLink);
 
-        void DestroyArticulation();
-
-        void InitPhysicsTickHandler();
         void PostPhysicsTick(float fixedDeltaTime);
 #endif
 


### PR DESCRIPTION
## What does this PR do?
Fixes build when PhysX 5 is not enabled.

## How was this PR tested?
Built editor with -DAZ_USE_PHYSX5=OFF and -DAZ_USE_PHYSX5=ON
