### PR TITLE
Make serialization of `char` to be the same as uint8_t consistently a…

### DIFF
--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.cpp
@@ -89,12 +89,6 @@ namespace AzNetworking
         return SerializeHelper(value, 0, false, unused, name);
     }
 
-    bool DeltaSerializerCreate::Serialize(char& value, const char* name, [[maybe_unused]] char minValue, [[maybe_unused]] char maxValue)
-    {
-        uint32_t unused = 0;
-        return SerializeHelper(value, 0, false, unused, name);
-    }
-
     bool DeltaSerializerCreate::Serialize(int8_t& value, const char* name, [[maybe_unused]] int8_t minValue, [[maybe_unused]] int8_t maxValue)
     {
         uint32_t unused = 0;
@@ -273,11 +267,11 @@ namespace AzNetworking
         return SerializeHelper(value, 0, false, unused, name);
     }
 
-    bool DeltaSerializerApply::Serialize(char& value, const char* name, [[maybe_unused]] char minValue, [[maybe_unused]] char maxValue)
-    {
-        uint32_t unused = 0;
-        return SerializeHelper(value, 0, false, unused, name);
-    }
+    //bool DeltaSerializerApply::Serialize(char& value, const char* name, [[maybe_unused]] char minValue, [[maybe_unused]] char maxValue)
+    //{
+    //    uint32_t unused = 0;
+    //    return SerializeHelper(value, 0, false, unused, name);
+    //}
 
     bool DeltaSerializerApply::Serialize(int8_t& value, const char* name, [[maybe_unused]] int8_t minValue, [[maybe_unused]] int8_t maxValue)
     {

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.cpp
@@ -267,12 +267,6 @@ namespace AzNetworking
         return SerializeHelper(value, 0, false, unused, name);
     }
 
-    //bool DeltaSerializerApply::Serialize(char& value, const char* name, [[maybe_unused]] char minValue, [[maybe_unused]] char maxValue)
-    //{
-    //    uint32_t unused = 0;
-    //    return SerializeHelper(value, 0, false, unused, name);
-    //}
-
     bool DeltaSerializerApply::Serialize(int8_t& value, const char* name, [[maybe_unused]] int8_t minValue, [[maybe_unused]] int8_t maxValue)
     {
         uint32_t unused = 0;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/DeltaSerializer.h
@@ -63,7 +63,6 @@ namespace AzNetworking
         // ISerializer interfaces
         SerializerMode GetSerializerMode() const override;
         bool Serialize(bool& value, const char* name) override;
-        bool Serialize(char& value, const char* name, char minValue, char maxValue) override;
         bool Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue) override;
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;
@@ -123,7 +122,6 @@ namespace AzNetworking
         // ISerializer interfaces
         SerializerMode GetSerializerMode() const override;
         bool Serialize(bool& value, const char* name) override;
-        bool Serialize(char& value, const char* name, char minValue, char maxValue) override;
         bool Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue) override;
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.cpp
@@ -45,12 +45,6 @@ namespace AzNetworking
         return true;
     }
 
-    bool HashSerializer::Serialize(char& value, [[maybe_unused]] const char* name, [[maybe_unused]] char minValue, [[maybe_unused]] char maxValue)
-    {
-        m_hash = AZ::TypeHash64(value, m_hash);
-        return true;
-    }
-
     bool HashSerializer::Serialize(int8_t& value, [[maybe_unused]] const char* name, [[maybe_unused]] int8_t minValue, [[maybe_unused]] int8_t maxValue)
     {
         m_hash = AZ::TypeHash64(value, m_hash);

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/HashSerializer.h
@@ -29,7 +29,6 @@ namespace AzNetworking
         // ISerializer interfaces
         SerializerMode GetSerializerMode() const override;
         bool Serialize(bool& value, const char* name) override;
-        bool Serialize(char& value, const char* name, char minValue, char maxValue) override;
         bool Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue) override;
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.h
@@ -67,7 +67,7 @@ namespace AzNetworking
         //! @param minValue the minimum value expected during serialization
         //! @param maxValue the maximum value expected during serialization
         //! @return boolean true for success, false for failure
-        virtual bool Serialize(char& value, const char* name, char minValue = AZStd::numeric_limits<char>::min(), char maxValue = AZStd::numeric_limits<char>::max()) = 0;
+        bool Serialize(char& value, const char* name, uint8_t minValue = AZStd::numeric_limits<uint8_t>::min(), uint8_t maxValue = AZStd::numeric_limits<uint8_t>::max());
 
         //! Serialize a signed byte.
         //! @param value    signed byte input value to serialize

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/ISerializer.inl
@@ -100,6 +100,11 @@ namespace AzNetworking
         m_serializerValid = false;
     }
 
+    inline bool ISerializer::Serialize(char& value, const char* name, uint8_t minValue, uint8_t maxValue)
+    {
+        return Serialize(reinterpret_cast<uint8_t&>(value), name, minValue, maxValue);
+    }
+
     #if AZ_TRAIT_COMPILER_INT64_T_IS_LONG
     inline bool ISerializer::Serialize(AZ::s64& value, const char* name, AZ::s64 minValue, AZ::s64 maxValue)
     {

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.cpp
@@ -34,11 +34,6 @@ namespace AzNetworking
         return SerializeBytes((const uint8_t*)&serializeValue, sizeof(uint8_t));
     }
 
-    bool NetworkInputSerializer::Serialize(char& value, [[maybe_unused]] const char* name, char minValue, char maxValue)
-    {
-        return SerializeBoundedValue<char>(minValue, maxValue, value);
-    }
-
     bool NetworkInputSerializer::Serialize(int8_t& value, [[maybe_unused]] const char* name, int8_t minValue, int8_t maxValue)
     {
         return SerializeBoundedValue<int8_t>(minValue, maxValue, value);

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkInputSerializer.h
@@ -33,7 +33,6 @@ namespace AzNetworking
         // ISerializer interfaces
         SerializerMode GetSerializerMode() const override;
         bool Serialize(bool& value, const char* name) override;
-        bool Serialize(char& value, const char* name, char minValue, char maxValue) override;
         bool Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue) override;
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.cpp
@@ -36,11 +36,6 @@ namespace AzNetworking
         return m_serializerValid;
     }
 
-    bool NetworkOutputSerializer::Serialize(char& value, [[maybe_unused]] const char* name, char minValue, char maxValue)
-    {
-        return SerializeBoundedValue<char>(minValue, maxValue, value);
-    }
-
     bool NetworkOutputSerializer::Serialize(int8_t& value, [[maybe_unused]] const char* name, int8_t minValue, int8_t maxValue)
     {
         return SerializeBoundedValue<int8_t>(minValue, maxValue, value);

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/NetworkOutputSerializer.h
@@ -39,7 +39,6 @@ namespace AzNetworking
         // ISerializer interfaces
         SerializerMode GetSerializerMode() const override;
         bool Serialize(bool& value, const char* name) override;
-        bool Serialize(char& value, const char* name, char minValue, char maxValue) override;
         bool Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue) override;
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.cpp
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.cpp
@@ -35,12 +35,6 @@ namespace AzNetworking
         return ProcessData(name, value);
     }
 
-    bool StringifySerializer::Serialize(char& value, const char* name, char, char)
-    {
-        const int val = value; // Print chars as integers
-        return ProcessData(name, val);
-    }
-
     bool StringifySerializer::Serialize(int8_t& value, const char* name, int8_t, int8_t)
     {
         return ProcessData(name, value);

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/StringifySerializer.h
@@ -31,7 +31,6 @@ namespace AzNetworking
         // ISerializer interfaces
         SerializerMode GetSerializerMode() const override;
         bool Serialize(bool& value, const char* name) override;
-        bool Serialize(char& value, const char* name, char minValue, char maxValue) override;
         bool Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue) override;
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.h
@@ -27,9 +27,11 @@ namespace AzNetworking
         TrackChangedSerializer(const uint8_t* buffer, uint32_t bufferCapacity);
 
         // ISerializer interfaces
+
+        using ISerializer::Serialize;
+
         SerializerMode GetSerializerMode() const override;
         bool Serialize(    bool& value, const char* name) override;
-        bool Serialize(    char& value, const char* name,     char minValue,     char maxValue) override;
         bool Serialize(  int8_t& value, const char* name,   int8_t minValue,   int8_t maxValue) override;
         bool Serialize( int16_t& value, const char* name,  int16_t minValue,  int16_t maxValue) override;
         bool Serialize( int32_t& value, const char* name,  int32_t minValue,  int32_t maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TrackChangedSerializer.inl
@@ -34,15 +34,6 @@ namespace AzNetworking
     }
 
     template <typename BASE_TYPE>
-    bool TrackChangedSerializer<BASE_TYPE>::Serialize(char& value, const char* name, char minValue, char maxValue)
-    {
-        const char cached = value;
-        const bool result = BASE_TYPE::Serialize(value, name, minValue, maxValue);
-        m_hasChanged |= (cached != value);
-        return result;
-    }
-
-    template <typename BASE_TYPE>
     bool TrackChangedSerializer<BASE_TYPE>::Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue)
     {
         const int8_t cached = value;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TypeValidatingSerializer.h
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TypeValidatingSerializer.h
@@ -50,7 +50,6 @@ namespace AzNetworking
         // ISerializer interfaces
         SerializerMode GetSerializerMode() const override;
         bool Serialize(bool& value, const char* name) override;
-        bool Serialize(char& value, const char* name, char minValue, char maxValue) override;
         bool Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue) override;
         bool Serialize(int16_t& value, const char* name, int16_t minValue, int16_t maxValue) override;
         bool Serialize(int32_t& value, const char* name, int32_t minValue, int32_t maxValue) override;

--- a/Code/Framework/AzNetworking/AzNetworking/Serialization/TypeValidatingSerializer.inl
+++ b/Code/Framework/AzNetworking/AzNetworking/Serialization/TypeValidatingSerializer.inl
@@ -78,13 +78,6 @@ namespace AzNetworking
     }
 
     template <typename BASE_TYPE>
-    bool TypeValidatingSerializer<BASE_TYPE>::Serialize(char& value, const char* name, char minValue, char maxValue)
-    {
-        bool result = Validate(name, ValidateSerializeType::Char);
-        return BASE_TYPE::Serialize(value, name, minValue, maxValue) && result;
-    }
-
-    template <typename BASE_TYPE>
     bool TypeValidatingSerializer<BASE_TYPE>::Serialize(int8_t& value, const char* name, int8_t minValue, int8_t maxValue)
     {
         bool result = Validate(name, ValidateSerializeType::Int8);

--- a/Code/Framework/AzNetworking/Tests/Serialization/TrackChangedSerializerTests.cpp
+++ b/Code/Framework/AzNetworking/Tests/Serialization/TrackChangedSerializerTests.cpp
@@ -93,7 +93,7 @@ namespace UnitTest
         EXPECT_TRUE(trackChangedSerializer.GetTrackedChangesFlag());
 
         trackChangedSerializer.ClearTrackedChangesFlag();
-        trackChangedSerializer.Serialize(outElement.testChar, "TestChar", AZStd::numeric_limits<char>::min(), AZStd::numeric_limits<char>::max());
+        trackChangedSerializer.Serialize(outElement.testChar, "TestChar");
         EXPECT_TRUE(trackChangedSerializer.GetTrackedChangesFlag());
 
         trackChangedSerializer.ClearTrackedChangesFlag();


### PR DESCRIPTION
## What does this PR do?

**Background**
* `char` is signed on x86/86, but unsigned by default on ARM architecture.
* On x86, the range of char is -127 to 128. On ARM64, since its unsigned by default, its 0-255
* You can have the compiler treat char as signed as a compile option, but that risks compatibility with other prebuilt ARM64 libraries

**Approach**
* Force the serialization of `char` to use uint8_t for serialization
* The serialized bytes for char will be based on an unsigned char (8-bit).
* Remove the pure virtual tag for the `char` serialization function and provide a base implementation that will reinterpret cast to uint8_t for serialization. This way any class that derives from ISerialization will work with `char` automatically provided they provide an implementation for serializing `uint8_t`

## How was this PR tested?

Tested on Linux ARM64 and x86, verified output binaries matches