### PR TITLE
Spham amzn/linux aarch64/fix unit tests

### DIFF
--- a/Code/Framework/AzCore/Tests/ScriptMath.cpp
+++ b/Code/Framework/AzCore/Tests/ScriptMath.cpp
@@ -278,11 +278,7 @@ namespace UnitTest
         script->Execute("AZTestAssert( not Vector2(math.huge, math.huge):IsFinite())");
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptMathTest, DISABLED_LuaVector3Test)
-#else
     TEST_F(ScriptMathTest, LuaVector3Test)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         // Not all Vector3 C++ functions are reflected into Lua:
         // Compound assignment operators are not supported in Lua (+=, -=, /=, *=)
@@ -360,7 +356,14 @@ namespace UnitTest
         script->Execute("AZTestAssert(v1:IsClose(Vector3(6, 8, 0)))");
         script->Execute("v1:Set(3, 4, 0)");
         script->Execute("v1:SetLengthEstimate(10)");
-        script->Execute("AZTestAssert(v1:IsClose(Vector3(6, 8, 0), 0.001))");
+
+
+        #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        #define LUA_VECTOR3_TEST_LENGTH_ESTIMATE_TOLERANCE "0.0195" // 10*2^(-9) ~= 0.0195 <- NEON Reciprocal ~ 9 bits
+        #else
+        #define LUA_VECTOR3_TEST_LENGTH_ESTIMATE_TOLERANCE "0.0049" // 10*2^(-11) ~= 0.0049 <- x86 Reciprocal ~ 11 bits
+        #endif
+        script->Execute("AZTestAssert(v1:IsClose(Vector3(6, 8, 0), " LUA_VECTOR3_TEST_LENGTH_ESTIMATE_TOLERANCE "))");
 
         ////distance
         script->Execute("v1:Set(1, 2, 3)");

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewBookmarkTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewBookmarkTests.cpp
@@ -133,11 +133,7 @@ namespace UnitTest
             IsClose(AZ::Vector3(expectedCameraRotationXDegrees, 0.0f, expectedCameraRotationZDegrees)));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ViewBookmarkTestFixture, DISABLED_ViewBookmarkCanBeStoredAndRetrievedAtIndex)
-#else
     TEST_F(ViewBookmarkTestFixture, ViewBookmarkCanBeStoredAndRetrievedAtIndex)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         using ::testing::IsFalse;
         AzToolsFramework::ViewBookmarkInterface* bookmarkInterface = AZ::Interface<AzToolsFramework::ViewBookmarkInterface>::Get();
@@ -158,9 +154,27 @@ namespace UnitTest
 
         const AZStd::optional<AzToolsFramework::ViewBookmark> lastKnownLocationBookmark = bookmarkInterface->LoadBookmarkAtIndex(4);
 
-        EXPECT_THAT(lastKnownLocationBookmark->m_position, IsClose(cameraPosition));
+        #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        // Expected:  (X: 75,      Y:  0, Z: 64)
+        // Actual:    (X: 74.9989, Y: -0, Z: 64)
+        // Delta:          0.0011      0,     0
+        constexpr float cameraPositionTolerance=0.0012f;
+        #else
+        constexpr float cameraPositionTolerance=0.0f;
+        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        EXPECT_THAT(lastKnownLocationBookmark->m_position, IsCloseTolerance(cameraPosition, cameraPositionTolerance));
+
+        #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        // Expected:  (X: 75,      Y: 0,  Z: 64)
+        // Actual:    (X: 74.9989, Y: -0, Z: 64)
+        // Delta:          0.0011      0,     0
+        constexpr float cameraRotationTolerance=0.0012f;
+        #else
+        constexpr float cameraRotationTolerance=0.0f;
+        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+
         EXPECT_THAT(
             lastKnownLocationBookmark->m_rotation,
-            IsClose(AZ::Vector3(expectedCameraRotationXDegrees, 0.0f, expectedCameraRotationZDegrees)));
+            IsCloseTolerance(AZ::Vector3(expectedCameraRotationXDegrees, 0.0f, expectedCameraRotationZDegrees), cameraRotationTolerance));
     }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewBookmarkTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewBookmarkTests.cpp
@@ -158,23 +158,25 @@ namespace UnitTest
         // Expected:  (X: 75,      Y:  0, Z: 64)
         // Actual:    (X: 74.9989, Y: -0, Z: 64)
         // Delta:          0.0011      0,     0
-        constexpr float cameraPositionTolerance=0.0012f;
-        #else
-        constexpr float cameraPositionTolerance=0.0f;
-        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        constexpr float cameraPositionTolerance = 0.0012f;
         EXPECT_THAT(lastKnownLocationBookmark->m_position, IsCloseTolerance(cameraPosition, cameraPositionTolerance));
+        #else
+        EXPECT_THAT(lastKnownLocationBookmark->m_position, IsClose(cameraPosition, cameraPositionTolerance));
+        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
 
         #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
         // Expected:  (X: 75,      Y: 0,  Z: 64)
         // Actual:    (X: 74.9989, Y: -0, Z: 64)
         // Delta:          0.0011      0,     0
-        constexpr float cameraRotationTolerance=0.0012f;
-        #else
-        constexpr float cameraRotationTolerance=0.0f;
-        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
-
+        constexpr float cameraRotationTolerance = 0.0012f;
         EXPECT_THAT(
             lastKnownLocationBookmark->m_rotation,
             IsCloseTolerance(AZ::Vector3(expectedCameraRotationXDegrees, 0.0f, expectedCameraRotationZDegrees), cameraRotationTolerance));
+        #else
+        EXPECT_THAT(
+            lastKnownLocationBookmark->m_rotation,
+            IsClose(AZ::Vector3(expectedCameraRotationXDegrees, 0.0f, expectedCameraRotationZDegrees)));
+        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+
     }
 } // namespace UnitTest

--- a/Code/Framework/AzToolsFramework/Tests/Viewport/ViewBookmarkTests.cpp
+++ b/Code/Framework/AzToolsFramework/Tests/Viewport/ViewBookmarkTests.cpp
@@ -161,7 +161,7 @@ namespace UnitTest
         constexpr float cameraPositionTolerance = 0.0012f;
         EXPECT_THAT(lastKnownLocationBookmark->m_position, IsCloseTolerance(cameraPosition, cameraPositionTolerance));
         #else
-        EXPECT_THAT(lastKnownLocationBookmark->m_position, IsClose(cameraPosition, cameraPositionTolerance));
+        EXPECT_THAT(lastKnownLocationBookmark->m_position, IsClose(cameraPosition));
         #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
 
         #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON

--- a/Gems/EMotionFX/Code/Tests/PoseTests.cpp
+++ b/Gems/EMotionFX/Code/Tests/PoseTests.cpp
@@ -476,11 +476,7 @@ namespace EMotionFX
         }
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_P(PoseTestsBoolParam, DISABLED_UpdateLocalSpaceTranforms)
-#else
     TEST_P(PoseTestsBoolParam, UpdateLocalSpaceTranforms)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         Pose pose;
         pose.LinkToActor(m_actor.get());
@@ -493,8 +489,13 @@ namespace EMotionFX
 
             // Set the model space transform directly, so that it won't automatically be updated.
             pose.SetModelSpaceTransformDirect(i, newTransform);
+            #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+            EXPECT_THAT(pose.GetModelSpaceTransformDirect(i), IsClose(newTransform));
+            EXPECT_THAT(pose.GetLocalSpaceTransformDirect(i), IsClose(oldLocalSpaceTransform));
+            #else
             EXPECT_EQ(pose.GetModelSpaceTransformDirect(i), newTransform);
             EXPECT_EQ(pose.GetLocalSpaceTransformDirect(i), oldLocalSpaceTransform);
+            #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
         }
 
         // We have to manually update the local space transforms as we directly set them.
@@ -516,15 +517,15 @@ namespace EMotionFX
         for (size_t i = 0; i < m_actor->GetSkeleton()->GetNumNodes(); ++i)
         {
             // Get the local space transform without auto-updating them, to see if update call worked.
-            EXPECT_EQ(pose.GetLocalSpaceTransformDirect(i), Transform(AZ::Vector3(0.0f, 0.0f, m_testOffset), AZ::Quaternion::CreateIdentity()));
+            #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+            EXPECT_THAT(pose.GetLocalSpaceTransformDirect(i), IsClose(Transform(AZ::Vector3(0.0f, 0.0f, m_testOffset), AZ::Quaternion::CreateIdentity())));
+            #else
+            EXPECT_EQ(pose.GetLocalSpaceTransformDirect(i), Transform(Transform(AZ::Vector3(0.0f, 0.0f, m_testOffset), AZ::Quaternion::CreateIdentity())));
+            #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
         }
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(PoseTests, DISABLED_ForceUpdateFullLocalSpacePose)
-#else
     TEST_F(PoseTests, ForceUpdateFullLocalSpacePose)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         Pose pose;
         pose.LinkToActor(m_actor.get());
@@ -537,8 +538,13 @@ namespace EMotionFX
 
             // Set the local space without invalidating the model space transform.
             pose.SetModelSpaceTransformDirect(i, newTransform);
+            #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+            EXPECT_THAT(pose.GetModelSpaceTransformDirect(i), IsClose(newTransform));
+            EXPECT_THAT(pose.GetLocalSpaceTransformDirect(i), IsClose(oldLocalSpaceTransform));
+            #else
             EXPECT_EQ(pose.GetModelSpaceTransformDirect(i), newTransform);
             EXPECT_EQ(pose.GetLocalSpaceTransformDirect(i), oldLocalSpaceTransform);
+            #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
         }
 
         // Update all local space transforms regardless of the invalidate flag.
@@ -547,7 +553,11 @@ namespace EMotionFX
         for (size_t i = 0; i < m_actor->GetSkeleton()->GetNumNodes(); ++i)
         {
             // Get the local space transform without auto-updating them, to see if update call worked.
+            #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+            EXPECT_THAT(pose.GetLocalSpaceTransformDirect(i), IsClose(Transform(AZ::Vector3(0.0f, 0.0f, m_testOffset), AZ::Quaternion::CreateIdentity())));
+            #else
             EXPECT_EQ(pose.GetLocalSpaceTransformDirect(i), Transform(AZ::Vector3(0.0f, 0.0f, m_testOffset), AZ::Quaternion::CreateIdentity()));
+            #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
         }
     }
 

--- a/Gems/EMotionFX/Code/Tests/UI/CanUseLayoutMenu.cpp
+++ b/Gems/EMotionFX/Code/Tests/UI/CanUseLayoutMenu.cpp
@@ -124,7 +124,7 @@ namespace EMotionFX
             QList<QPushButton*> dialogButtons = inputDialog->findChildren<QPushButton*>();
             for (QPushButton* dialogButton : dialogButtons)
             {
-                if (dialogButton->text() == "OK")
+                if (dialogButton->text().endsWith("OK"))
                 {
                     QTest::mouseClick(dialogButton, Qt::LeftButton);
                     break;
@@ -201,11 +201,7 @@ namespace EMotionFX
         QString m_saveLayoutFileName;
     };
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(CanUseLayoutMenuFixture, DISABLED_CanUseLayoutMenu)
-#else
     TEST_F(CanUseLayoutMenuFixture, CanUseLayoutMenu)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         RecordProperty("test_case_id", "C1698603");
 

--- a/Gems/LmbrCentral/Code/Tests/CapsuleShapeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/CapsuleShapeTest.cpp
@@ -388,11 +388,7 @@ namespace UnitTest
         EXPECT_NEAR(distance, 2.0f, 1e-2f);
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(CapsuleShapeTest, DISABLED_ShapeHasThreadsafeGetSetCalls)
-#else
     TEST_F(CapsuleShapeTest, ShapeHasThreadsafeGetSetCalls)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         // Verify that setting values from one thread and querying values from multiple other threads in parallel produces
         // correct, consistent results.

--- a/Gems/LmbrCentral/Code/Tests/PolygonPrismShapeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/PolygonPrismShapeTest.cpp
@@ -85,11 +85,7 @@ namespace UnitTest
         LmbrCentral::PolygonPrismShapeComponentRequestBus::Event(entity.GetId(), &LmbrCentral::PolygonPrismShapeComponentRequests::SetVertices, vertices);
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(PolygonPrismShapeTest, DISABLED_PolygonShapeComponent_IsPointInside)
-#else
     TEST_F(PolygonPrismShapeTest, PolygonShapeComponent_IsPointInside)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         AZ::Entity entity;
         CreatePolygonPrism(
@@ -235,7 +231,7 @@ namespace UnitTest
         }
         {
             bool inside;
-            LmbrCentral::ShapeComponentRequestsBus::EventResult(inside, entity.GetId(), &LmbrCentral::ShapeComponentRequests::IsPointInside, AZ::Vector3(502.0f, 585.0f, 32.0f));
+            LmbrCentral::ShapeComponentRequestsBus::EventResult(inside, entity.GetId(), &LmbrCentral::ShapeComponentRequests::IsPointInside, AZ::Vector3(502.0f, 585.1f, 32.0f));
             EXPECT_TRUE(inside);
         }
         {

--- a/Gems/LmbrCentral/Code/Tests/ShapeThreadsafeTest.cpp
+++ b/Gems/LmbrCentral/Code/Tests/ShapeThreadsafeTest.cpp
@@ -31,6 +31,14 @@ namespace UnitTest
         // always be 10.  (The shape extends 10 above and 10 below the origin, so 20 above origin is 10 above the shape)
         constexpr float ExpectedDistance = 10.0f;
 
+        // Comparing floats needs a tolerance based on whether we are using NEON or not
+        #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        constexpr float compareTolerance = 1.0e-4;
+        #else
+        constexpr float compareTolerance = 1.0e-6;
+        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+
+
         AZ::EntityId shapeEntityId = shapeEntity.GetId();
 
         // Pick an arbitrary number of threads and iterations that are large enough to demonstrate thread safety problems.
@@ -64,7 +72,7 @@ namespace UnitTest
                         // You can put a breakpoint on the ASSERT_EQ line to see the current state of things in the failure case.
                         if (distance != ExpectedDistance)
                         {
-                            ASSERT_EQ(distance, ExpectedDistance);
+                            ASSERT_NEAR(distance, ExpectedDistance, compareTolerance);
                         }
                     }
                 });

--- a/Gems/PhysX/Code/Tests/PrimitiveShapeFitterTests.cpp
+++ b/Gems/PhysX/Code/Tests/PrimitiveShapeFitterTests.cpp
@@ -37,15 +37,22 @@ namespace PhysX::Pipeline
     extern const AZStd::array<AZ::Vector3, 514> CapsuleVertices;
     extern const AZStd::array<AZ::Vector3, 8> MinimalVertices;
 
+    #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+    // NEON has a lower float precision than SIMD/SCALAR
+    static constexpr double defaultTolerance = 1.0e-4;
+    #else
+    static constexpr double defaultTolerance = 1.0e-6;
+    #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
 
-    static void ExpectNear(const AZ::Vector3& actual, const AZ::Vector3& expected, const double tolerance = 1.0e-6)
+
+    static void ExpectNear(const AZ::Vector3& actual, const AZ::Vector3& expected, const double tolerance = defaultTolerance)
     {
         EXPECT_NEAR(actual(0), expected(0), tolerance);
         EXPECT_NEAR(actual(1), expected(1), tolerance);
         EXPECT_NEAR(actual(2), expected(2), tolerance);
     }
 
-    static void ExpectParallel(const AZ::Vector3& actual, const AZ::Vector3& expected, const double tolerance = 1.0e-6)
+    static void ExpectParallel(const AZ::Vector3& actual, const AZ::Vector3& expected, const double tolerance = defaultTolerance)
     {
         if (expected.Dot(actual) > 0.0)
         {
@@ -63,12 +70,12 @@ namespace PhysX::Pipeline
         const AZ::Vector3& zAxis
     )
     {
-        EXPECT_NEAR(xAxis.GetLengthSq(), 1.0, 1.0e-6);
-        EXPECT_NEAR(yAxis.GetLengthSq(), 1.0, 1.0e-6);
-        EXPECT_NEAR(zAxis.GetLengthSq(), 1.0, 1.0e-6);
+        EXPECT_NEAR(xAxis.GetLengthSq(), 1.0, defaultTolerance);
+        EXPECT_NEAR(yAxis.GetLengthSq(), 1.0, defaultTolerance);
+        EXPECT_NEAR(zAxis.GetLengthSq(), 1.0, defaultTolerance);
 
-        EXPECT_NEAR(xAxis.Dot(yAxis), 0.0, 1.0e-6);
-        ExpectNear(zAxis, xAxis.Cross(yAxis), 1.0e-6);
+        EXPECT_NEAR(xAxis.Dot(yAxis), 0.0, defaultTolerance);
+        ExpectNear(zAxis, xAxis.Cross(yAxis), defaultTolerance);
     }
 
     static AZStd::vector<Vec3> AZVerticesToLYVertices(const AZStd::vector<AZ::Vector3>& vertices)
@@ -366,11 +373,7 @@ namespace PhysX::Pipeline
         ExpectNear(configPtr->m_transform->GetTranslation(), AZ::Vector3(1.0, 2.0, 3.0));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST(GetShapeConfigurationTestFixture, DISABLED_SimpleBoxTest)
-#else
     TEST(GetShapeConfigurationTestFixture, SimpleBoxTest)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         const MeshAssetData::ShapeConfigurationPair pair = SimpleBox->GetShapeConfigurationPair();
 
@@ -418,11 +421,7 @@ namespace PhysX::Pipeline
         ExpectNear(configPtr->m_transform->GetBasisZ(), AZ::Vector3(0.5, 0.0, 0.8660254038));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST(GetShapeConfigurationTestFixture, DISABLED_SimpleCapsuleTest)
-#else
     TEST(GetShapeConfigurationTestFixture, SimpleCapsuleTest)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         const MeshAssetData::ShapeConfigurationPair pair = SimpleCapsule->GetShapeConfigurationPair();
 
@@ -432,8 +431,8 @@ namespace PhysX::Pipeline
         // Validate shape.
         ASSERT_THAT(shapePtr, ::testing::NotNull());
         ASSERT_TRUE(shapePtr->GetShapeType() == Physics::ShapeType::Capsule);
-        EXPECT_NEAR(static_cast<const Physics::CapsuleShapeConfiguration&>(*shapePtr).m_height, 6.0, 1.0e-6);
-        EXPECT_NEAR(static_cast<const Physics::CapsuleShapeConfiguration&>(*shapePtr).m_radius, 1.0, 1.0e-6);
+        EXPECT_NEAR(static_cast<const Physics::CapsuleShapeConfiguration&>(*shapePtr).m_height, 6.0, defaultTolerance);
+        EXPECT_NEAR(static_cast<const Physics::CapsuleShapeConfiguration&>(*shapePtr).m_radius, 1.0, defaultTolerance);
 
         // Validate transform.
         ASSERT_THAT(configPtr, ::testing::NotNull());
@@ -454,8 +453,8 @@ namespace PhysX::Pipeline
         // Validate shape.
         ASSERT_THAT(shapePtr, ::testing::NotNull());
         ASSERT_TRUE(shapePtr->GetShapeType() == Physics::ShapeType::Capsule);
-        EXPECT_NEAR(static_cast<const Physics::CapsuleShapeConfiguration&>(*shapePtr).m_height, 6.0, 1.0e-6);
-        EXPECT_NEAR(static_cast<const Physics::CapsuleShapeConfiguration&>(*shapePtr).m_radius, 1.0, 1.0e-6);
+        EXPECT_NEAR(static_cast<const Physics::CapsuleShapeConfiguration&>(*shapePtr).m_height, 6.0, defaultTolerance);
+        EXPECT_NEAR(static_cast<const Physics::CapsuleShapeConfiguration&>(*shapePtr).m_radius, 1.0, defaultTolerance);
 
         // Validate transform.
         ASSERT_THAT(configPtr, ::testing::NotNull());
@@ -524,11 +523,7 @@ namespace PhysX::Pipeline
         );
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_P(FitPrimitiveShapeTestFixture, DISABLED_BoxTest)
-#else
     TEST_P(FitPrimitiveShapeTestFixture, BoxTest)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         const AZ::Transform& transform = GetParam();
 
@@ -566,11 +561,7 @@ namespace PhysX::Pipeline
         ExpectRightHandedOrthonormalBasis(xAxis, yAxis, zAxis);
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_P(FitPrimitiveShapeTestFixture, DISABLED_CapsuleTest)
-#else
     TEST_P(FitPrimitiveShapeTestFixture, CapsuleTest)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         const AZ::Transform& transform = GetParam();
 
@@ -603,11 +594,7 @@ namespace PhysX::Pipeline
         ExpectRightHandedOrthonormalBasis(xAxis, yAxis, zAxis);
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_P(FitPrimitiveShapeTestFixture, DISABLED_VolumeMinimizationTest)
-#else
     TEST_P(FitPrimitiveShapeTestFixture, VolumeMinimizationTest)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         // This test verifies that the volume minimization coefficient works as expected. The vertices used here form a
         // 2x2x2 cube centered at the origin. We let the fitter decide which primitive fits best, which should always be

--- a/Gems/ScriptCanvas/Code/Tests/Framework/ScriptCanvasUnitTestFixture.h
+++ b/Gems/ScriptCanvas/Code/Tests/Framework/ScriptCanvasUnitTestFixture.h
@@ -15,4 +15,14 @@ namespace ScriptCanvasUnitTest
         : public UnitTest::LeakDetectionFixture
     {
     };
+
+    MATCHER_P(IsClose, expected, "")
+    {
+        #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        constexpr float tolerance = 0.001f;
+        #else
+        constexpr float tolerance = 0.0f;
+        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        return arg.IsClose(expected, tolerance);
+    }
 }

--- a/Gems/ScriptCanvas/Code/Tests/Libraries/Entity/ScriptCanvasUnitTest_EntityFunctions.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Libraries/Entity/ScriptCanvasUnitTest_EntityFunctions.cpp
@@ -9,6 +9,7 @@
 #include <AzCore/Component/ComponentApplicationBus.h>
 #include <AzCore/Component/Entity.h>
 #include <AzCore/Component/TransformBus.h>
+#include <AzCore/UnitTest/TestTypes.h>
 #include <Tests/Framework/ScriptCanvasUnitTestFixture.h>
 #include <Libraries/Entity/EntityFunctions.h>
 
@@ -86,37 +87,25 @@ namespace ScriptCanvasUnitTest
         AZ::Entity m_entity;
     };
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestEntityFunctions, DISABLED_GetEntityRight_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestEntityFunctions, GetEntityRight_Call_GetExpectedResult)
-#endif
     {
         float scale = 123.f;
         auto actualResult = EntityFunctions::GetEntityRight(m_id, scale);
-        EXPECT_EQ(actualResult, AZ::Vector3(scale, 0, 0));
+        EXPECT_THAT(actualResult, IsClose(AZ::Vector3(scale, 0, 0)));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestEntityFunctions, DISABLED_GetEntityForward_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestEntityFunctions, GetEntityForward_Call_GetExpectedResult)
-#endif
     {
         float scale = 123.f;
         auto actualResult = EntityFunctions::GetEntityForward(m_id, scale);
-        EXPECT_EQ(actualResult, AZ::Vector3(0, scale, 0));
+        EXPECT_THAT(actualResult, IsClose(AZ::Vector3(0, scale, 0)));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestEntityFunctions, DISABLED_GetEntityUp_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestEntityFunctions, GetEntityUp_Call_GetExpectedResult)
-#endif
     {
         float scale = 123.f;
         auto actualResult = EntityFunctions::GetEntityUp(m_id, scale);
-        EXPECT_EQ(actualResult, AZ::Vector3(0, 0, scale));
+        EXPECT_THAT(actualResult, IsClose(AZ::Vector3(0, 0, scale)));
     }
 
     TEST_F(ScriptCanvasUnitTestEntityFunctions, Rotate_Call_GetExpectedResult)

--- a/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Quaternion.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Quaternion.cpp
@@ -39,24 +39,16 @@ namespace ScriptCanvasUnitTest
         EXPECT_EQ(actualResult, AZ::Quaternion::CreateIdentity());
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestQuaternionFunctions, DISABLED_FromMatrix3x3_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestQuaternionFunctions, FromMatrix3x3_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = QuaternionFunctions::FromMatrix3x3(AZ::Matrix3x3::CreateIdentity());
-        EXPECT_EQ(actualResult, AZ::Quaternion::CreateIdentity());
+        EXPECT_THAT(actualResult, IsClose(AZ::Quaternion::CreateIdentity()));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestQuaternionFunctions, DISABLED_FromMatrix4x4_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestQuaternionFunctions, FromMatrix4x4_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = QuaternionFunctions::FromMatrix4x4(AZ::Matrix4x4::CreateIdentity());
-        EXPECT_EQ(actualResult, AZ::Quaternion::CreateIdentity());
+        EXPECT_THAT(actualResult, IsClose(AZ::Quaternion::CreateIdentity()));
     }
 
     TEST_F(ScriptCanvasUnitTestQuaternionFunctions, FromTransform_Call_GetExpectedResult)
@@ -95,14 +87,15 @@ namespace ScriptCanvasUnitTest
         EXPECT_TRUE(actualResult);
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestQuaternionFunctions, DISABLED_LengthReciprocal_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestQuaternionFunctions, LengthReciprocal_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = QuaternionFunctions::LengthReciprocal(AZ::Quaternion::CreateIdentity());
-        EXPECT_EQ(actualResult, 1);
+        #if AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        constexpr float tolerance = 0.00001f;
+        #else
+        constexpr float tolerance = 0.0f;
+        #endif // AZ_TRAIT_USE_PLATFORM_SIMD_NEON
+        EXPECT_NEAR(actualResult, 1.0f, tolerance);
     }
 
     TEST_F(ScriptCanvasUnitTestQuaternionFunctions, LengthSquared_Call_GetExpectedResult)

--- a/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Transform.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Transform.cpp
@@ -15,26 +15,19 @@ namespace ScriptCanvasUnitTest
 
     using ScriptCanvasUnitTestTransformFunctions = ScriptCanvasUnitTestFixture;
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestTransformFunctions, DISABLED_FromMatrix3x3_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestTransformFunctions, FromMatrix3x3_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = TransformFunctions::FromMatrix3x3(AZ::Matrix3x3::CreateIdentity());
-        EXPECT_EQ(actualResult, AZ::Transform::CreateIdentity());
+        auto expectedResult = AZ::Transform::CreateIdentity();
+        EXPECT_THAT(actualResult, IsClose(expectedResult));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestTransformFunctions, DISABLED_FromMatrix3x3AndTranslation_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestTransformFunctions, FromMatrix3x3AndTranslation_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = TransformFunctions::FromMatrix3x3AndTranslation(AZ::Matrix3x3::CreateIdentity(), AZ::Vector3::CreateOne());
         EXPECT_EQ(actualResult.GetUniformScale(), 1);
-        EXPECT_EQ(actualResult.GetRotation(), AZ::Quaternion::CreateIdentity());
-        EXPECT_EQ(actualResult.GetTranslation(), AZ::Vector3::CreateOne());
+        EXPECT_THAT(actualResult.GetRotation(), IsClose(AZ::Quaternion::CreateIdentity()));
+        EXPECT_THAT(actualResult.GetTranslation(), IsClose(AZ::Vector3::CreateOne()));
     }
 
     TEST_F(ScriptCanvasUnitTestTransformFunctions, FromRotation_Call_GetExpectedResult)
@@ -71,34 +64,22 @@ namespace ScriptCanvasUnitTest
         EXPECT_EQ(actualResult.GetTranslation(), AZ::Vector3::CreateOne());
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestTransformFunctions, DISABLED_GetRight_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestTransformFunctions, GetRight_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = TransformFunctions::GetRight(AZ::Transform::CreateIdentity(), 1);
-        EXPECT_EQ(actualResult, AZ::Vector3(1, 0, 0));
+        EXPECT_THAT(actualResult, IsClose(AZ::Vector3(1, 0, 0)));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestTransformFunctions, DISABLED_GetForward_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestTransformFunctions, GetForward_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = TransformFunctions::GetForward(AZ::Transform::CreateIdentity(), 1);
-        EXPECT_EQ(actualResult, AZ::Vector3(0, 1, 0));
+        EXPECT_THAT(actualResult, IsClose(AZ::Vector3(0, 1, 0)));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestTransformFunctions, DISABLED_GetUp_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestTransformFunctions, GetUp_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = TransformFunctions::GetUp(AZ::Transform::CreateIdentity(), 1);
-        EXPECT_EQ(actualResult, AZ::Vector3(0, 0, 1));
+        EXPECT_THAT(actualResult, IsClose(AZ::Vector3(0, 0, 1)));
     }
 
     TEST_F(ScriptCanvasUnitTestTransformFunctions, GetTranslation_Call_GetExpectedResult)

--- a/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Vector3.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Vector3.cpp
@@ -178,14 +178,10 @@ namespace ScriptCanvasUnitTest
         EXPECT_EQ(actualResult, AZ::Vector3::CreateZero());
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestVector3Functions, DISABLED_Reciprocal_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestVector3Functions, Reciprocal_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = Vector3Functions::Reciprocal(AZ::Vector3::CreateOne());
-        EXPECT_EQ(actualResult, AZ::Vector3::CreateOne());
+        EXPECT_THAT(actualResult, IsClose(AZ::Vector3::CreateOne()));
     }
 
     TEST_F(ScriptCanvasUnitTestVector3Functions, Slerp_Call_GetExpectedResult)
@@ -194,14 +190,10 @@ namespace ScriptCanvasUnitTest
         EXPECT_EQ(actualResult, AZ::Vector3::CreateOne());
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestVector3Functions, DISABLED_DirectionTo_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestVector3Functions, DirectionTo_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = Vector3Functions::DirectionTo(AZ::Vector3::CreateZero(), AZ::Vector3(1, 0, 0), 1);
-        EXPECT_EQ(AZStd::get<0>(actualResult), AZ::Vector3(1, 0, 0));
+        EXPECT_THAT(AZStd::get<0>(actualResult), IsClose(AZ::Vector3(1, 0, 0)));
         EXPECT_EQ(AZStd::get<1>(actualResult), 1);
     }
 } // namespace ScriptCanvasUnitTest

--- a/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Vector4.cpp
+++ b/Gems/ScriptCanvas/Code/Tests/Libraries/Math/ScriptCanvasUnitTest_Vector4.cpp
@@ -123,24 +123,16 @@ namespace ScriptCanvasUnitTest
         EXPECT_EQ(actualResult, AZ::Vector4(1, 0, 0, 0));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestVector4Functions, DISABLED_Reciprocal_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestVector4Functions, Reciprocal_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = Vector4Functions::Reciprocal(AZ::Vector4::CreateOne());
-        EXPECT_EQ(actualResult, AZ::Vector4::CreateOne());
+        EXPECT_THAT(actualResult, IsClose(AZ::Vector4::CreateOne()));
     }
 
-#if AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
-    TEST_F(ScriptCanvasUnitTestVector4Functions, DISABLED_DirectionTo_Call_GetExpectedResult)
-#else
     TEST_F(ScriptCanvasUnitTestVector4Functions, DirectionTo_Call_GetExpectedResult)
-#endif // AZ_TRAIT_DISABLE_FAILED_ARM64_TESTS
     {
         auto actualResult = Vector4Functions::DirectionTo(AZ::Vector4::CreateZero(), AZ::Vector4(1, 0, 0, 0), 1);
-        EXPECT_EQ(AZStd::get<0>(actualResult), AZ::Vector4(1, 0, 0, 0));
+        EXPECT_THAT(AZStd::get<0>(actualResult), IsClose(AZ::Vector4(1, 0, 0, 0)));
         EXPECT_EQ(AZStd::get<1>(actualResult), 1);
     }
 } // namespace ScriptCanvasUnitTest


### PR DESCRIPTION
## What does this PR do?

This internal PR represents the ARM64/NEON adjustments made to tests that were failing on ARM64/NEON (Linux) caused by float precision errors. 

Detail descriptions of each change are located in the commit messages for this branch. 

**Note** : This is a PR back to the working ARM64 branch and not to development. This PR is to isolate the NEON-float precision specific changes. Not all of the adjustments may be indicative of just precision issues, but I don't have enough experience with SIMD math to make these judgements

## How was this PR tested?
Unit Tests
