### PR TITLE
Fix unit tests for articulation staging branch

### DIFF
--- a/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SimulatedBodyConfiguration.cpp
+++ b/Code/Framework/AzFramework/AzFramework/Physics/Configuration/SimulatedBodyConfiguration.cpp
@@ -13,14 +13,42 @@
 
 namespace AzPhysics
 {
+    namespace Internal
+    {
+        bool DeprecateWorldBodyConfiguration(AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement)
+        {
+            // WorldBodyConfiguration on serialized the name so capture that.
+            AZStd::string name = "";
+            classElement.GetChildData(AZ::Crc32("name"), name);
+            // convert to the new class
+            classElement.Convert<SimulatedBodyConfiguration>(context);
+            // add the captured name
+            classElement.AddElementWithData(context, "name", name);
+            return true;
+        }
+
+        bool SimulatedBodyVersionConverter(
+            [[maybe_unused]] AZ::SerializeContext& context, AZ::SerializeContext::DataElementNode& classElement)
+        {
+            if (classElement.GetVersion() <= 1)
+            {
+                classElement.RemoveElementByName(AZ_CRC_CE("scale"));
+            }
+
+            return true;
+        }
+    } // namespace Internal
+
     AZ_CLASS_ALLOCATOR_IMPL(SimulatedBodyConfiguration, AZ::SystemAllocator);
 
     void SimulatedBodyConfiguration::Reflect(AZ::ReflectContext* context)
     {
         if (auto* serializeContext = azrtti_cast<AZ::SerializeContext*>(context))
         {
+            serializeContext->ClassDeprecate(
+                "WorldBodyConfiguration", AZ::Uuid("{6EEB377C-DC60-4E10-AF12-9626C0763B2D}"), &Internal::DeprecateWorldBodyConfiguration);
             serializeContext->Class<SimulatedBodyConfiguration>()
-                ->Version(1)
+                ->Version(2, &Internal::SimulatedBodyVersionConverter)
                 ->Field("name", &SimulatedBodyConfiguration::m_debugName)
                 ->Field("position", &SimulatedBodyConfiguration::m_position)
                 ->Field("orientation", &SimulatedBodyConfiguration::m_orientation)


### PR DESCRIPTION
## What does this PR do?

Putting back the code that treats deprecated class WorldBodyConfiguration. Ragdoll unit tests uses data that still use `WorldBodyConfiguration` class and it was failing because of it.

Ideally we'd change the data in the unit tests, but there are assets in AutomatedTesting project that uses WorldBodyConfiguration too, so the safest approach at the moment is to put back the code.

## How was this PR tested?

Run unit tests and passed.
