### PR TITLE
store link pointer and sensor indices for root articulation link comp…

### DIFF
--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -164,10 +164,11 @@ namespace PhysX
         }
         else
         {
-            m_link = nullptr;
             m_driveJoint = nullptr;
-            m_sensorIndices.clear();
         }
+
+        m_link = nullptr;
+        m_sensorIndices.clear();
 
         // set the behavior when the parent's transform changes back to default, since physics is no longer controlling the transform
         GetEntity()->GetTransform()->SetOnParentChangedBehavior(AZ::OnParentChangedBehavior::Update);

--- a/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/ArticulationLinkComponent.cpp
@@ -119,6 +119,8 @@ namespace PhysX
                 }
 
                 CreateArticulation();
+                m_link = GetArticulationLink(GetEntityId());
+                m_sensorIndices = GetSensorIndices(GetEntityId());
             }
         }
         else


### PR DESCRIPTION
…onent

## What does this PR do?
Stores the link pointer and the list of sensor indices for the root articulation link component (previously they were only getting stored for child links).

## How was this PR tested?
Ran panda test level.