### PR TITLE
Added effective limit to armature

### DIFF
--- a/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
+++ b/Gems/PhysX/Code/Source/EditorArticulationLinkComponent.cpp
@@ -201,7 +201,7 @@ namespace PhysX
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsSingleDofJointType)
 
                     ->DataElement(0, &ArticulationLinkConfiguration::m_armature, "Armature", "Mass for prismatic joints, inertia for hinge")
-                    ->Attribute(AZ::Edit::Attributes::Min, AZ::Vector3::CreateZero())
+                    ->Attribute(AZ::Edit::Attributes::Min, 0.0f)
                     ->Attribute(AZ::Edit::Attributes::Visibility, &ArticulationLinkConfiguration::IsSingleDofJointType)
 
                     ->ClassElement(AZ::Edit::ClassElements::Group, "Sensors")


### PR DESCRIPTION
## What does this PR do?

The limitation with on armature was not effective with `AZ::Vector3::CreateZero()`

## How was this PR tested?

Manual.
